### PR TITLE
Log only non-client data

### DIFF
--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/APIExceptionHandler.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/APIExceptionHandler.java
@@ -19,14 +19,14 @@ public class APIExceptionHandler {
   @ExceptionHandler(Exception.class)
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   public void unknownException(Exception ex, WebRequest wr) {
-    logger.error("Unable to handle {}", wr, ex);
+    logger.error("Unable to handle {}", wr.getDescription(false), ex);
   }
 
   @ExceptionHandler({HttpMessageNotReadableException.class, ServletRequestBindingException.class,
       InvalidProtocolBufferException.class})
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public void bindingExceptions(Exception ex, WebRequest wr) {
-    logger.error("Binding failed {}", wr, ex);
+    logger.error("Binding failed {}", wr.getDescription(false), ex);
   }
 
 }


### PR DESCRIPTION
This is intended to prevent the WebRequest to leak client data into the log, which could have happen in the old code.