### PR TITLE
Set versions to SNAPSHOT in master

### DIFF
--- a/common/persistence/pom.xml
+++ b/common/persistence/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.opencwa</groupId>
   <artifactId>persistence</artifactId>
-  <version>0.0.1</version>
+  <version>0.0.1-SNAPSHOT</version>
 
   <properties>
     <java.version>11</java.version>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.opencwa</groupId>
       <artifactId>protocols</artifactId>
-      <version>0.0.1</version>
+      <version>0.0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.opencwa</groupId>
-    <version>0.0.1</version>
+    <version>0.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>common</artifactId>
-  <version>0.0.1</version>
+  <version>0.0.1-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <modules>

--- a/common/protocols/pom.xml
+++ b/common/protocols/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <artifactId>common</artifactId>
     <groupId>org.opencwa</groupId>
-    <version>0.0.1</version>
+    <version>0.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>protocols</artifactId>
-  <version>0.0.1</version>
+  <version>0.0.1-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</modules>
 	<groupId>org.opencwa</groupId>
 	<artifactId>server</artifactId>
-	<version>0.0.1</version>
+	<version>0.0.1-SNAPSHOT</version>
 	<name>server</name>
 	<description>CWA Server</description>
 

--- a/services/distribution/pom.xml
+++ b/services/distribution/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>services</artifactId>
     <groupId>org.opencwa</groupId>
-    <version>0.0.1</version>
+    <version>0.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>distribution</artifactId>
-  <version>0.0.1</version>
+  <version>0.0.1-SNAPSHOT</version>
 </project>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -14,7 +14,7 @@
 
   <artifactId>services</artifactId>
   <groupId>org.opencwa</groupId>
-  <version>0.0.1</version>
+  <version>0.0.1-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <modules>
@@ -34,12 +34,12 @@
     <dependency>
       <groupId>org.opencwa</groupId>
       <artifactId>persistence</artifactId>
-      <version>0.0.1</version>
+      <version>0.0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.opencwa</groupId>
       <artifactId>protocols</artifactId>
-      <version>0.0.1</version>
+      <version>0.0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/services/submission/pom.xml
+++ b/services/submission/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <artifactId>services</artifactId>
     <groupId>org.opencwa</groupId>
-    <version>0.0.1</version>
+    <version>0.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>submission</artifactId>
-  <version>0.0.1</version>
+  <version>0.0.1-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -8,12 +8,12 @@
   <parent>
     <artifactId>server</artifactId>
     <groupId>org.opencwa</groupId>
-    <version>0.0.1</version>
+    <version>0.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>tools</artifactId>
-  <version>0.0.1</version>
+  <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/tools/test-data-generator/pom.xml
+++ b/tools/test-data-generator/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <artifactId>protocols</artifactId>
       <groupId>org.opencwa</groupId>
-      <version>0.0.1</version>
+      <version>0.0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <artifactId>picocli</artifactId>
@@ -77,9 +77,9 @@
     <artifactId>tools</artifactId>
     <groupId>org.opencwa</groupId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.0.1</version>
+    <version>0.0.1-SNAPSHOT</version>
   </parent>
 
-  <version>0.0.1</version>
+  <version>0.0.1-SNAPSHOT</version>
 
 </project>


### PR DESCRIPTION
"Non-SNAPSHOT" versions should only be in the [release](https://github.com/corona-warn-app/cwa-server/tree/release) branch. @johanneseschrig 