### PR TITLE
Reduce unnecessary usage of var

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/exposureconfig/ExposureConfigurationProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/exposureconfig/ExposureConfigurationProvider.java
@@ -1,6 +1,7 @@
 package app.coronawarn.server.services.distribution.exposureconfig;
 
 import app.coronawarn.server.common.protocols.internal.RiskScoreParameters;
+import app.coronawarn.server.common.protocols.internal.RiskScoreParameters.Builder;
 import app.coronawarn.server.services.distribution.exposureconfig.parsing.YamlConstructorForProtoBuf;
 import java.io.InputStream;
 import org.yaml.snakeyaml.Yaml;
@@ -44,7 +45,7 @@ public class ExposureConfigurationProvider {
     InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(path);
 
     try {
-      var loaded = yaml.loadAs(inputStream, RiskScoreParameters.newBuilder().getClass());
+      Builder loaded = yaml.loadAs(inputStream, RiskScoreParameters.newBuilder().getClass());
       if (loaded == null) {
         throw new UnableToLoadFileException(path);
       }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/exposureconfig/parsing/YamlConstructorForProtoBuf.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/exposureconfig/parsing/YamlConstructorForProtoBuf.java
@@ -32,7 +32,7 @@ public class YamlConstructorForProtoBuf extends Constructor {
     }
 
     private String snakeToCamelCase(String snakeCase) {
-      var camelCase = Arrays.stream(snakeCase.split("_"))
+      String camelCase = Arrays.stream(snakeCase.split("_"))
           .map(word -> Character.toUpperCase(word.charAt(0)) + word.substring(1))
           .reduce("", String::concat);
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/exposureconfig/validation/ExposureConfigurationValidator.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/exposureconfig/validation/ExposureConfigurationValidator.java
@@ -3,6 +3,7 @@ package app.coronawarn.server.services.distribution.exposureconfig.validation;
 import app.coronawarn.server.common.protocols.internal.RiskLevel;
 import app.coronawarn.server.common.protocols.internal.RiskScoreParameters;
 import app.coronawarn.server.services.distribution.exposureconfig.validation.WeightValidationError.ErrorType;
+import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
@@ -51,7 +52,7 @@ public class ExposureConfigurationValidator {
 
   private void validateParameterRiskLevels(String name, Object object)
       throws IntrospectionException {
-    var bean = Introspector.getBeanInfo(object.getClass());
+    BeanInfo bean = Introspector.getBeanInfo(object.getClass());
 
     Arrays.stream(bean.getPropertyDescriptors())
         .filter(propertyDescriptor -> propertyDescriptor.getPropertyType() == RiskLevel.class)
@@ -89,7 +90,7 @@ public class ExposureConfigurationValidator {
   }
 
   private boolean respectsMaximumDecimalPlaces(double weight) {
-    var bd = new BigDecimal(String.valueOf(weight));
+    BigDecimal bd = new BigDecimal(String.valueOf(weight));
 
     return bd.scale() <= ParameterSpec.WEIGHT_MAX_DECIMALS;
   }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/exposureconfig/ExposureConfigurationMasterFileTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/exposureconfig/ExposureConfigurationMasterFileTest.java
@@ -21,7 +21,7 @@ public class ExposureConfigurationMasterFileTest {
     var config = new ExposureConfigurationProvider().readMasterFile();
 
     var validator = new ExposureConfigurationValidator(config);
-    var result =  validator.validate();
+    ValidationResult result = validator.validate();
 
     assertEquals(SUCCESS, result);
   }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/exposureconfig/ExposureConfigurationProviderTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/exposureconfig/ExposureConfigurationProviderTest.java
@@ -3,6 +3,7 @@ package app.coronawarn.server.services.distribution.exposureconfig;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import app.coronawarn.server.common.protocols.internal.RiskScoreParameters;
 import org.junit.jupiter.api.Test;
 
 public class ExposureConfigurationProviderTest {
@@ -10,7 +11,7 @@ public class ExposureConfigurationProviderTest {
   @Test
   public void okFile() throws UnableToLoadFileException {
     var provider = new ExposureConfigurationProvider();
-    var result = provider.readFile("parameters/all_ok.yaml");
+    RiskScoreParameters result = provider.readFile("parameters/all_ok.yaml");
 
     assertNotNull(result, "File is null, indicating loading failed");
   }

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/SubmissionControllerTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/SubmissionControllerTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -41,6 +42,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
@@ -105,9 +107,9 @@ public class SubmissionControllerTest {
     // INTERNAL_SERVER_ERROR is the result of blocking by StrictFirewall for non POST calls.
     //                       We can change this when Spring Security 5.4.x is released.
     // METHOD_NOT_ALLOWED is the result of TRACE calls (disabled by default in tomcat)
-    var allowedErrors = Arrays.asList(INTERNAL_SERVER_ERROR, METHOD_NOT_ALLOWED);
+    List<HttpStatus> allowedErrors = Arrays.asList(INTERNAL_SERVER_ERROR, METHOD_NOT_ALLOWED);
 
-    var actStatus = testRestTemplate
+    HttpStatus actStatus = testRestTemplate
         .exchange(SUBMISSION_URL, deniedHttpMethod, null, Void.class).getStatusCode();
 
     assertTrue(allowedErrors.contains(actStatus),


### PR DESCRIPTION
I suggest using `var` only for cases where it actually increases readability e.g.
```
var validator = new ExposureConfigurationValidator(config);
```
instead of 
```
ExposureConfigurationValidator validator = new ExposureConfigurationValidator(config);
```
is ok. 

Else it makes the code less explicit and less readable. 