### PR TITLE
Add submission timestamp to diagnosis key

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
@@ -22,16 +22,18 @@ public class DiagnosisKey {
   private long rollingStartNumber;
   private long rollingPeriod;
   private int transmissionRiskLevel;
+  private long submissionTimestamp;
 
   /**
    * Should be called by builders.
    */
-  DiagnosisKey(
-      byte[] keyData, long rollingStartNumber, long rollingPeriod, int transmissionRiskLevel) {
+  DiagnosisKey(byte[] keyData, long rollingStartNumber, long rollingPeriod,
+      int transmissionRiskLevel, long submissionTimestamp) {
     this.keyData = keyData;
     this.rollingStartNumber = rollingStartNumber;
     this.rollingPeriod = rollingPeriod;
     this.transmissionRiskLevel = transmissionRiskLevel;
+    this.submissionTimestamp = submissionTimestamp;
   }
 
   /**
@@ -78,6 +80,14 @@ public class DiagnosisKey {
     return transmissionRiskLevel;
   }
 
+  /**
+   * Returns the timestamp associated with the submission of this {@link DiagnosisKey} as hours
+   * since epoch.
+   */
+  public long getSubmissionTimestamp() {
+    return submissionTimestamp;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -90,13 +100,15 @@ public class DiagnosisKey {
     return rollingStartNumber == that.rollingStartNumber
         && rollingPeriod == that.rollingPeriod
         && transmissionRiskLevel == that.transmissionRiskLevel
+        && submissionTimestamp == that.submissionTimestamp
         && Objects.equals(id, that.id)
         && Arrays.equals(keyData, that.keyData);
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(id, rollingStartNumber, rollingPeriod, transmissionRiskLevel);
+    int result = Objects
+        .hash(id, rollingStartNumber, rollingPeriod, transmissionRiskLevel, submissionTimestamp);
     result = 31 * result + Arrays.hashCode(keyData);
     return result;
   }

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilder.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilder.java
@@ -5,8 +5,10 @@ import static app.coronawarn.server.common.persistence.domain.DiagnosisKeyBuilde
 import static app.coronawarn.server.common.persistence.domain.DiagnosisKeyBuilders.RollingPeriodBuilder;
 import static app.coronawarn.server.common.persistence.domain.DiagnosisKeyBuilders.RollingStartNumberBuilder;
 import static app.coronawarn.server.common.persistence.domain.DiagnosisKeyBuilders.TransmissionRiskLevelBuilder;
+import static java.time.temporal.ChronoUnit.HOURS;
 
 import app.coronawarn.server.common.protocols.external.exposurenotification.Key;
+import java.time.Instant;
 
 /**
  * An instance of this builder can be retrieved by calling {@link DiagnosisKey#builder()}. A {@link
@@ -53,7 +55,10 @@ public class DiagnosisKeyBuilder implements Builder, RollingStartNumberBuilder,
   }
 
   public DiagnosisKey build() {
-    return new DiagnosisKey(
-        this.keyData, this.rollingStartNumber, this.rollingPeriod, this.transmissionRiskLevel);
+    // hours since epoch
+    long submissionTimestamp = Instant.now().getEpochSecond() / 3600L;
+
+    return new DiagnosisKey(this.keyData, this.rollingStartNumber, this.rollingPeriod,
+        this.transmissionRiskLevel, submissionTimestamp);
   }
 }

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilders.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilders.java
@@ -3,7 +3,8 @@ package app.coronawarn.server.common.persistence.domain;
 import app.coronawarn.server.common.protocols.external.exposurenotification.Key;
 
 /**
- * This interfaces bundles a interfaces that are used for the implementation of DiagnosisKeyBuilder.
+ * This interface bundles interfaces that are used for the implementation of {@link
+ * DiagnosisKeyBuilder}.
  */
 interface DiagnosisKeyBuilders {
 
@@ -65,7 +66,8 @@ interface DiagnosisKeyBuilders {
   interface FinalBuilder {
 
     /**
-     * Builds a {@link DiagnosisKey} instance.
+     * Builds a {@link DiagnosisKey} instance and sets the submission timestamp to hours since
+     * epoch.
      */
     DiagnosisKey build();
   }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilderTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilderTest.java
@@ -6,9 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import app.coronawarn.server.common.protocols.external.exposurenotification.Key;
 import com.google.protobuf.ByteString;
 import java.nio.charset.Charset;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 public class DiagnosisKeyBuilderTest {
+
   private final byte[] expKeyData = "myByteArr".getBytes(Charset.defaultCharset());
   private final long expRollingStartNumber = 123;
   private final long expRollingPeriod = 123;
@@ -26,8 +28,10 @@ public class DiagnosisKeyBuilderTest {
 
     DiagnosisKey actDiagnosisKey = DiagnosisKey.builder().fromProtoBuf(protoBufObj).build();
 
+    assertEquals(getCurrentHoursSinceEpoch(), actDiagnosisKey.getSubmissionTimestamp());
     assertArrayEquals(this.expKeyData, actDiagnosisKey.getKeyData());
     assertEquals(this.expRollingStartNumber, actDiagnosisKey.getRollingStartNumber());
+    assertEquals(this.expRollingPeriod, actDiagnosisKey.getRollingStartNumber());
     assertEquals(this.expTransmissionRiskLevel, actDiagnosisKey.getTransmissionRiskLevel());
   }
 
@@ -39,9 +43,14 @@ public class DiagnosisKeyBuilderTest {
         .withRollingPeriod(this.expRollingPeriod)
         .withTransmissionRiskLevel(this.expTransmissionRiskLevel).build();
 
+    assertEquals(getCurrentHoursSinceEpoch(), actDiagnosisKey.getSubmissionTimestamp());
     assertArrayEquals(this.expKeyData, actDiagnosisKey.getKeyData());
     assertEquals(this.expRollingStartNumber, actDiagnosisKey.getRollingStartNumber());
     assertEquals(this.expRollingPeriod, actDiagnosisKey.getRollingPeriod());
     assertEquals(this.expTransmissionRiskLevel, actDiagnosisKey.getTransmissionRiskLevel());
+  }
+
+  private long getCurrentHoursSinceEpoch() {
+    return Instant.now().getEpochSecond() / 3600L;
   }
 }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
@@ -11,8 +11,9 @@ public class DiagnosisKeyTest {
   final static long expRollingStartNumber = 1L;
   final static long expRollingPeriod = 2L;
   final static int expTransmissionRiskLevel = 3;
-  final static DiagnosisKey diagnosisKey = new DiagnosisKey(
-      expKeyData, expRollingStartNumber, expRollingPeriod, expTransmissionRiskLevel);
+  final static long expSubmissionTimestamp = 4L;
+  final static DiagnosisKey diagnosisKey = new DiagnosisKey(expKeyData, expRollingStartNumber,
+      expRollingPeriod, expTransmissionRiskLevel, expSubmissionTimestamp);
 
   @Test
   public void testRollingStartNumberGetter() {
@@ -27,5 +28,10 @@ public class DiagnosisKeyTest {
   @Test
   public void testTransmissionRiskLevelGetter() {
     assertEquals(expTransmissionRiskLevel, diagnosisKey.getTransmissionRiskLevel());
+  }
+
+  @Test
+  public void testSubmissionTimestampGetter() {
+    assertEquals(expSubmissionTimestamp, diagnosisKey.getSubmissionTimestamp());
   }
 }


### PR DESCRIPTION
implements #51 
- adds a submission timestamp rounded up to the next full hour