### PR TITLE
Externalizing default values from docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,15 @@
+# This file comntains simple default values for the deployment through Docker Compose
+# Please change these default values before running docker-compose
+
+# Docker Compose Postgres settings
+POSTGRES_DB=cwa
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+
+# Docker Compose PgAdmin settings
+PGADMIN_DEFAULT_EMAIL=user@domain.com
+PGADMIN_DEFAULT_PASSWORD=password
+
+# Docker Compose MinIO settings
+MINIO_ACCESS_KEY=cws_key_id
+MINIO_SECRET_KEY=cws_secret_key_id

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you want to use Docker-based deployment, you need to install Docker on your l
 
 #### Running the Full cwa Backend Using Docker Compose
 
-For your convenience, a full setup has been prepared using [Docker Compose](https://docs.docker.com/compose/reference/overview/). To build the backend services, run ```docker-compose build``` in the repository's root directory. 
+For your convenience, a full setup has been prepared using [Docker Compose](https://docs.docker.com/compose/reference/overview/). To build the backend services, run ```docker-compose build``` in the repository's root directory. A default configuration file can be found under ```.env```in the root folder of the repository. The default values for the local Postgres and MinIO build should be changed in this file before docker-compose is run.
 
 Once the services are built, you can start the whole backend using ```docker-compose up```.
 The distribution service runs once and then finishes. If you want to trigger additional distribution runs, run ```docker-compose start distribution```.
@@ -51,7 +51,7 @@ Service       | Description | Endpoint and Default Credentials
 --------------|-------------|-----------
 submission    | The Corona-Warn-App submission service                                            | http://localhost:8080 
 distribution  | The Corona-Warn-App distribution service                                          | NO ENDPOINT
-postgres      | A [postgres] database installation                                                | postgres:5432 <br> Username: postgres <br> Password: x24GeYzDp7kaZ8B
+postgres      | A [postgres] database installation                                                | postgres:5432 <br> Username: postgres <br> Password: postgres
 pgadmin       | A [pgadmin](https://www.pgadmin.org/) installation for the postgres database      | http://localhost:8081 <br> Username: user@domain.com <br> Password: password
 minio         | [MinIO] is an S3-compliant object store                                           | http://localhost:8082/ <br> Access key: cws_key_id <br> Secret key: cws_secret_key_id
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,9 @@ services:
       SPRING_PROFILES_ACTIVE: cloud
       POSTGRESQL_SERVICE_PORT: '5432'
       POSTGRESQL_SERVICE_HOST: postgres
-      POSTGRESQL_DATABASE: cwa
-      POSTGRESQL_PASSWORD: x24GeYzDp7kaZ8B
-      POSTGRESQL_USER: postgres
+      POSTGRESQL_DATABASE: ${POSTGRES_DB}
+      POSTGRESQL_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRESQL_USER: ${POSTGRES_USER}
     networks:
       - cwa
   distribution:
@@ -28,11 +28,12 @@ services:
       SPRING_PROFILES_ACTIVE: cloud
       POSTGRESQL_SERVICE_PORT: '5432'
       POSTGRESQL_SERVICE_HOST: postgres
-      POSTGRESQL_DATABASE: cwa
-      POSTGRESQL_PASSWORD: x24GeYzDp7kaZ8B
-      POSTGRESQL_USER: postgres
-      AWS_ACCESS_KEY_ID: cws_key_id
-      AWS_SECRET_ACCESS_KEY: cws_secret_key_id
+      POSTGRESQL_DATABASE: ${POSTGRES_DB}
+      POSTGRESQL_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRESQL_USER: ${POSTGRES_USER}
+      # Settings for the S3 compatible MinIO objectstore
+      AWS_ACCESS_KEY_ID: ${MINIO_ACCESS_KEY}
+      AWS_SECRET_ACCESS_KEY: ${MINIO_SECRET_KEY}
       cwa.objectstore.endpoint: http://minio:9000
       cwa.objectstore.bucket: cwa
       app.coronawarn.server.services.distribution.paths.output: /tmp/distribution
@@ -45,10 +46,9 @@ services:
       - "5432:5432"
     environment:
       PGDATA: /data/postgres
-      POSTGRES_DB: cwa
-      POSTGRESQL_USER: postgres
-      POSTGRESQL_DATABASE: cwa
-      POSTGRES_PASSWORD: x24GeYzDp7kaZ8B
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
        - postgres_volume:/data/postgres
     networks:
@@ -66,8 +66,8 @@ services:
     depends_on:
       - postgres
     environment:
-      PGADMIN_DEFAULT_EMAIL: user@domain.com
-      PGADMIN_DEFAULT_PASSWORD: password
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
   minio:
     image: "minio/minio"
     volumes:
@@ -75,8 +75,8 @@ services:
     ports:
       - "8082:9000"
     environment:
-      MINIO_ACCESS_KEY: cws_key_id
-      MINIO_SECRET_KEY: cws_secret_key_id
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
     entrypoint: sh
     command: -c 'mkdir -p /data/cwa && minio server /data'
     networks:


### PR DESCRIPTION
Closes #114 

I externalized the docker-compose default configuration to .env and made it more explicit in the readme and in the env file that these values should be considered as default values. I also changed the default values to be more easily recognized as such. As the goal is still to enable a convenient one command way to start the backend and as this mechanism is only used locally I still decided to commit the .env file.