### PR TITLE
Add unit test for DiagnosisKey.isYoungerThanRetentionThreshold

### DIFF
--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
@@ -21,6 +21,8 @@ package app.coronawarn.server.common.persistence.domain;
 
 import static java.time.ZoneOffset.UTC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.Charset;
 import java.time.Instant;
@@ -66,9 +68,9 @@ public class DiagnosisKeyTest {
     DiagnosisKey diagnosisKeyFiveDays = new DiagnosisKey(expKeyData, fiveDaysAgo,
         expRollingPeriod, expTransmissionRiskLevel, expSubmissionTimestamp);
 
-    assertEquals(false, diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(4L));
-    assertEquals(false, diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(5L));
-    assertEquals(true, diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(6L));
+    assertFalse(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(4L));
+    assertFalse(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(5L));
+    assertTrue(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(6L));
   }
 
 }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
@@ -19,9 +19,12 @@
 
 package app.coronawarn.server.common.persistence.domain;
 
+import static java.time.ZoneOffset.UTC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.Charset;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 public class DiagnosisKeyTest {
@@ -53,4 +56,19 @@ public class DiagnosisKeyTest {
   public void testSubmissionTimestampGetter() {
     assertEquals(expSubmissionTimestamp, diagnosisKey.getSubmissionTimestamp());
   }
+
+  @Test
+  public void testIsYoungerThanRetentionThreshold() {
+    long fiveDaysAgo = LocalDateTime
+        .ofInstant(Instant.now(), UTC)
+        .minusDays(5).minusMinutes(10)
+        .toEpochSecond(UTC) / (60 * 10);
+    DiagnosisKey diagnosisKeyFiveDays = new DiagnosisKey(expKeyData, fiveDaysAgo,
+        expRollingPeriod, expTransmissionRiskLevel, expSubmissionTimestamp);
+
+    assertEquals(false, diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(4L));
+    assertEquals(false, diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(5L));
+    assertEquals(true, diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(6L));
+  }
+
 }


### PR DESCRIPTION
- The method DiagnosisKey.isYoungerThanRetentionThreshold is currently untested, this PR adds an unit test.