### PR TITLE
Reduce size of exposure notifications

### DIFF
--- a/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/external/exposurenotification/exposure_notification.proto
+++ b/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/external/exposurenotification/exposure_notification.proto
@@ -11,8 +11,8 @@ message File {
 }
 
 message Header {
-  int64 startTimestamp = 1; // Time window of keys in this file based on arrival to server, in UTC.
-  int64 endTimestamp = 2;
+  int32 startTimestamp = 1; // Time window of keys in this file based on arrival to server, in UTC.
+  int32 endTimestamp = 2;
   string region = 3; // Region for which these keys came from (e.g., country)
   int32 batchNum = 4; // E.g., Batch 2 of 10
   int32 batchSize = 5;

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/util/Batch.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/util/Batch.java
@@ -75,8 +75,8 @@ public class Batch {
     return IntStream.range(0, partitions.size())
         .mapToObj(index -> {
           Header header = Header.newBuilder()
-              .setStartTimestamp(startTimestamp.toEpochMilli())
-              .setEndTimestamp(endTimeStamp.toEpochMilli())
+              .setStartTimestamp((int)startTimestamp.getEpochSecond())
+              .setEndTimestamp((int)endTimeStamp.getEpochSecond())
               .setRegion(region)
               .setBatchNum(index + 1)
               .setBatchSize(numBatches)


### PR DESCRIPTION
Well, we probably can´t determine an infection time down to the millisecond, so seconds should be fine and we can jump to an int32 instead of an int64.

This saves 8 Byte per exposed user when downloading the exposure notifications.. Especially because the milliseconds part contains a lot of entropy and can´t be compressed efficiently.

Assuming 5k exposed users, this saves 39KByte/download when we assume ~60 Million users this is a lot of traffic!

Hopefully Corona won´t be an issue in 2038 ;)