### PR TITLE
check dependencies for security issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,22 @@
 				</executions>
 			</plugin>
 			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>5.3.2</version>
+				<configuration>
+					<failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-dependency-plugin</artifactId>
 				<version>3.1.2</version>
 			</plugin>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -117,6 +117,22 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>5.3.2</version>
+        <configuration>
+          <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>3.1.2</version>
       </plugin>


### PR DESCRIPTION
It is important to prevent the accidental use of dependencies with (known) vulnerabilities in applications that work with sensitive data as this application will do, in my opinion.

Therefore, I added the OWASP Dependency-Check to the build process which checks the dependencies for known vulnerabilities. The checks are executed locally against a database that is automatically refreshed by the plugin.

For now, I configured the plugin to provoke a build failure if there is a vulnerable dependency. Actually, this is currently happening, but the respective dependency is annotated with a reference to the vulnerability details, so it seems to be a known problem. In such a case, it might be helpful to temporarily whitelist the dependency (known 'false-positives' can be configured using the plugin). Apart from that, the plugin offers the ability to set a CVSS threshold above which the build will fail.

For discussion: Configuring the plugin to be executed on every ```package``` invocation might be too strict, especially combined with build failure on any vulnerability. Maybe it is sensible to execute it - as per default - only when running ```mvn verify``` and to include this when the software is build for production.

This plugin appeared helpful to me before, I'm not involved in its development.

This is a first version of this PR and I'm happy to improve it based on your suggestions!