### PR TITLE
Increase robustness of DiagnosisKeyService: reject negative retention period

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
@@ -62,12 +62,17 @@ public class DiagnosisKeyService {
   }
 
   /**
-   * Deletes all diagnosis key entries which have a submission timestamp that is older than the specified number of
-   * days.
+   * Deletes all diagnosis key entries which have a submission timestamp that is older than the
+   * specified number of days.
    *
    * @param daysToRetain the number of days until which diagnosis keys will be retained.
+   * @throws IllegalArgumentException if {@code daysToRetain} is negative.
    */
   public void applyRetentionPolicy(int daysToRetain) {
+    if (daysToRetain < 0) {
+      throw new IllegalArgumentException("Number of days to retain must be greater or equal to 0.");
+    }
+
     long threshold = LocalDateTime
         .ofInstant(Instant.now(), UTC)
         .minusDays(daysToRetain)

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTest.java
@@ -21,6 +21,7 @@ package app.coronawarn.server.common.persistence.service;
 
 import static app.coronawarn.server.common.persistence.service.DiagnosisKeyServiceTestHelper.assertDiagnosisKeysEqual;
 import static java.time.ZoneOffset.UTC;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
@@ -32,7 +33,10 @@ import java.util.Collections;
 import java.util.List;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
@@ -79,6 +83,21 @@ public class DiagnosisKeyServiceTest {
     var actKeys = diagnosisKeyService.getDiagnosisKeys();
 
     assertDiagnosisKeysEqual(expKeys, actKeys);
+  }
+
+  @DisplayName("Assert a positive retention period is accepted.")
+  @ValueSource(ints = {0, 1, Integer.MAX_VALUE})
+  @ParameterizedTest
+  void testApplyRetentionPolicyForValidNumberOfDays(int daysToRetain) {
+    assertDoesNotThrow(() -> diagnosisKeyService.applyRetentionPolicy(daysToRetain));
+  }
+
+  @DisplayName("Assert a negative retention period is rejected.")
+  @ValueSource(ints = {Integer.MIN_VALUE, -1})
+  @ParameterizedTest
+  void testApplyRetentionPolicyForNegativeNumberOfDays(int daysToRetain) {
+    assertThrows(IllegalArgumentException.class,
+        () -> diagnosisKeyService.applyRetentionPolicy(daysToRetain));
   }
 
   @Test


### PR DESCRIPTION
_Upfront: Great project and thank you for the contribution so far, colleagues!_

---
I could provide a small improvement to code robustness (here by applying the principle of _failing early_):

Service bean [`DiagnosisKeyService`](https://github.com/corona-warn-app/cwa-server/blob/master/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java#L35) exposes `public` method `applyRetentionPolicy(int daysToRetain)`

- As a public method, it should validate input parameters.
- Though, as of now, _negative_ values for the diagnosis key retention period are allowed.

The method concerned is the following:

https://github.com/corona-warn-app/cwa-server/blob/90f713db6e3f2207e167ad82a9b9857415fcf4d9/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java#L61-L73

- While a negative integer theoretically could be considered as valid input, it is questionable if there is the requirement to delete diagnosis key entries having a timestamp in the future (as such entries should not exist in the first place).
- An alternative would be to accept negative integers for `daysToRetain` and to interpret this as a request to have all diagnostic keys deleted, equivalent to providing `0` as input parameter. I would argue against this alternative because it could hide an actual problem with the retention period value provided.