### PR TITLE
Removing duplicate property services.submission.retention-days in submission application.properties

### DIFF
--- a/services/submission/src/main/resources/application.properties
+++ b/services/submission/src/main/resources/application.properties
@@ -11,7 +11,6 @@ services.submission.payload.max-number-of-keys=14
 spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 
-services.submission.retention-days=14
 spring.flyway.locations=classpath:db/migration/postgres
 
 # Postgres configuration


### PR DESCRIPTION
Removing one duplicated property `services.submission.retention-days=14` in submission application property.
@ole-lilienthal 