### PR TITLE
Add groupId to maven-dependency-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>3.1.2</version>
       </plugin>


### PR DESCRIPTION
Was getting an error in intelliJ, plugin is used in circle ci