### PR TITLE
define compose service name as endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
     ports:
       - "8003:8000"
     environment:
+      ENDPOINT: objectstore
       REMOTE_MANAGEMENT_DISABLE: 1
       SCALITY_ACCESS_KEY_ID: ${OBJECTSTORE_ACCESSKEY}
       SCALITY_SECRET_ACCESS_KEY: ${OBJECTSTORE_SECRETKEY}


### PR DESCRIPTION
@ole-lilienthal, verbose logging revealed this error: `"Error: bad request: hostname objectstore is not in valid endpoints..."` which is fixed with the `ENDPOINT` env var. 