### PR TITLE
Don't fail circleci build if sonar fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           path: ~/test-results/junit
       - run:
           name: Analyze on SonarCloud
-          command: mvn verify sonar:sonar
+          command: mvn verify sonar:sonar --fail-never
 
 workflows:
   main:


### PR DESCRIPTION
`mvn verify sonar:sonar` fails for forked PR builds. For now, just see if we can add the don't flag so sonar won't work for community PRs for now, but unblocks them.