### PR TITLE
DiagnosisKey: Reject negative retention period for threshold calculation

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
@@ -136,8 +136,12 @@ public class DiagnosisKey {
    *
    * @param daysToRetain the number of days before a key is outdated
    * @return true, if the rolling start number is in the time span between now, and the given days to retain
+   * @throws IllegalArgumentException if {@code daysToRetain} is negative.
    */
-  public boolean isYoungerThanRetentionThreshold(long daysToRetain) {
+  public boolean isYoungerThanRetentionThreshold(int daysToRetain) {
+    if (daysToRetain < 0) {
+      throw new IllegalArgumentException("Retention threshold must be greater or equal to 0.");
+    }
     long threshold = LocalDateTime
         .ofInstant(Instant.now(), UTC)
         .minusDays(daysToRetain)

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
@@ -21,9 +21,9 @@ package app.coronawarn.server.common.persistence.domain;
 
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -84,14 +84,15 @@ public class DiagnosisKeyTest {
   @ValueSource(ints = {0, 1, Integer.MAX_VALUE})
   @ParameterizedTest
   public void testRetentionThresholdAcceptsPositiveValue(int daysToRetain) {
-    assertDoesNotThrow(() -> diagnosisKey.isYoungerThanRetentionThreshold(daysToRetain));
+    assertThatCode(() -> diagnosisKey.isYoungerThanRetentionThreshold(daysToRetain))
+        .doesNotThrowAnyException();
   }
 
   @DisplayName("Test retention threshold rejects negative value")
   @ValueSource(ints = {Integer.MIN_VALUE, -1})
   @ParameterizedTest
   public void testRetentionThresholdRejectsNegativeValue(int daysToRetain) {
-    assertThrows(IllegalArgumentException.class,
-        () -> diagnosisKey.isYoungerThanRetentionThreshold(daysToRetain));
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> diagnosisKey.isYoungerThanRetentionThreshold(daysToRetain));
   }
 }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
@@ -20,14 +20,19 @@
 package app.coronawarn.server.common.persistence.domain;
 
 import static java.time.ZoneOffset.UTC;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.Charset;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class DiagnosisKeyTest {
 
@@ -68,8 +73,23 @@ public class DiagnosisKeyTest {
     DiagnosisKey diagnosisKeyFiveDays = new DiagnosisKey(expKeyData, fiveDaysAgo,
         expRollingPeriod, expTransmissionRiskLevel, expSubmissionTimestamp);
 
-    assertFalse(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(4L));
-    assertFalse(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(5L));
-    assertTrue(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(6L));
+    assertFalse(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(4));
+    assertFalse(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(5));
+    assertTrue(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(6));
+  }
+
+  @DisplayName("Test retention threshold accepts positive value")
+  @ValueSource(ints = {0, 1, Integer.MAX_VALUE})
+  @ParameterizedTest
+  public void testRetentionThresholdAcceptsPositiveValue(int daysToRetain) {
+    assertDoesNotThrow(() -> diagnosisKey.isYoungerThanRetentionThreshold(daysToRetain));
+  }
+
+  @DisplayName("Test retention threshold rejects negative value")
+  @ValueSource(ints = {Integer.MIN_VALUE, -1})
+  @ParameterizedTest
+  public void testRetentionThresholdRejectsNegativeValue(int daysToRetain) {
+    assertThrows(IllegalArgumentException.class,
+        () -> diagnosisKey.isYoungerThanRetentionThreshold(daysToRetain));
   }
 }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
@@ -23,8 +23,6 @@ import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 import java.nio.charset.Charset;
@@ -75,9 +73,9 @@ public class DiagnosisKeyTest {
     DiagnosisKey diagnosisKeyFiveDays = new DiagnosisKey(expKeyData, fiveDaysAgo,
         expRollingPeriod, expTransmissionRiskLevel, expSubmissionTimestamp);
 
-    assertFalse(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(4));
-    assertFalse(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(5));
-    assertTrue(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(6));
+    assertThat(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(4)).isFalse();
+    assertThat(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(5)).isFalse();
+    assertThat(diagnosisKeyFiveDays.isYoungerThanRetentionThreshold(6)).isTrue();
   }
 
   @DisplayName("Test retention threshold accepts positive value")


### PR DESCRIPTION
Hello colleagues,

follow-up on https://github.com/corona-warn-app/cwa-server/pull/211, which was regarding class `DiagnosisKeyService`.

Analogous, this PR improves code in class `DiagnosisKey`:

##### Change type from `long` to `int` for method parameter `daysToRetain` for a method in class `DiagnosisKey`
https://github.com/corona-warn-app/cwa-server/blob/2701e119bcec26a1144616f3ddddcbaedb1baf24/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java#L140

1. `long` value range not required (current planned retention value in the magnitude of 10 days).
1. The method, as of today, actually crashes with `java.time.DateTimeException` when being called with `Long.MAX` as parameter value (_"Invalid value for EpochDay"..._).

#### For the same method: reject negative values for method parameter `daysToRetain` 
- Negative values not required in the domain; current value range could hide actual errors. 
- See reasoning of  https://github.com/corona-warn-app/cwa-server/pull/211.