### PR TITLE
Throw IOException if output directory clearing fails

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/OutputDirectoryProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/OutputDirectoryProvider.java
@@ -57,6 +57,8 @@ public class OutputDirectoryProvider {
     logger.debug("Clearing output directory...");
     java.io.File outputDirectory = getFileOnDisk();
     FileUtils.deleteDirectory(outputDirectory);
-    outputDirectory.mkdirs();
+    if (!outputDirectory.mkdirs()) {
+      throw new IOException("Failed to clear output directory.");
+    }
   }
 }


### PR DESCRIPTION
Throws an IOException if ``OutputDirectoryProvider.clear()`` fails to delete and re-create the output directory.