### PR TITLE
Adds Risk Score Classification Configuration

### DIFF
--- a/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/internal/risk_score_classification.proto
+++ b/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/internal/risk_score_classification.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+package app.coronawarn.server.common.protocols.internal;
+option java_package = "app.coronawarn.server.common.protocols.internal";
+option java_multiple_files = true;
+
+message RiskScoreClassification {
+  repeated RiskScoreClass riskScoreClasses = 1;
+}
+
+message RiskScoreClass {
+  string label = 1;
+  int32 minRiskLevel = 2;
+  int32 maxRiskLevel = 3;
+  string url = 4;
+}

--- a/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/internal/risk_score_classification.proto
+++ b/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/internal/risk_score_classification.proto
@@ -4,12 +4,12 @@ option java_package = "app.coronawarn.server.common.protocols.internal";
 option java_multiple_files = true;
 
 message RiskScoreClassification {
-  repeated RiskScoreClass riskScoreClasses = 1;
+  repeated RiskScoreClass risk_classes = 1;
 }
 
 message RiskScoreClass {
   string label = 1;
-  int32 minRiskLevel = 2;
-  int32 maxRiskLevel = 3;
+  int32 min = 2;
+  int32 max = 3;
   string url = 4;
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/RiskScoreClassificationProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/RiskScoreClassificationProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Corona-Warn-App
+ *
+ * SAP SE and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package app.coronawarn.server.services.distribution.assembly.appconfig;
+
+import app.coronawarn.server.common.protocols.internal.RiskScoreClassification;
+
+/**
+ * Provides the risk score classification based on a file on the file system. The existing file must be a valid YAML
+ * file, and must match the specification of the proto file risk_score_classification.proto.
+ */
+public class RiskScoreClassificationProvider {
+
+  private RiskScoreClassificationProvider() {
+  }
+
+  /**
+   * The location of the risk score classification master file.
+   */
+  public static final String MASTER_FILE = "risk-score-classification/master.yaml";
+
+  /**
+   * Fetches the master configuration as a {@link RiskScoreClassification} instance.
+   *
+   * @return the risk score classification as {@link RiskScoreClassification}
+   * @throws UnableToLoadFileException when the file/transformation did not succeed
+   */
+  public static RiskScoreClassification readMasterFile() throws UnableToLoadFileException {
+    return readFile(MASTER_FILE);
+  }
+
+  /**
+   * Fetches a risk score classification file based on the given path. The path must be available in the classloader.
+   *
+   * @param path The path, e.g. folder/my-risk-score-classification.yaml
+   * @return the RiskScoreClassification
+   * @throws UnableToLoadFileException when the file access/transformation did not succeed
+   */
+  public static RiskScoreClassification readFile(String path) throws UnableToLoadFileException {
+    return YamlLoader.loadYamlIntoProtobufBuilder(path, RiskScoreClassification.Builder.class).build();
+  }
+}

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/parsing/YamlConstructorForProtoBuf.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/parsing/YamlConstructorForProtoBuf.java
@@ -56,5 +56,4 @@ public class YamlConstructorForProtoBuf extends Constructor {
       return Character.toLowerCase(camelCase.charAt(0)) + camelCase.substring(1);
     }
   }
-
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidationError.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidationError.java
@@ -27,7 +27,7 @@ public class RiskScoreClassificationValidationError implements ValidationError {
 
   private final Object value;
 
-  private final String reason;
+  private final ErrorType reason;
 
   /**
    * Creates a {@link RiskScoreClassificationValidationError} that stores the specified validation error source,
@@ -35,9 +35,9 @@ public class RiskScoreClassificationValidationError implements ValidationError {
    *
    * @param errorSource A label that describes the property associated with this validation error.
    * @param value       The value that caused the validation error.
-   * @param reason      A description of this specific validation error.
+   * @param reason      A validation error specifier.
    */
-  public RiskScoreClassificationValidationError(String errorSource, Object value, String reason) {
+  public RiskScoreClassificationValidationError(String errorSource, Object value, ErrorType reason) {
     this.errorSource = errorSource;
     this.value = value;
     this.reason = reason;
@@ -69,5 +69,13 @@ public class RiskScoreClassificationValidationError implements ValidationError {
   @Override
   public int hashCode() {
     return Objects.hash(errorSource, value, reason);
+  }
+
+  public enum ErrorType {
+    BLANK_LABEL,
+    MIN_GREATER_THAN_MAX,
+    VALUE_OUT_OF_BOUNDS,
+    INVALID_URL,
+    INVALID_PARTITIONING
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidationError.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidationError.java
@@ -1,0 +1,73 @@
+/*
+ * Corona-Warn-App
+ *
+ * SAP SE and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package app.coronawarn.server.services.distribution.assembly.appconfig.validation;
+
+import java.util.Objects;
+
+public class RiskScoreClassificationValidationError implements ValidationError {
+
+  private final String errorSource;
+
+  private final Object value;
+
+  private final String reason;
+
+  /**
+   * Creates a {@link RiskScoreClassificationValidationError} that stores the specified validation error source,
+   * erroneous value and a reason for the error to occur.
+   *
+   * @param errorSource A label that describes the property associated with this validation error.
+   * @param value       The value that caused the validation error.
+   * @param reason      A description of this specific validation error.
+   */
+  public RiskScoreClassificationValidationError(String errorSource, Object value, String reason) {
+    this.errorSource = errorSource;
+    this.value = value;
+    this.reason = reason;
+  }
+
+  @Override
+  public String toString() {
+    return "RiskScoreClassificationValidationError{"
+        + "errorType=" + reason
+        + ", parameter='" + errorSource + '\''
+        + ", givenValue=" + value
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RiskScoreClassificationValidationError that = (RiskScoreClassificationValidationError) o;
+    return Objects.equals(errorSource, that.errorSource)
+        && Objects.equals(value, that.value)
+        && Objects.equals(reason, that.reason);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(errorSource, value, reason);
+  }
+}

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidator.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidator.java
@@ -19,6 +19,12 @@
 
 package app.coronawarn.server.services.distribution.assembly.appconfig.validation;
 
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.RiskScoreClassificationValidationError.ErrorType.BLANK_LABEL;
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.RiskScoreClassificationValidationError.ErrorType.INVALID_PARTITIONING;
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.RiskScoreClassificationValidationError.ErrorType.INVALID_URL;
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.RiskScoreClassificationValidationError.ErrorType.MIN_GREATER_THAN_MAX;
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.RiskScoreClassificationValidationError.ErrorType.VALUE_OUT_OF_BOUNDS;
+
 import app.coronawarn.server.common.protocols.internal.RiskScoreClass;
 import app.coronawarn.server.common.protocols.internal.RiskScoreClassification;
 import java.net.MalformedURLException;
@@ -68,23 +74,20 @@ public class RiskScoreClassificationValidator extends AppConfigurationValidator 
 
       if (minRiskLevel > maxRiskLevel) {
         errors.add(new RiskScoreClassificationValidationError(
-            "minRiskLevel, maxRiskLevel", minRiskLevel + ", " + maxRiskLevel,
-            "minRiskLevel is greater than maxRiskLevel"));
+            "minRiskLevel, maxRiskLevel", minRiskLevel + ", " + maxRiskLevel, MIN_GREATER_THAN_MAX));
       }
     }
   }
 
   private void validateLabel(String label) {
     if (label.isBlank()) {
-      errors.add(new RiskScoreClassificationValidationError("label", label, "blank label"));
+      errors.add(new RiskScoreClassificationValidationError("label", label, BLANK_LABEL));
     }
   }
 
   private void validateRiskScoreValueBounds(int value) {
     if (value < 0 || value > RISK_SCORE_VALUE_RANGE - 1) {
-      errors.add(new RiskScoreClassificationValidationError(
-          "minRiskLevel/maxRiskLevel", value,
-          "minRiskLevel or maxRiskLevel is out of bounds"));
+      errors.add(new RiskScoreClassificationValidationError("minRiskLevel/maxRiskLevel", value, VALUE_OUT_OF_BOUNDS));
     }
   }
 
@@ -93,7 +96,7 @@ public class RiskScoreClassificationValidator extends AppConfigurationValidator 
       try {
         new URL(url);
       } catch (MalformedURLException e) {
-        errors.add(new RiskScoreClassificationValidationError("url", url, "invalid url"));
+        errors.add(new RiskScoreClassificationValidationError("url", url, INVALID_URL));
       }
     }
   }
@@ -104,9 +107,7 @@ public class RiskScoreClassificationValidator extends AppConfigurationValidator 
         .sum();
 
     if (partitionSum != RISK_SCORE_VALUE_RANGE) {
-      errors.add(new RiskScoreClassificationValidationError(
-          "covered value range", partitionSum,
-          "covered value range does not match risk score value range"));
+      errors.add(new RiskScoreClassificationValidationError("covered value range", partitionSum, INVALID_PARTITIONING));
     }
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidator.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidator.java
@@ -63,9 +63,9 @@ public class RiskScoreClassificationValidator extends AppConfigurationValidator 
   }
 
   private void validateValues() {
-    for (RiskScoreClass riskScoreClass : riskScoreClassification.getRiskScoreClassesList()) {
-      int minRiskLevel = riskScoreClass.getMinRiskLevel();
-      int maxRiskLevel = riskScoreClass.getMaxRiskLevel();
+    for (RiskScoreClass riskScoreClass : riskScoreClassification.getRiskClassesList()) {
+      int minRiskLevel = riskScoreClass.getMin();
+      int maxRiskLevel = riskScoreClass.getMax();
 
       validateLabel(riskScoreClass.getLabel());
       validateRiskScoreValueBounds(minRiskLevel);
@@ -102,8 +102,8 @@ public class RiskScoreClassificationValidator extends AppConfigurationValidator 
   }
 
   private void validateValueRangeCoverage() {
-    int partitionSum = riskScoreClassification.getRiskScoreClassesList().stream()
-        .mapToInt(riskScoreClass -> (riskScoreClass.getMaxRiskLevel() - riskScoreClass.getMinRiskLevel() + 1))
+    int partitionSum = riskScoreClassification.getRiskClassesList().stream()
+        .mapToInt(riskScoreClass -> (riskScoreClass.getMax() - riskScoreClass.getMin() + 1))
         .sum();
 
     if (partitionSum != RISK_SCORE_VALUE_RANGE) {

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidator.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidator.java
@@ -1,0 +1,112 @@
+/*
+ * Corona-Warn-App
+ *
+ * SAP SE and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package app.coronawarn.server.services.distribution.assembly.appconfig.validation;
+
+import app.coronawarn.server.common.protocols.internal.RiskScoreClass;
+import app.coronawarn.server.common.protocols.internal.RiskScoreClassification;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * The RiskScoreClassificationValidator validates the values of an associated {@link RiskScoreClassification} instance.
+ */
+public class RiskScoreClassificationValidator extends AppConfigurationValidator {
+
+  /**
+   * This defines the number of possible values (0 ... RISK_SCORE_VALUE_RANGE - 1) for the total risk score.
+   */
+  public static final int RISK_SCORE_VALUE_RANGE = 256;
+
+  private final RiskScoreClassification riskScoreClassification;
+
+  public RiskScoreClassificationValidator(RiskScoreClassification riskScoreClassification) {
+    this.riskScoreClassification = riskScoreClassification;
+  }
+
+  /**
+   * Performs a validation of the associated {@link RiskScoreClassification} instance and returns information about
+   * validation failures.
+   *
+   * @return The ValidationResult instance, containing information about possible errors.
+   */
+  @Override
+  public ValidationResult validate() {
+    errors = new ValidationResult();
+
+    validateValues();
+    validateValueRangeCoverage();
+
+    return errors;
+  }
+
+  private void validateValues() {
+    for (RiskScoreClass riskScoreClass : riskScoreClassification.getRiskScoreClassesList()) {
+      int minRiskLevel = riskScoreClass.getMinRiskLevel();
+      int maxRiskLevel = riskScoreClass.getMaxRiskLevel();
+
+      validateLabel(riskScoreClass.getLabel());
+      validateRiskScoreValueBounds(minRiskLevel);
+      validateRiskScoreValueBounds(maxRiskLevel);
+      validateUrl(riskScoreClass.getUrl());
+
+      if (minRiskLevel > maxRiskLevel) {
+        errors.add(new RiskScoreClassificationValidationError(
+            "minRiskLevel, maxRiskLevel", minRiskLevel + ", " + maxRiskLevel,
+            "minRiskLevel is greater than maxRiskLevel"));
+      }
+    }
+  }
+
+  private void validateLabel(String label) {
+    if (label.isBlank()) {
+      errors.add(new RiskScoreClassificationValidationError("label", label, "blank label"));
+    }
+  }
+
+  private void validateRiskScoreValueBounds(int value) {
+    if (value < 0 || value > RISK_SCORE_VALUE_RANGE - 1) {
+      errors.add(new RiskScoreClassificationValidationError(
+          "minRiskLevel/maxRiskLevel", value,
+          "minRiskLevel or maxRiskLevel is out of bounds"));
+    }
+  }
+
+  private void validateUrl(String url) {
+    if (!url.isBlank()) {
+      try {
+        new URL(url);
+      } catch (MalformedURLException e) {
+        errors.add(new RiskScoreClassificationValidationError("url", url, "invalid url"));
+      }
+    }
+  }
+
+  private void validateValueRangeCoverage() {
+    int partitionSum = riskScoreClassification.getRiskScoreClassesList().stream()
+        .mapToInt(riskScoreClass -> (riskScoreClass.getMaxRiskLevel() - riskScoreClass.getMinRiskLevel() + 1))
+        .sum();
+
+    if (partitionSum != RISK_SCORE_VALUE_RANGE) {
+      errors.add(new RiskScoreClassificationValidationError(
+          "covered value range", partitionSum,
+          "covered value range does not match risk score value range"));
+    }
+  }
+}

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ValidationResult.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ValidationResult.java
@@ -40,11 +40,6 @@ public class ValidationResult {
     return this.errors.add(error);
   }
 
-  @Override
-  public String toString() {
-    return errors.toString();
-  }
-
   /**
    * Checks whether this validation result instance has at least one error.
    *
@@ -54,13 +49,9 @@ public class ValidationResult {
     return !this.errors.isEmpty();
   }
 
-  /**
-   * Checks whether this validation result instance has no errors.
-   *
-   * @return true if yes, false otherwise
-   */
-  public boolean isSuccessful() {
-    return !hasErrors();
+  @Override
+  public String toString() {
+    return errors.toString();
   }
 
   @Override

--- a/services/distribution/src/main/resources/risk-score-classification/master.yaml
+++ b/services/distribution/src/main/resources/risk-score-classification/master.yaml
@@ -1,0 +1,26 @@
+# This is the Risk Score Classification master file which partitions the risk
+# score value range (0-255) into distinct risk classes that will be used to by
+# the app in order to present the correct risk classification in a user
+# friendly manner, based on the underlying total risk score, to the user.
+#
+# The risk classes must not overlap and
+# cover the full risk score value range (0-255).
+#
+# Change this file with caution!
+
+risk_classes:
+  -
+    class: LOW
+    min: 0
+    max: 100
+    url: "https://www..."
+  -
+    class: MID
+    min: 101
+    max: 200
+    url: "https://www..."
+  -
+    class: HIGH
+    min: 201
+    max: 255
+    url: "https://www..."

--- a/services/distribution/src/main/resources/risk-score-classification/master.yaml
+++ b/services/distribution/src/main/resources/risk-score-classification/master.yaml
@@ -24,3 +24,4 @@ risk_classes:
     min: 201
     max: 255
     url: "https://www..."
+    

--- a/services/distribution/src/main/resources/risk-score-classification/master.yaml
+++ b/services/distribution/src/main/resources/risk-score-classification/master.yaml
@@ -10,17 +10,17 @@
 
 risk_classes:
   -
-    class: LOW
+    label: "LOW"
     min: 0
     max: 100
     url: "https://www..."
   -
-    class: MID
+    label: "MID"
     min: 101
     max: 200
     url: "https://www..."
   -
-    class: HIGH
+    label: "HIGH"
     min: 201
     max: 255
     url: "https://www..."

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/RiskScoreClassificationProviderMasterFileTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/RiskScoreClassificationProviderMasterFileTest.java
@@ -1,0 +1,46 @@
+/*
+ * Corona-Warn-App
+ *
+ * SAP SE and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package app.coronawarn.server.services.distribution.assembly.appconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.coronawarn.server.services.distribution.assembly.appconfig.validation.ExposureConfigurationValidator;
+import app.coronawarn.server.services.distribution.assembly.appconfig.validation.RiskScoreClassificationValidator;
+import app.coronawarn.server.services.distribution.assembly.appconfig.validation.ValidationResult;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test will verify that the provided risk score classification master file is syntactically correct and according
+ * to spec.
+ * There should never be any deployment when this test is failing.
+ */
+public class RiskScoreClassificationProviderMasterFileTest {
+
+  private static final ValidationResult SUCCESS = new ValidationResult();
+
+  @Test
+  public void testMasterFile() throws UnableToLoadFileException {
+    var config = RiskScoreClassificationProvider.readMasterFile();
+
+    var validator = new RiskScoreClassificationValidator(config);
+
+    assertThat(validator.validate()).isEqualTo(SUCCESS);
+  }
+}

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidatorTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidatorTest.java
@@ -1,0 +1,173 @@
+/*
+ * Corona-Warn-App
+ *
+ * SAP SE and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package app.coronawarn.server.services.distribution.assembly.appconfig.validation;
+
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.RiskScoreClassificationValidator.RISK_SCORE_VALUE_RANGE;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.RiskScoreClassificationValidationError.ErrorType.*;
+
+import app.coronawarn.server.common.protocols.internal.RiskScoreClass;
+import app.coronawarn.server.common.protocols.internal.RiskScoreClassification;
+import app.coronawarn.server.services.distribution.assembly.appconfig.validation.RiskScoreClassificationValidationError.ErrorType;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class RiskScoreClassificationValidatorTest {
+
+  private final static int MAX_SCORE = RISK_SCORE_VALUE_RANGE - 1;
+  private final static String VALID_LABEL = "myLabel";
+  private final static String VALID_URL = "";
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " "})
+  void failsForBlankLabels(String invalidLabel) {
+    var validator = buildValidator(buildRiskClass(invalidLabel, 0, MAX_SCORE, ""));
+    var expectedResult = buildExpectedResult(buildError("label", invalidLabel, ErrorType.BLANK_LABEL));
+
+    assertThat(validator.validate()).isEqualTo(expectedResult);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"invalid.Url", "invalid-url", "$$$://invalid.url"})
+  void failsForInvalidUrl(String invalidUrl) {
+    var validator = buildValidator(buildRiskClass(VALID_LABEL, 0, MAX_SCORE, invalidUrl));
+    var expectedResult = buildExpectedResult(buildError("url", invalidUrl, ErrorType.INVALID_URL));
+
+    assertThat(validator.validate()).isEqualTo(expectedResult);
+  }
+
+  @Test
+  void failsForNegativeRiskValues() {
+    // must cover value range of equal size in order to avoid INVALID_PARTITIONING error
+    int negativeMin = -MAX_SCORE - 1;
+    int negativeMax = -1;
+    var validator = buildValidator(buildRiskClass(VALID_LABEL, negativeMin, negativeMax, VALID_URL));
+    var expectedResult = buildExpectedResult(
+        buildError("minRiskLevel/maxRiskLevel", negativeMin, ErrorType.VALUE_OUT_OF_BOUNDS),
+        buildError("minRiskLevel/maxRiskLevel", negativeMax, ErrorType.VALUE_OUT_OF_BOUNDS));
+
+    assertThat(validator.validate()).isEqualTo(expectedResult);
+  }
+
+  @Test
+  void failsForTooLargeRiskValues() {
+    // must cover value range of equal size in order to avoid INVALID_PARTITIONING error
+    int tooLargeMin = MAX_SCORE + 1;
+    int tooLargeMax = 2 * MAX_SCORE + 1;
+    var validator = buildValidator(buildRiskClass(VALID_LABEL, tooLargeMin, tooLargeMax, VALID_URL));
+    var expectedResult = buildExpectedResult(
+        buildError("minRiskLevel/maxRiskLevel", tooLargeMin, ErrorType.VALUE_OUT_OF_BOUNDS),
+        buildError("minRiskLevel/maxRiskLevel", tooLargeMax, ErrorType.VALUE_OUT_OF_BOUNDS));
+
+    assertThat(validator.validate()).isEqualTo(expectedResult);
+  }
+
+  @Test
+  void failsIfMinGreaterThanMax() {
+    int min = 1;
+    int max = 0;
+    // Note: additional classes have to be added in order to reach the expected value range size
+    var validator = buildValidator(buildRiskClass(VALID_LABEL, min, max, VALID_URL),
+        buildRiskClass(VALID_LABEL, 0, MAX_SCORE, VALID_URL));
+    var expectedResult = buildExpectedResult(
+        buildError("minRiskLevel, maxRiskLevel", (min + ", " + max), MIN_GREATER_THAN_MAX));
+
+    assertThat(validator.validate()).isEqualTo(expectedResult);
+  }
+
+  @ParameterizedTest
+  @MethodSource("createInvalidPartitionings")
+  void failsIfPartitioningInvalid(RiskScoreClassification invalidClassification) {
+    var validator = new RiskScoreClassificationValidator(invalidClassification);
+    int coveredRange = invalidClassification.getRiskScoreClassesList().stream()
+        .mapToInt(riskScoreClass -> (riskScoreClass.getMaxRiskLevel() - riskScoreClass.getMinRiskLevel() + 1))
+        .sum();
+    var expectedResult = buildExpectedResult(
+        buildError("covered value range", coveredRange, INVALID_PARTITIONING));
+
+    assertThat(validator.validate()).isEqualTo(expectedResult);
+  }
+
+  private static Stream<Arguments> createInvalidPartitionings() {
+    return Stream.of(
+        buildClassification(buildRiskClass(VALID_LABEL, 0, 0, VALID_URL)),
+        buildClassification(
+            buildRiskClass(VALID_LABEL, 0, MAX_SCORE / 2, VALID_URL),
+            buildRiskClass(VALID_LABEL, MAX_SCORE / 2 + 1, MAX_SCORE, VALID_URL),
+            buildRiskClass(VALID_LABEL, 0, MAX_SCORE, VALID_URL)),
+        buildClassification(
+            buildRiskClass(VALID_LABEL, 0, MAX_SCORE, VALID_URL),
+            buildRiskClass(VALID_LABEL, 0, MAX_SCORE, VALID_URL))
+    ).map(Arguments::of);
+  }
+
+  @ParameterizedTest
+  @MethodSource("createValidClassifications")
+  void doesNotFailForValidClassification(RiskScoreClassification validClassification) {
+    var validator = new RiskScoreClassificationValidator(validClassification);
+    assertThat(validator.validate()).isEqualTo(new ValidationResult());
+  }
+
+  private static Stream<Arguments> createValidClassifications() {
+    return Stream.of(
+        // blank url
+        buildClassification(buildRiskClass(VALID_LABEL, 0, MAX_SCORE, "")),
+        // legit url
+        buildClassification(buildRiskClass(VALID_LABEL, 0, MAX_SCORE, "http://www.sap.com")),
+        // [0:MAX_SCORE/2][MAX_SCORE/2:MAX_SCORE]
+        buildClassification(
+            buildRiskClass(VALID_LABEL, 0, MAX_SCORE / 2, VALID_URL),
+            buildRiskClass(VALID_LABEL, MAX_SCORE / 2 + 1, MAX_SCORE, VALID_URL)),
+        // [0:MAX_SCORE-10][MAX_SCORE-9][MAX_SCORE-8:MAX_SCORE]
+        buildClassification(
+            buildRiskClass(VALID_LABEL, 0, MAX_SCORE - 10, VALID_URL),
+            buildRiskClass(VALID_LABEL, MAX_SCORE - 9, MAX_SCORE - 9, VALID_URL),
+            buildRiskClass(VALID_LABEL, MAX_SCORE - 8, MAX_SCORE, VALID_URL))
+    ).map(Arguments::of);
+  }
+
+  private static RiskScoreClassificationValidationError buildError(String parameter, Object value, ErrorType reason) {
+    return new RiskScoreClassificationValidationError(parameter, value, reason);
+  }
+
+  private static RiskScoreClassificationValidator buildValidator(RiskScoreClass... riskScoreClasses) {
+    return new RiskScoreClassificationValidator(buildClassification(riskScoreClasses));
+  }
+
+  private static RiskScoreClassification buildClassification(RiskScoreClass... riskScoreClasses) {
+    return RiskScoreClassification.newBuilder().addAllRiskScoreClasses(asList(riskScoreClasses)).build();
+  }
+
+  private static RiskScoreClass buildRiskClass(String label, int min, int max, String url) {
+    return RiskScoreClass.newBuilder().setLabel(label).setMinRiskLevel(min).setMaxRiskLevel(max).setUrl(url).build();
+  }
+
+  private static ValidationResult buildExpectedResult(RiskScoreClassificationValidationError... errors) {
+    var validationResult = new ValidationResult();
+    Arrays.stream(errors).forEach(validationResult::add);
+    return validationResult;
+  }
+}

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidatorTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidatorTest.java
@@ -102,8 +102,8 @@ public class RiskScoreClassificationValidatorTest {
   @MethodSource("createInvalidPartitionings")
   void failsIfPartitioningInvalid(RiskScoreClassification invalidClassification) {
     var validator = new RiskScoreClassificationValidator(invalidClassification);
-    int coveredRange = invalidClassification.getRiskScoreClassesList().stream()
-        .mapToInt(riskScoreClass -> (riskScoreClass.getMaxRiskLevel() - riskScoreClass.getMinRiskLevel() + 1))
+    int coveredRange = invalidClassification.getRiskClassesList().stream()
+        .mapToInt(riskScoreClass -> (riskScoreClass.getMax() - riskScoreClass.getMin() + 1))
         .sum();
     var expectedResult = buildExpectedResult(
         buildError("covered value range", coveredRange, INVALID_PARTITIONING));
@@ -158,11 +158,11 @@ public class RiskScoreClassificationValidatorTest {
   }
 
   private static RiskScoreClassification buildClassification(RiskScoreClass... riskScoreClasses) {
-    return RiskScoreClassification.newBuilder().addAllRiskScoreClasses(asList(riskScoreClasses)).build();
+    return RiskScoreClassification.newBuilder().addAllRiskClasses(asList(riskScoreClasses)).build();
   }
 
   private static RiskScoreClass buildRiskClass(String label, int min, int max, String url) {
-    return RiskScoreClass.newBuilder().setLabel(label).setMinRiskLevel(min).setMaxRiskLevel(max).setUrl(url).build();
+    return RiskScoreClass.newBuilder().setLabel(label).setMin(min).setMax(max).setUrl(url).build();
   }
 
   private static ValidationResult buildExpectedResult(RiskScoreClassificationValidationError... errors) {


### PR DESCRIPTION
Resolves #78 

- Adds proto files and master.yml for risk score classification.
- Adds ``risk_score_classification`` archive to ``configuration`` directory.
- Adds validation code + tests for risk score classifications.
- Validates risk score classification master file during test runs.