### PR TITLE
Add logging of invalid diagnosis keys

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
@@ -163,7 +163,7 @@ public class DiagnosisKey {
    *
    * @return A set of constraint violations of this key.
    */
-  public Set<ConstraintViolation<DiagnosisKey>> getConstraintViolations() {
+  public Set<ConstraintViolation<DiagnosisKey>> validate() {
     return VALIDATOR.validate(this);
   }
 

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
@@ -151,16 +151,6 @@ public class DiagnosisKey {
   }
 
   /**
-   * Determines if this key is valid.
-   *
-   * @return true, if valid, else false.
-   */
-  public boolean isValid() {
-    Set<ConstraintViolation<DiagnosisKey>> violations = getConstraintViolations();
-    return violations.isEmpty();
-  }
-
-  /**
    * Gets any constraint violations that this key might incorporate.
    *
    * <p><ul>
@@ -175,6 +165,18 @@ public class DiagnosisKey {
    */
   public Set<ConstraintViolation<DiagnosisKey>> getConstraintViolations() {
     return VALIDATOR.validate(this);
+  }
+
+  @Override
+  public String toString() {
+    return "DiagnosisKey{"
+        + "id=" + id
+        + ", keyData=" + Arrays.toString(keyData)
+        + ", rollingStartNumber=" + rollingStartNumber
+        + ", rollingPeriod=" + rollingPeriod
+        + ", transmissionRiskLevel=" + transmissionRiskLevel
+        + ", submissionTimestamp=" + submissionTimestamp
+        + '}';
   }
 
   @Override

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
@@ -168,18 +168,6 @@ public class DiagnosisKey {
   }
 
   @Override
-  public String toString() {
-    return "DiagnosisKey{"
-        + "id=" + id
-        + ", keyData=" + Arrays.toString(keyData)
-        + ", rollingStartNumber=" + rollingStartNumber
-        + ", rollingPeriod=" + rollingPeriod
-        + ", transmissionRiskLevel=" + transmissionRiskLevel
-        + ", submissionTimestamp=" + submissionTimestamp
-        + '}';
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilder.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilder.java
@@ -105,7 +105,7 @@ public class DiagnosisKeyBuilder implements Builder, RollingStartNumberBuilder,
   }
 
   private DiagnosisKey throwIfValidationFails(DiagnosisKey diagnosisKey) {
-    Set<ConstraintViolation<DiagnosisKey>> violations = diagnosisKey.getConstraintViolations();
+    Set<ConstraintViolation<DiagnosisKey>> violations = diagnosisKey.validate();
 
     if (!violations.isEmpty()) {
       String violationsMessage = violations.stream()

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
@@ -66,7 +66,7 @@ public class DiagnosisKeyService {
   }
 
   private static boolean isDiagnosisKeyValid(DiagnosisKey diagnosisKey) {
-    Collection<ConstraintViolation<DiagnosisKey>> violations = diagnosisKey.getConstraintViolations();
+    Collection<ConstraintViolation<DiagnosisKey>> violations = diagnosisKey.validate();
     boolean isValid = violations.isEmpty();
 
     if (!isValid) {

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
@@ -70,7 +70,9 @@ public class DiagnosisKeyService {
     boolean isValid = violations.isEmpty();
 
     if (!isValid) {
-      logger.warn("Validation failed for diagnosis key from database. Violations: {}", violations);
+      List<String> violationMessages =
+          violations.stream().map(ConstraintViolation::getMessage).collect(Collectors.toList());
+      logger.warn("Validation failed for diagnosis key from database. Violations: {}", violationMessages);
     }
 
     return isValid;

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
@@ -70,8 +70,7 @@ public class DiagnosisKeyService {
     boolean isValid = violations.isEmpty();
 
     if (!isValid) {
-      logger.warn("Validation failed for diagnosis key from database. Diagnosis key: {}, Violations: {}",
-          diagnosisKey, violations);
+      logger.warn("Validation failed for diagnosis key from database. Violations: {}", violations);
     }
 
     return isValid;


### PR DESCRIPTION
Resolves #219 

- Logs failed validations in ``DiagnosisKeyService.getDiagnosisKeys()``.
- Renames ``DiagnosisKey.getConstraintValidations`` to ``DiagnosisKey.validate`` for consistency (see ``javax.validation.Validator``, ``AppConfigurationValidator``).
- Removes ``DiagnosisKey.isValid()`` since it is no longer used.

Example log entry:
```
2020-05-24T18:41:45+02:00 WARN  main a.c.s.c.p.s.DiagnosisKeyService[61500]: Validation failed for diagnosis key from database. Diagnosis key: DiagnosisKey{id=null, keyData=[49, 55, 45, 45, 98, 121, 116, 101, 108, 111, 110, 103, 97, 114, 114, 97, 121], rollingStartNumber=73800, rollingPeriod=144, transmissionRiskLevel=1, submissionTimestamp=1}, Violations: [ConstraintViolationImpl{interpolatedMessage='Key data must be a byte array of length 16.', propertyPath=keyData, rootBeanClass=class app.coronawarn.server.common.persistence.domain.DiagnosisKey, messageTemplate='Key data must be a byte array of length 16.'}]
```