### PR TITLE
Remove unnecessary @Autowired annotations.

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/AppConfigurationStructureProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/AppConfigurationStructureProvider.java
@@ -23,7 +23,6 @@ import app.coronawarn.server.services.distribution.assembly.appconfig.structure.
 import app.coronawarn.server.services.distribution.assembly.structure.WritableOnDisk;
 import app.coronawarn.server.services.distribution.assembly.structure.directory.Directory;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -36,8 +35,7 @@ public class AppConfigurationStructureProvider {
   private final CryptoProvider cryptoProvider;
   private final DistributionServiceConfig distributionServiceConfig;
 
-  @Autowired
-  public AppConfigurationStructureProvider(CryptoProvider cryptoProvider,
+  AppConfigurationStructureProvider(CryptoProvider cryptoProvider,
       DistributionServiceConfig distributionServiceConfig) {
     this.cryptoProvider = cryptoProvider;
     this.distributionServiceConfig = distributionServiceConfig;

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/CryptoProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/CryptoProvider.java
@@ -36,7 +36,6 @@ import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
@@ -62,8 +61,7 @@ public class CryptoProvider {
   /**
    * Creates a CryptoProvider, using {@link BouncyCastleProvider}.
    */
-  @Autowired
-  public CryptoProvider(ResourceLoader resourceLoader, DistributionServiceConfig distributionServiceConfig) {
+  CryptoProvider(ResourceLoader resourceLoader, DistributionServiceConfig distributionServiceConfig) {
     this.resourceLoader = resourceLoader;
     this.privateKeyPath = distributionServiceConfig.getPaths().getPrivateKey();
     this.certificatePath = distributionServiceConfig.getPaths().getCertificate();

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/CwaApiStructureProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/CwaApiStructureProvider.java
@@ -25,7 +25,6 @@ import app.coronawarn.server.services.distribution.assembly.structure.directory.
 import app.coronawarn.server.services.distribution.assembly.structure.directory.decorator.indexing.IndexingDecoratorOnDisk;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import java.util.Set;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -46,8 +45,7 @@ public class CwaApiStructureProvider {
   /**
    * Creates a new CwaApiStructureProvider.
    */
-  @Autowired
-  public CwaApiStructureProvider(
+  CwaApiStructureProvider(
       AppConfigurationStructureProvider appConfigurationStructureProvider,
       DiagnosisKeysStructureProvider diagnosisKeysStructureProvider,
       DistributionServiceConfig distributionServiceConfig) {

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/DiagnosisKeysStructureProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/DiagnosisKeysStructureProvider.java
@@ -28,7 +28,6 @@ import app.coronawarn.server.services.distribution.config.DistributionServiceCon
 import java.util.Collection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -47,8 +46,7 @@ public class DiagnosisKeysStructureProvider {
   /**
    * Creates a new DiagnosisKeysStructureProvider.
    */
-  @Autowired
-  public DiagnosisKeysStructureProvider(DiagnosisKeyService diagnosisKeyService, CryptoProvider cryptoProvider,
+  DiagnosisKeysStructureProvider(DiagnosisKeyService diagnosisKeyService, CryptoProvider cryptoProvider,
       DistributionServiceConfig distributionServiceConfig) {
     this.diagnosisKeyService = diagnosisKeyService;
     this.cryptoProvider = cryptoProvider;

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/OutputDirectoryProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/OutputDirectoryProvider.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -39,8 +38,7 @@ public class OutputDirectoryProvider {
   private static final Logger logger = LoggerFactory.getLogger(OutputDirectoryProvider.class);
   private final String outputPath;
 
-  @Autowired
-  public OutputDirectoryProvider(DistributionServiceConfig distributionServiceConfig) {
+  OutputDirectoryProvider(DistributionServiceConfig distributionServiceConfig) {
     this.outputPath = distributionServiceConfig.getPaths().getOutput();
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -76,8 +75,7 @@ public class ObjectStoreAccess {
    * @throws GeneralSecurityException When there were problems creating the S3 client
    * @throws MinioException           When there were problems creating the S3 client
    */
-  @Autowired
-  public ObjectStoreAccess(DistributionServiceConfig distributionServiceConfig)
+  ObjectStoreAccess(DistributionServiceConfig distributionServiceConfig)
       throws IOException, GeneralSecurityException, MinioException {
     this.client = createClient(distributionServiceConfig.getObjectStore());
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/Assembly.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/Assembly.java
@@ -27,7 +27,6 @@ import app.coronawarn.server.services.distribution.assembly.structure.directory.
 import app.coronawarn.server.services.distribution.assembly.structure.util.ImmutableStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.ApplicationContext;
@@ -53,8 +52,7 @@ public class Assembly implements ApplicationRunner {
    * Creates an Assembly, using {@link OutputDirectoryProvider}, {@link CwaApiStructureProvider} and
    * {@link ApplicationContext}.
    */
-  @Autowired
-  public Assembly(OutputDirectoryProvider outputDirectoryProvider,
+  Assembly(OutputDirectoryProvider outputDirectoryProvider,
       CwaApiStructureProvider cwaApiStructureProvider, ApplicationContext applicationContext) {
     this.outputDirectoryProvider = outputDirectoryProvider;
     this.cwaApiStructureProvider = cwaApiStructureProvider;

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/RetentionPolicy.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/RetentionPolicy.java
@@ -24,7 +24,6 @@ import app.coronawarn.server.services.distribution.Application;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.ApplicationContext;
@@ -50,8 +49,7 @@ public class RetentionPolicy implements ApplicationRunner {
   /**
    * Creates a new RetentionPolicy.
    */
-  @Autowired
-  public RetentionPolicy(DiagnosisKeyService diagnosisKeyService,
+  RetentionPolicy(DiagnosisKeyService diagnosisKeyService,
       ApplicationContext applicationContext,
       DistributionServiceConfig distributionServiceConfig) {
     this.diagnosisKeyService = diagnosisKeyService;

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/S3Distribution.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/S3Distribution.java
@@ -28,7 +28,6 @@ import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.core.annotation.Order;
@@ -47,8 +46,7 @@ public class S3Distribution implements ApplicationRunner {
 
   private final ObjectStoreAccess objectStoreAccess;
 
-  @Autowired
-  public S3Distribution(OutputDirectoryProvider outputDirectoryProvider, ObjectStoreAccess objectStoreAccess) {
+  S3Distribution(OutputDirectoryProvider outputDirectoryProvider, ObjectStoreAccess objectStoreAccess) {
     this.outputDirectoryProvider = outputDirectoryProvider;
     this.objectStoreAccess = objectStoreAccess;
   }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/TestDataGeneration.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/TestDataGeneration.java
@@ -37,7 +37,6 @@ import org.apache.commons.math3.random.JDKRandomGenerator;
 import org.apache.commons.math3.random.RandomGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
@@ -79,8 +78,7 @@ public class TestDataGeneration implements ApplicationRunner {
   /**
    * Creates a new TestDataGeneration runner.
    */
-  @Autowired
-  public TestDataGeneration(DiagnosisKeyService diagnosisKeyService,
+  TestDataGeneration(DiagnosisKeyService diagnosisKeyService,
       DistributionServiceConfig distributionServiceConfig) {
     this.diagnosisKeyService = diagnosisKeyService;
     this.retentionDays = distributionServiceConfig.getRetentionDays();


### PR DESCRIPTION
Spring will use a canonical constructor for dependency injection and doesn't need @Autowired unless there's an ambiguity to resolve.

Reduced visibility of such constructors to package private to prevent code in other packages from creating instances manually.