### PR TITLE
Fix Docker Compose on Windows Hyper-V

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The docker-compose contains the following services:
 
 Service           | Description | Endpoint and Default Credentials
 ------------------|-------------|-----------
-submission        | The Corona-Warn-App submission service                                                      | `http://localhost:8000` <br> `http://localhost:8005` (for actuator endpoint)
+submission        | The Corona-Warn-App submission service                                                      | `http://localhost:8000` <br> `http://localhost:8006` (for actuator endpoint)
 distribution      | The Corona-Warn-App distribution service                                                    | NO ENDPOINT
 postgres          | A [postgres] database installation                                                          | `postgres:8001` <br> Username: postgres <br> Password: postgres
 pgadmin           | A [pgadmin](https://www.pgadmin.org/) installation for the postgres database                | `http://localhost:8002` <br> Username: user@domain.com <br> Password: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - postgres
     ports:
       - "8000:8080"
-      - "8005:8081"
+      - "8006:8081"
     environment:
       SPRING_PROFILES_ACTIVE: dev
       POSTGRESQL_SERVICE_PORT: '5432'


### PR DESCRIPTION
The latest Windows 10 update added port 8005 to the excluded port range of Hyper-V. To check if your system is affected, you can run this command and check if port 8005 is in the exclusion range:

`netsh int ipv4 show excludedportrange protocol=tcp`

This makes `docker-compose up` fail on up-to-date Windows 10 machines with the following error message:

`An attempt was made to access a socket in a way forbidden by its access permissions.`

This PR changes the actuator port to `8006` (which is not in the exclusion range) to fix this.

References:
- https://stackoverflow.com/a/59044246
- https://github.com/docker/for-win/issues/3171