### PR TITLE
Use ChatOps to allow Sonar scanning on PRs from Forks

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -15,7 +15,7 @@ jobs:
       - name: get pull request url
         id: pullrequest
         run: |
-          echo "::set-output name=number::$(echo ${{ github.event.comment.issue_url }} | sed 's/https:\/\/api.github.com\/repos\/CCFenner\/cwa-server\/issues\///g')"
+          echo "::set-output name=number::$(echo ${{ github.event.comment.issue_url }} | sed 's/https:\/\/api.github.com\/repos\/${GITHUB_REPOSITORY_OWNER}\/cwa-server\/issues\///g')"
           echo "::set-output name=url::$(curl ${{ github.event.comment.issue_url }} | jq '.pull_request.url' | sed 's/\"//g')"
       - name: get branch name
         id: repository

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -1,0 +1,38 @@
+name: ChatOps
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  sonar:
+    name: 'SonarCloud on PR'
+
+    runs-on: ubuntu-latest
+    if: github.event.comment.body == '/sonar' && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER')
+
+    steps:
+      - name: get pull request url
+        id: pullrequest
+        run: |
+          echo "::set-output name=number::$(echo ${{ github.event.comment.issue_url }} | sed 's/https:\/\/api.github.com\/repos\/CCFenner\/cwa-server\/issues\///g')"
+          echo "::set-output name=url::$(curl ${{ github.event.comment.issue_url }} | jq '.pull_request.url' | sed 's/\"//g')"
+      - name: get branch name
+        id: repository
+        run: |
+          echo "::set-output name=branch::$(curl ${{ steps.pullrequest.outputs.url }} | jq '.head.ref' | sed 's/\"//g')"
+          echo "::set-output name=slug::$(curl ${{ steps.pullrequest.outputs.url }} | jq '.head.repo.full_name' | sed 's/\"//g')"
+      # Checkout
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false # necessary to be able to provide own PAT
+          repository: ${{ steps.repository.outputs.slug }}
+          ref: ${{ steps.repository.outputs.branch }}
+      # Add remote to upstream repository
+      - run: git remote add upstream https://${CHATOPS_USER}:${CHATOPS_TOKEN}@github.com/$GITHUB_REPOSITORY
+        env:
+          CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}
+          CHATOPS_USER: ${{ secrets.CHATOPS_USER }}
+      # Only push to SonarCloud branch if PR is created from a fork
+      - if: ${{ steps.repository.outputs.slug != 'CCFenner/cwa-server' }}
+        run: git push -f upstream HEAD:chatops-sonar-${{steps.pullrequest.outputs.number}}

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   sonar:
-    name: 'SonarCloud on PR'
+    name: 'Push to SonarCloud Branch'
 
     runs-on: ubuntu-latest
     if: github.event.comment.body == '/sonar' && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER')
@@ -15,7 +15,7 @@ jobs:
       - name: get pull request url
         id: pullrequest
         run: |
-          echo "::set-output name=number::$(echo ${{ github.event.comment.issue_url }} | sed 's/https:\/\/api.github.com\/repos\/${GITHUB_REPOSITORY_OWNER}\/cwa-server\/issues\///g')"
+          echo "::set-output name=number::$(echo ${{ github.event.comment.issue_url }} | sed 's/https:\/\/api.github.com\/repos\/${{ github.repository_owner }}\/cwa-server\/issues\///g')"
           echo "::set-output name=url::$(curl ${{ github.event.comment.issue_url }} | jq '.pull_request.url' | sed 's/\"//g')"
       - name: get branch name
         id: repository
@@ -34,5 +34,5 @@ jobs:
           CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}
           CHATOPS_USER: ${{ secrets.CHATOPS_USER }}
       # Only push to SonarCloud branch if PR is created from a fork
-      - if: ${{ steps.repository.outputs.slug != 'CCFenner/cwa-server' }}
+      - if: ${{ steps.repository.outputs.slug != github.repository }}
         run: git push -f upstream HEAD:chatops-sonar-${{steps.pullrequest.outputs.number}}

--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -35,7 +35,7 @@ jobs:
         mvn --batch-mode verify sonar:sonar \
         -Dsonar.login=${SONAR_TOKEN} \
         -Dsonar.host.url=${SONAR_URL} \
-        -Dsonar.organization=ccfenner \
+        -Dsonar.organization=corona-warn-app \
         -Dsonar.projectKey=${GITHUB_REPOSITORY/\//_}
       env:
         SONAR_URL: https://sonarcloud.io

--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -1,0 +1,43 @@
+name: "ci"
+
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+    - chatops-sonar-*
+
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    # only run if it's a push event or a pull request from upstream
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+
+    name: 'github actions: sonar'
+    steps:
+    - run: echo ${{ github.repository }}
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-sonar-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-sonar-
+          ${{ runner.os }}-maven-
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - run: |
+        mvn --batch-mode verify sonar:sonar \
+        -Dsonar.login=${SONAR_TOKEN} \
+        -Dsonar.host.url=${SONAR_URL} \
+        -Dsonar.organization=ccfenner \
+        -Dsonar.projectKey=${GITHUB_REPOSITORY/\//_}
+      env:
+        SONAR_URL: https://sonarcloud.io
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Issue

Due to the fact that `secret.SONAR_TOKEN` (el al.) is not available on PR builds from froks (CircleCI, GitHub Actions) the Sonar scan can not be executed. 

## Idea

On a PR from fork a member of the dev team needs to trigger the Sonar scan after verified that the changes do not expose the Sonar token. 
This is possible by fetching the changes from fork and push to a branch on upstream repository where secrets are available.

Options:

1. Push to `master` branch
    - 🛠️ action `ci / github actions: sonar (push)` is executed doing a main branch scan
    - ✅ status for GH action is reported
1. PR from upstream repository:
    - 🛠️ action `ci / github actions: sonar (pull_request)` is executed doing a SonarClour PR scan 
    - ✅ status is reported from GH action and SonarCloud app (+ comment about issues, etc.)
1. PR from forked repository:
    - 🛠️ action `ci / github actions: sonar (pull_request)` is skipped
    - 👨 Owner, Member, Contributor can post a comment with a keyword (`/sonar`) on the PR to run a job that pushes the PR code to a upstream branch `chatops-sonar-<pr#>`
    - ✅ status for GH action is reported, **no status or comment by SonarCloud app (yet)**
1. Push to `chatops-sonar-*` branch
    - 🛠️ action `ci / github actions: sonar (push)` is executed doing a feature branch scan
    - ✅ status for GH action is reported

## Open Topics

- [ ] provide `SONAR_TOKEN` as secret to the repository
- [ ] provide username (personal / technical) to workflow or to secret as `CHATOPS_USER`
- [ ] provide personal access token as secret to the repository as `CHATOPS_TOKEN`
- [ ] enable PR scan for `chatops-sonar-<pr#>`
- [ ] remove branches (`chatops-sonar-<pr#>`) once scan is done
- [ ] remove Sonar scan from CircleCI -> separate PR when this one is merged
- [x] switch owner to `corona-warn-app`

fixes #237



