### PR TITLE
Removes use of obsolete java.util.Stack

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/structure/directory/IndexDirectory.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/structure/directory/IndexDirectory.java
@@ -24,7 +24,6 @@ import app.coronawarn.server.services.distribution.assembly.structure.util.Immut
 import app.coronawarn.server.services.distribution.assembly.structure.util.functional.Formatter;
 import app.coronawarn.server.services.distribution.assembly.structure.util.functional.WritableFunction;
 import java.util.Set;
-import java.util.Stack;
 
 /**
  * A "meta {@link Directory directory}" that maps its on-disk subdirectories to some list of elements. This list of
@@ -38,7 +37,7 @@ public interface IndexDirectory<T, W extends Writable<W>> extends Directory<W> {
   /**
    * Adds a writable under the name {@code name}, whose content is calculated by the {@code writableFunction} to each
    * one of the directories created from the index. The {@code fileFunction} calculates the file content from a {@link
-   * java.util.Stack} of parent {@link IndexDirectoryOnDisk} indices. File content calculation happens on {@link
+   * ImmutableStack} of parent {@link IndexDirectoryOnDisk} indices. File content calculation happens on {@link
    * DirectoryOnDisk#write}.
    *
    * @param writableFunction A function that can output a new writable.

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/structure/directory/IndexDirectoryOnDisk.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/structure/directory/IndexDirectoryOnDisk.java
@@ -27,7 +27,6 @@ import app.coronawarn.server.services.distribution.assembly.structure.util.funct
 import app.coronawarn.server.services.distribution.assembly.structure.util.functional.WritableFunction;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.Stack;
 
 /**
  * An {@link IndexDirectory} that can be written to disk.
@@ -47,7 +46,7 @@ public class IndexDirectoryOnDisk<T> extends DirectoryOnDisk implements IndexDir
    *
    * @param name           The name that this directory should have on disk.
    * @param indexFunction  An {@link IndexFunction} that calculates the index of this {@link IndexDirectoryOnDisk} from
-   *                       a {@link java.util.Stack} of parent {@link IndexDirectoryOnDisk} indices. The top element of
+   *                       a {@link ImmutableStack} of parent {@link IndexDirectoryOnDisk} indices. The top element of
    *                       the stack is from the closest {@link IndexDirectoryOnDisk} in the parent chain.
    * @param indexFormatter A {@link Formatter} used to format the directory name for each index element returned by the
    *                       {@link IndexDirectoryOnDisk#indexFunction}.
@@ -78,7 +77,7 @@ public class IndexDirectoryOnDisk<T> extends DirectoryOnDisk implements IndexDir
    * {@link IndexDirectory#addWritableToAll writables} to those. The respective element of the index will be pushed
    * onto the Stack for subsequent {@link Writable#prepare} calls.
    *
-   * @param indices A {@link Stack} of parameters from all {@link IndexDirectory IndexDirectories} further up in the
+   * @param indices A {@link ImmutableStack} of parameters from all {@link IndexDirectory IndexDirectories} further up in the
    *                hierarchy. The Stack may contain different types, depending on the types {@code T} of
    *                {@link IndexDirectory IndexDirectories} further up in the hierarchy.
    */

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/structure/directory/IndexDirectoryOnDisk.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/structure/directory/IndexDirectoryOnDisk.java
@@ -77,9 +77,9 @@ public class IndexDirectoryOnDisk<T> extends DirectoryOnDisk implements IndexDir
    * {@link IndexDirectory#addWritableToAll writables} to those. The respective element of the index will be pushed
    * onto the Stack for subsequent {@link Writable#prepare} calls.
    *
-   * @param indices A {@link ImmutableStack} of parameters from all {@link IndexDirectory IndexDirectories} further up in the
-   *                hierarchy. The Stack may contain different types, depending on the types {@code T} of
-   *                {@link IndexDirectory IndexDirectories} further up in the hierarchy.
+   * @param indices A {@link ImmutableStack} of parameters from all {@link IndexDirectory IndexDirectories} further up
+   *                in the hierarchy. The Stack may contain different types, depending on the types {@code T} of {@link
+   *                IndexDirectory IndexDirectories} further up in the hierarchy.
    */
   @Override
   public void prepare(ImmutableStack<Object> indices) {

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/structure/util/ImmutableStack.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/structure/util/ImmutableStack.java
@@ -19,21 +19,22 @@
 
 package app.coronawarn.server.services.distribution.assembly.structure.util;
 
-import java.util.Stack;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 public class ImmutableStack<T> {
 
-  private final Stack<T> stack;
+  private final Deque<T> stack;
 
   public ImmutableStack() {
-    this.stack = new Stack<>();
+    this.stack = new ArrayDeque<>();
   }
 
   /**
    * Creates a clone of the specified {@link ImmutableStack}.
    */
   public ImmutableStack(ImmutableStack<T> other) {
-    this.stack = (Stack<T>) other.stack.clone();
+    this.stack = new ArrayDeque<>(other.stack);
   }
 
   /**

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/structure/util/ImmutableStackTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/structure/util/ImmutableStackTest.java
@@ -1,0 +1,50 @@
+package app.coronawarn.server.services.distribution.assembly.structure.util;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class ImmutableStackTest {
+
+  private final ImmutableStack<String> stack =
+      new ImmutableStack<String>().push("Joker").push("Queen").push("King");
+
+  @Test
+  void checkPushes() {
+    var newStack = stack.push("Ace");
+
+    assertThat(newStack).isNotSameAs(stack);
+    assertThat(newStack.peek()).isEqualTo("Ace");
+    assertThat(stack.peek()).isEqualTo("King");
+  }
+
+  @Test
+  void checkPops() {
+    var newStack = stack.pop();
+
+    assertThat(newStack).isNotSameAs(stack);
+    assertThat(newStack.peek()).isEqualTo("Queen");
+    assertThat(stack.peek()).isEqualTo("King");
+  }
+
+  @Test
+  void checkPeeks() {
+    assertThat(stack.peek()).isEqualTo("King");
+  }
+
+  @Test
+  void checksEmptyStackHasNoting() {
+    assertThat(new ImmutableStack<>().peek()).isNull();
+  }
+
+  @Test
+  void throwsExceptionWhenPopsFromEmptyStack() {
+    assertThatExceptionOfType(NoSuchElementException.class)
+        .isThrownBy(() -> new ImmutableStack<>().pop());
+  }
+}

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/structure/util/ImmutableStackTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/structure/util/ImmutableStackTest.java
@@ -1,3 +1,22 @@
+/*
+ * Corona-Warn-App
+ *
+ * SAP SE and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package app.coronawarn.server.services.distribution.assembly.structure.util;
 
 import org.assertj.core.api.Assertions;


### PR DESCRIPTION
`java.util.Stack` is a nonstandard class that predates the Java Collections Framework. `ArrayDeque` provides the same functionality, but it's not synchronized in contrast to `java.util.Stack`.

Fixes #271