### PR TITLE
add license-plugin configuration for file headers

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,4 @@
 -Drevision=0.5.2-SNAPSHOT
+-Dlicense.projectName=Corona-Warn-App
+-Dlicense.inceptionYear=2020
+-Dlicense.licenseName=apache_v2

--- a/common/persistence/pom.xml
+++ b/common/persistence/pom.xml
@@ -14,6 +14,10 @@
   <artifactId>persistence</artifactId>
   <version>${revision}</version>
 
+  <organization>
+    <name>SAP SE</name>
+  </organization>
+
   <properties>
     <java.version>11</java.version>
     <maven.compiler.source>11</maven.compiler.source>
@@ -105,6 +109,19 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>2.0.0</version>
+        <configuration>
+          <includes>**/*.java</includes>
+          <copyrightOwners>${organization.name} and all other contributors</copyrightOwners>
+          <processStartTag>---license-start</processStartTag>
+          <processEndTag>---license-end</processEndTag>
+          <sectionDelimiter>---</sectionDelimiter>
+          <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
+        </configuration>
+      </plugin>
       <plugin>
         <!-- see https://maven.apache.org/maven-ci-friendly.html#install-deploy -->
         <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,13 @@
   <groupId>org.opencwa</groupId>
   <artifactId>server</artifactId>
   <version>${revision}</version>
+
   <name>server</name>
   <description>CWA Server</description>
+  <organization>
+    <name>SAP SE</name>
+  </organization>
+
   <url>https://www.coronawarn.app/</url>
   <ciManagement>
     <url>https://app.circleci.com/pipelines/github/corona-warn-app/cwa-server</url>
@@ -37,6 +42,19 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>2.0.0</version>
+        <configuration>
+          <includes>**/*.java</includes>
+          <copyrightOwners>${organization.name} and all other contributors</copyrightOwners>
+          <processStartTag>---license-start</processStartTag>
+          <processEndTag>---license-end</processEndTag>
+          <sectionDelimiter>---</sectionDelimiter>
+          <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
+        </configuration>
+      </plugin>
       <plugin>
         <!-- see https://maven.apache.org/maven-ci-friendly.html#install-deploy -->
         <groupId>org.codehaus.mojo</groupId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -16,6 +16,10 @@
   <groupId>org.opencwa</groupId>
   <version>${revision}</version>
 
+  <organization>
+    <name>SAP SE</name>
+  </organization>
+
   <packaging>pom</packaging>
   <modules>
     <module>distribution</module>
@@ -89,6 +93,19 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>2.0.0</version>
+        <configuration>
+          <includes>**/*.java</includes>
+          <copyrightOwners>${organization.name} and all other contributors</copyrightOwners>
+          <processStartTag>---license-start</processStartTag>
+          <processEndTag>---license-end</processEndTag>
+          <sectionDelimiter>---</sectionDelimiter>
+          <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
+        </configuration>
+      </plugin>
       <plugin>
         <!-- see https://maven.apache.org/maven-ci-friendly.html#install-deploy -->
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
related to #354 

## Description

This change adds configuration for the [license-maven-plugin](https://www.mojohaus.org/license-maven-plugin/) to generate the following file header:

```java
/*-
 * ---license-start
 * Corona-Warn-App
 * ---
 * Copyright (C) 2020 SAP SE and all other contributors
 * ---
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 * 
 *      http://www.apache.org/licenses/LICENSE-2.0
 * 
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 * ---license-end
 */
```

## Usage

Run `mvn license:remove-file-header` to remove *old* license headers and `mvn license:update-file-header` to generate headers everywhere (`**/*.java`) it is missing (currently ~130 as old header is not recognized).
