### PR TITLE
Decouple ObjectStoreAccess from specific client

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
@@ -20,16 +20,9 @@
 package app.coronawarn.server.services.distribution.objectstore;
 
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
+import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreClient;
+import app.coronawarn.server.services.distribution.objectstore.client.S3Object;
 import app.coronawarn.server.services.distribution.objectstore.publish.LocalFile;
-import io.minio.MinioClient;
-import io.minio.PutObjectOptions;
-import io.minio.Result;
-import io.minio.errors.MinioException;
-import io.minio.messages.DeleteError;
-import io.minio.messages.Item;
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,21 +59,17 @@ public class ObjectStoreAccess {
 
   private final String bucket;
 
-  private final MinioClient client;
+  private final ObjectStoreClient client;
 
   /**
    * Constructs an {@link ObjectStoreAccess} instance for communication with the specified object store endpoint and
    * bucket.
    *
    * @param distributionServiceConfig The config properties
-   * @param minioClient               The client used for interaction with the object store
-   * @throws IOException              When there were problems creating the S3 client
-   * @throws GeneralSecurityException When there were problems creating the S3 client
-   * @throws MinioException           When there were problems creating the S3 client
+   * @param objectStoreClient         The client used for interaction with the object store
    */
-  ObjectStoreAccess(DistributionServiceConfig distributionServiceConfig, MinioClient minioClient)
-      throws IOException, GeneralSecurityException, MinioException {
-    this.client = minioClient;
+  ObjectStoreAccess(DistributionServiceConfig distributionServiceConfig, ObjectStoreClient objectStoreClient) {
+    this.client = objectStoreClient;
     this.bucket = distributionServiceConfig.getObjectStore().getBucket();
     this.isSetPublicReadAclOnPutObject = distributionServiceConfig.getObjectStore().isSetPublicReadAclOnPutObject();
 
@@ -94,7 +83,7 @@ public class ObjectStoreAccess {
    *
    * @param localFile The file to be published.
    */
-  public void putObject(LocalFile localFile) throws IOException, GeneralSecurityException, MinioException {
+  public void putObject(LocalFile localFile) {
     putObject(localFile, DEFAULT_MAX_CACHE_AGE);
   }
 
@@ -105,12 +94,12 @@ public class ObjectStoreAccess {
    * @param maxAge    A cache control parameter that specifies the maximum amount of time in seconds that a resource can
    *                  be considered "fresh" when held in a cache.
    */
-  public void putObject(LocalFile localFile, int maxAge) throws IOException, GeneralSecurityException, MinioException {
+  public void putObject(LocalFile localFile, int maxAge) {
     String s3Key = localFile.getS3Key();
-    PutObjectOptions options = createOptionsFor(localFile, maxAge);
+    Map<String, String> headers = createHeaders(maxAge);
 
     logger.info("... uploading {}", s3Key);
-    this.client.putObject(bucket, s3Key, localFile.getFile().toString(), options);
+    this.client.putObject(bucket, s3Key, localFile.getFile(), headers);
   }
 
   /**
@@ -118,24 +107,14 @@ public class ObjectStoreAccess {
    *
    * @param prefix the prefix, e.g. my/folder/
    */
-  public void deleteObjectsWithPrefix(String prefix)
-      throws MinioException, GeneralSecurityException, IOException {
+  public void deleteObjectsWithPrefix(String prefix) {
     List<String> toDelete = getObjectsWithPrefix(prefix)
         .stream()
         .map(S3Object::getObjectName)
         .collect(Collectors.toList());
 
     logger.info("Deleting {} entries with prefix {}", toDelete.size(), prefix);
-    var deletionResponse = this.client.removeObjects(bucket, toDelete);
-
-    List<DeleteError> errors = new ArrayList<>();
-    for (Result<DeleteError> deleteErrorResult : deletionResponse) {
-      errors.add(deleteErrorResult.get());
-    }
-
-    if (!errors.isEmpty()) {
-      throw new MinioException("Can't delete files, number of errors: " + errors.size());
-    }
+    this.client.removeObjects(bucket, toDelete);
   }
 
   /**
@@ -144,28 +123,15 @@ public class ObjectStoreAccess {
    * @param prefix the prefix, e.g. my/folder/
    * @return the list of objects
    */
-  public List<S3Object> getObjectsWithPrefix(String prefix)
-      throws IOException, GeneralSecurityException, MinioException {
-    var objects = this.client.listObjects(bucket, prefix, true);
-
-    var list = new ArrayList<S3Object>();
-    for (Result<Item> item : objects) {
-      list.add(S3Object.of(item.get()));
-    }
-
-    return list;
+  public List<S3Object> getObjectsWithPrefix(String prefix) {
+    return client.getObjects(bucket, prefix);
   }
 
-  private PutObjectOptions createOptionsFor(LocalFile file, int maxAge) {
-    var options = new PutObjectOptions(file.getFile().toFile().length(), -1);
-
+  private Map<String, String> createHeaders(int maxAge) {
     Map<String, String> headers = new HashMap<>(Map.of("cache-control", "public,max-age=" + maxAge));
     if (this.isSetPublicReadAclOnPutObject) {
       headers.put("x-amz-acl", "public-read");
     }
-    options.setHeaders(headers);
-
-    return options;
+    return headers;
   }
-
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/S3Publisher.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/S3Publisher.java
@@ -23,10 +23,8 @@ import app.coronawarn.server.services.distribution.assembly.component.CwaApiStru
 import app.coronawarn.server.services.distribution.objectstore.publish.LocalFile;
 import app.coronawarn.server.services.distribution.objectstore.publish.PublishFileSet;
 import app.coronawarn.server.services.distribution.objectstore.publish.PublishedFileSet;
-import io.minio.errors.MinioException;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.GeneralSecurityException;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +66,7 @@ public class S3Publisher {
    *
    * @throws IOException in case there were problems reading files from the disk.
    */
-  public void publish() throws IOException, GeneralSecurityException, MinioException {
+  public void publish() throws IOException {
     var published = new PublishedFileSet(access.getObjectsWithPrefix(CWA_S3_ROOT));
     var toPublish = new PublishFileSet(root);
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/S3RetentionPolicy.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/S3RetentionPolicy.java
@@ -21,10 +21,7 @@ package app.coronawarn.server.services.distribution.objectstore;
 
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig.Api;
-import io.minio.errors.MinioException;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.security.GeneralSecurityException;
+import app.coronawarn.server.services.distribution.objectstore.client.S3Object;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -54,7 +51,7 @@ public class S3RetentionPolicy {
    *
    * @param retentionDays the number of days, that files should be retained on S3.
    */
-  public void applyRetentionPolicy(int retentionDays) throws MinioException, GeneralSecurityException, IOException {
+  public void applyRetentionPolicy(int retentionDays) {
     List<S3Object> diagnosisKeysObjects = objectStoreAccess.getObjectsWithPrefix("version/v1/"
         + api.getDiagnosisKeysPath() + "/"
         + api.getCountryPath() + "/"
@@ -81,10 +78,6 @@ public class S3RetentionPolicy {
    * @param diagnosisKey the  diagnosis key, that should be deleted.
    */
   public void deleteDiagnosisKey(S3Object diagnosisKey) {
-    try {
-      objectStoreAccess.deleteObjectsWithPrefix(diagnosisKey.getObjectName());
-    } catch (Exception e) {
-      throw new UncheckedIOException(new IOException(e));
-    }
+    objectStoreAccess.deleteObjectsWithPrefix(diagnosisKey.getObjectName());
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/MinioClientWrapper.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/MinioClientWrapper.java
@@ -1,0 +1,96 @@
+/*
+ * Corona-Warn-App
+ *
+ * SAP SE and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package app.coronawarn.server.services.distribution.objectstore.client;
+
+import io.minio.MinioClient;
+import io.minio.PutObjectOptions;
+import io.minio.Result;
+import io.minio.errors.ErrorResponseException;
+import io.minio.errors.InsufficientDataException;
+import io.minio.errors.InternalException;
+import io.minio.errors.InvalidBucketNameException;
+import io.minio.errors.InvalidResponseException;
+import io.minio.errors.XmlParserException;
+import io.minio.messages.Item;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of {@link ObjectStoreClient} that encapsulates a {@link MinioClient}.
+ */
+public class MinioClientWrapper implements ObjectStoreClient {
+
+  private final MinioClient minioClient;
+
+  public MinioClientWrapper(MinioClient minioClient) {
+    this.minioClient = minioClient;
+  }
+
+  @Override
+  public List<S3Object> getObjects(String bucket, String prefix) {
+    var objects = this.minioClient.listObjects(bucket, prefix, true);
+
+    var list = new ArrayList<S3Object>();
+    for (Result<Item> item : objects) {
+      try {
+        list.add(S3Object.of(item.get()));
+      } catch (ErrorResponseException | NoSuchAlgorithmException | InternalException | IOException | InvalidKeyException
+          | InvalidResponseException | InvalidBucketNameException | InsufficientDataException | XmlParserException e) {
+        throw new ObjectStoreOperationFailedException("Failed to download objects from object store.", e);
+      }
+    }
+    return list;
+  }
+
+  @Override
+  public void putObject(String bucket, String objectName, Path filePath, Map<String, String> headers) {
+    try {
+      var options = new PutObjectOptions(Files.size(filePath), -1);
+      options.setHeaders(headers);
+      minioClient.putObject(bucket, objectName, filePath.toString(), options);
+    } catch (ErrorResponseException | NoSuchAlgorithmException | InternalException | IOException | InvalidKeyException
+        | InvalidResponseException | InvalidBucketNameException | InsufficientDataException | XmlParserException e) {
+      throw new ObjectStoreOperationFailedException("Failed to upload object to object store.", e);
+    }
+  }
+
+  @Override
+  public void removeObjects(String bucket, List<String> objectNames) {
+    if (minioClient.removeObjects(bucket, objectNames).iterator().hasNext()) {
+      throw new ObjectStoreOperationFailedException("Failed to remove objects from object store");
+    }
+  }
+
+  @Override
+  public boolean bucketExists(String bucket) {
+    try {
+      return minioClient.bucketExists(bucket);
+    } catch (ErrorResponseException | NoSuchAlgorithmException | InternalException | IOException | InvalidKeyException
+        | InvalidResponseException | InvalidBucketNameException | InsufficientDataException | XmlParserException e) {
+      throw new ObjectStoreOperationFailedException("Failed to check if object store bucket exists.", e);
+    }
+  }
+}

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClient.java
@@ -1,0 +1,70 @@
+/*
+ * Corona-Warn-App
+ *
+ * SAP SE and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package app.coronawarn.server.services.distribution.objectstore.client;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple Storage Service (aka S3) client to perform bucket and object operations.
+ */
+public interface ObjectStoreClient {
+
+  /**
+   * Downloads the all objects that match the specified prefix from the specified object store bucket.
+   *
+   * @param bucket The name of the object store bucket.
+   * @param prefix The prefix that the names of the returned objects start with.
+   * @return A list of objects from the object store that match the specified parameters.
+   * @throws ObjectStoreOperationFailedException if the operation could not be performed.
+   */
+  List<S3Object> getObjects(String bucket, String prefix) throws ObjectStoreOperationFailedException;
+
+  /**
+   * Uploads data from the specified file to an object with the specified name.
+   *
+   * @param bucket     The name of the object store bucket.
+   * @param objectName The name of the target object.
+   * @param filePath   The path associated with the file to upload.
+   * @param headers    The headers to be used during upload.
+   * @throws ObjectStoreOperationFailedException if the operation could not be performed.
+   */
+  void putObject(String bucket, String objectName, Path filePath, Map<String, String> headers)
+      throws ObjectStoreOperationFailedException;
+
+  /**
+   * Removes all the specified objects from the specified object store bucket.
+   *
+   * @param bucket      The name of the object store bucket.
+   * @param objectNames The names of objects to delete.
+   * @throws ObjectStoreOperationFailedException if the operation could not be performed.
+   */
+  void removeObjects(String bucket, List<String> objectNames) throws ObjectStoreOperationFailedException;
+
+  /**
+   * Checks if an object store bucket with the specified name exists.
+   *
+   * @param bucket The name of the object store bucket.
+   * @return True if the bucket exists.
+   * @throws ObjectStoreOperationFailedException if the operation could not be performed.
+   */
+  boolean bucketExists(String bucket) throws ObjectStoreOperationFailedException;
+}

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClientConfig.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClientConfig.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package app.coronawarn.server.services.distribution.objectstore;
+package app.coronawarn.server.services.distribution.objectstore.client;
 
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig.ObjectStore;
@@ -36,27 +36,25 @@ public class ObjectStoreClientConfig {
   private static final String DEFAULT_REGION = "eu-west-1";
 
   @Bean
-  public MinioClient createMinioClient(DistributionServiceConfig distributionServiceConfig)
+  public ObjectStoreClient createObjectStoreClient(DistributionServiceConfig distributionServiceConfig)
       throws InvalidPortException, InvalidEndpointException {
     return createClient(distributionServiceConfig.getObjectStore());
   }
 
-  private MinioClient createClient(ObjectStore objectStore)
+  private MinioClientWrapper createClient(ObjectStore objectStore)
       throws InvalidPortException, InvalidEndpointException {
     if (isSsl(objectStore)) {
-      return new MinioClient(
+      return new MinioClientWrapper(new MinioClient(
           objectStore.getEndpoint(),
           objectStore.getPort(),
           objectStore.getAccessKey(), objectStore.getSecretKey(),
           DEFAULT_REGION,
-          true
-      );
+          true));
     } else {
-      return new MinioClient(
+      return new MinioClientWrapper(new MinioClient(
           objectStore.getEndpoint(),
           objectStore.getPort(),
-          objectStore.getAccessKey(), objectStore.getSecretKey()
-      );
+          objectStore.getAccessKey(), objectStore.getSecretKey()));
     }
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreOperationFailedException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreOperationFailedException.java
@@ -1,0 +1,46 @@
+/*
+ * Corona-Warn-App
+ *
+ * SAP SE and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package app.coronawarn.server.services.distribution.objectstore.client;
+
+/**
+ * {@link ObjectStoreOperationFailedException} indicates that a object store operation could not be performed.
+ */
+public class ObjectStoreOperationFailedException extends RuntimeException {
+
+  /**
+   * Constructs a new {@link ObjectStoreOperationFailedException} with the specified message.
+   *
+   * @param message The detail message.
+   */
+  public ObjectStoreOperationFailedException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new {@link ObjectStoreOperationFailedException} with the specified message and the {@link Throwable}
+   * that cause the object store operation to fail.
+   *
+   * @param message The detail message.
+   * @param cause   The cause.
+   */
+  public ObjectStoreOperationFailedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3Object.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3Object.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package app.coronawarn.server.services.distribution.objectstore;
+package app.coronawarn.server.services.distribution.objectstore.client;
 
 import io.minio.messages.Item;
 import java.util.HashMap;
@@ -56,17 +56,13 @@ public class S3Object {
    * @param objectName the target object name
    * @param etag the e-etag
    */
-  protected S3Object(String objectName, String etag) {
+  public S3Object(String objectName, String etag) {
     this(objectName);
     this.etag = etag;
   }
 
   public String getObjectName() {
     return objectName;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
   }
 
   public String getEtag() {
@@ -80,14 +76,7 @@ public class S3Object {
    * @return the S3Object representation
    */
   public static S3Object of(Item item) {
-    S3Object s3Object = new S3Object(item.objectName());
-
-    if (item.userMetadata() != null) {
-      s3Object.metadata = item.userMetadata();
-    }
-
-    s3Object.etag = item.etag().replaceAll("\"", "");
-
-    return s3Object;
+    String etag = item.etag().replaceAll("\"", "");
+    return new S3Object(item.objectName(), etag);
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/publish/PublishedFileSet.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/publish/PublishedFileSet.java
@@ -19,7 +19,7 @@
 
 package app.coronawarn.server.services.distribution.objectstore.publish;
 
-import app.coronawarn.server.services.distribution.objectstore.S3Object;
+import app.coronawarn.server.services.distribution.objectstore.client.S3Object;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/S3Distribution.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/S3Distribution.java
@@ -22,10 +22,9 @@ package app.coronawarn.server.services.distribution.runner;
 import app.coronawarn.server.services.distribution.assembly.component.OutputDirectoryProvider;
 import app.coronawarn.server.services.distribution.objectstore.ObjectStoreAccess;
 import app.coronawarn.server.services.distribution.objectstore.S3Publisher;
-import io.minio.errors.MinioException;
+import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreOperationFailedException;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.GeneralSecurityException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
@@ -59,7 +58,7 @@ public class S3Distribution implements ApplicationRunner {
 
       s3Publisher.publish();
       logger.info("Data pushed to CDN successfully.");
-    } catch (UnsupportedOperationException | GeneralSecurityException | MinioException | IOException e) {
+    } catch (UnsupportedOperationException | ObjectStoreOperationFailedException | IOException e) {
       logger.error("Distribution failed.", e);
     }
   }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccessTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccessTest.java
@@ -26,10 +26,8 @@ import static org.mockito.Mockito.when;
 import app.coronawarn.server.services.distribution.Application;
 import app.coronawarn.server.services.distribution.objectstore.publish.LocalFile;
 import app.coronawarn.server.services.distribution.objectstore.publish.LocalGenericFile;
-import io.minio.errors.MinioException;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.GeneralSecurityException;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,33 +59,31 @@ class ObjectStoreAccessTest {
   private ResourceLoader resourceLoader;
 
   @BeforeEach
-  public void setup()
-      throws MinioException, GeneralSecurityException, IOException {
+  public void setup() {
     objectStoreAccess.deleteObjectsWithPrefix(testRunId);
   }
 
   @AfterEach
-  public void teardown() throws IOException, GeneralSecurityException, MinioException {
+  public void teardown() {
     objectStoreAccess.deleteObjectsWithPrefix(testRunId);
   }
 
   @Test
-  void defaultIsEmptyTrue() throws MinioException, GeneralSecurityException, IOException {
+  void defaultIsEmptyTrue() {
     var files = objectStoreAccess.getObjectsWithPrefix(testRunId);
 
     assertThat(files).withFailMessage("Content should be empty").isEmpty();
   }
 
   @Test
-  void fetchFilesNothingFound()
-      throws MinioException, GeneralSecurityException, IOException {
+  void fetchFilesNothingFound() {
     var files = objectStoreAccess.getObjectsWithPrefix("THIS_PREFIX_DOES_NOT_EXIST");
 
     assertThat(files).withFailMessage("Found files, but should be empty!").isEmpty();
   }
 
   @Test
-  void pushTestFileAndDelete() throws IOException, GeneralSecurityException, MinioException {
+  void pushTestFileAndDelete() throws IOException {
     LocalFile localFile = new LocalGenericFile(getExampleFile(), getRootTestFolder());
     String testFileTargetKey = testRunId + localFile.getS3Key();
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccessUnitTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccessUnitTest.java
@@ -28,11 +28,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
+import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreClient;
 import app.coronawarn.server.services.distribution.objectstore.publish.LocalFile;
-import io.minio.MinioClient;
-import io.minio.PutObjectOptions;
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,19 +47,19 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @EnableConfigurationProperties(value = DistributionServiceConfig.class)
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {MinioClient.class}, initializers = ConfigFileApplicationContextInitializer.class)
+@ContextConfiguration(classes = {ObjectStoreClient.class}, initializers = ConfigFileApplicationContextInitializer.class)
 class ObjectStoreAccessUnitTest {
 
   private static final String EXP_S3_KEY = "fooS3Key";
-  private static final String EXP_FILE_CONTENT = "barFileContent";
 
   private final DistributionServiceConfig distributionServiceConfig;
   private final String expBucketName;
   private LocalFile testLocalFile;
   private ObjectStoreAccess objectStoreAccess;
+  private Path expPath;
 
   @MockBean
-  private MinioClient minioClient;
+  private ObjectStoreClient objectStoreClient;
 
   @Autowired
   public ObjectStoreAccessUnitTest(DistributionServiceConfig distributionServiceConfig) {
@@ -68,46 +68,45 @@ class ObjectStoreAccessUnitTest {
   }
 
   @BeforeEach
-  public void setUpMocks() throws Exception {
-    when(minioClient.bucketExists(any())).thenReturn(true);
-    this.objectStoreAccess = new ObjectStoreAccess(distributionServiceConfig, minioClient);
+  public void setUpMocks() {
+    when(objectStoreClient.bucketExists(any())).thenReturn(true);
+    this.objectStoreAccess = new ObjectStoreAccess(distributionServiceConfig, objectStoreClient);
     this.testLocalFile = setUpLocalFileMock();
   }
 
   private LocalFile setUpLocalFileMock() {
     var testLocalFile = mock(LocalFile.class);
-    var testPath = mock(Path.class);
+    expPath = mock(Path.class);
 
     when(testLocalFile.getS3Key()).thenReturn(EXP_S3_KEY);
-    when(testLocalFile.getFile()).thenReturn(testPath);
-    when(testPath.toFile()).thenReturn(mock(File.class));
-    when(testPath.toString()).thenReturn(EXP_FILE_CONTENT);
+    when(testLocalFile.getFile()).thenReturn(expPath);
+    when(expPath.toFile()).thenReturn(mock(File.class));
 
     return testLocalFile;
   }
 
   @Test
-  void testPutObjectSetsDefaultCacheControlHeader() throws Exception {
-    ArgumentCaptor<PutObjectOptions> options = ArgumentCaptor.forClass(PutObjectOptions.class);
+  void testPutObjectSetsDefaultCacheControlHeader() {
+    ArgumentCaptor<Map<String, String>> headers = ArgumentCaptor.forClass(Map.class);
     var expHeader = entry("cache-control", "public,max-age=" + ObjectStoreAccess.DEFAULT_MAX_CACHE_AGE);
 
     objectStoreAccess.putObject(testLocalFile);
 
-    verify(minioClient, atLeastOnce())
-        .putObject(eq(expBucketName), eq(EXP_S3_KEY), eq(EXP_FILE_CONTENT), options.capture());
-    Assertions.assertThat(options.getValue().headers()).contains(expHeader);
+    verify(objectStoreClient, atLeastOnce())
+        .putObject(eq(expBucketName), eq(EXP_S3_KEY), eq(expPath), headers.capture());
+    Assertions.assertThat(headers.getValue()).contains(expHeader);
   }
 
   @Test
-  void testPutObjectSetsSpecifiedCacheControlHeader() throws Exception {
-    ArgumentCaptor<PutObjectOptions> options = ArgumentCaptor.forClass(PutObjectOptions.class);
+  void testPutObjectSetsSpecifiedCacheControlHeader() {
+    ArgumentCaptor<Map<String, String>> headers = ArgumentCaptor.forClass(Map.class);
     var expMaxAge = 1337;
     var expHeader = entry("cache-control", "public,max-age=" + expMaxAge);
 
     objectStoreAccess.putObject(testLocalFile, expMaxAge);
 
-    verify(minioClient, atLeastOnce())
-        .putObject(eq(expBucketName), eq(EXP_S3_KEY), eq(EXP_FILE_CONTENT), options.capture());
-    Assertions.assertThat(options.getValue().headers()).contains(expHeader);
+    verify(objectStoreClient, atLeastOnce())
+        .putObject(eq(expBucketName), eq(EXP_S3_KEY), eq(expPath), headers.capture());
+    Assertions.assertThat(headers.getValue()).contains(expHeader);
   }
 }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/S3PublisherIntegrationTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/S3PublisherIntegrationTest.java
@@ -22,10 +22,10 @@ package app.coronawarn.server.services.distribution.objectstore;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
-import io.minio.errors.MinioException;
+import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreClientConfig;
+import app.coronawarn.server.services.distribution.objectstore.client.S3Object;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.GeneralSecurityException;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,7 +55,7 @@ class S3PublisherIntegrationTest {
   private ResourceLoader resourceLoader;
 
   @Test
-  void publishTestFolderOk() throws IOException, GeneralSecurityException, MinioException {
+  void publishTestFolderOk() throws IOException {
     S3Publisher publisher = new S3Publisher(getFolderAsPath(rootTestFolder), objectStoreAccess);
 
     publisher.publish();
@@ -69,12 +69,12 @@ class S3PublisherIntegrationTest {
   }
 
   @BeforeEach
-  public void setup() throws MinioException, GeneralSecurityException, IOException {
+  public void setup() {
     objectStoreAccess.deleteObjectsWithPrefix("");
   }
 
   @AfterEach
-  public void teardown() throws IOException, GeneralSecurityException, MinioException {
+  public void teardown() {
     objectStoreAccess.deleteObjectsWithPrefix("");
   }
 }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/S3PublisherTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/S3PublisherTest.java
@@ -24,9 +24,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.minio.errors.MinioException;
+import app.coronawarn.server.services.distribution.objectstore.client.S3Object;
 import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,7 +49,7 @@ class S3PublisherTest {
   private ResourceLoader resourceLoader;
 
   @Test
-  void allNewNoExisting() throws IOException, GeneralSecurityException, MinioException {
+  void allNewNoExisting() throws IOException {
     when(objectStoreAccess.getObjectsWithPrefix("version")).thenReturn(noneExisting());
 
     createTestPublisher().publish();
@@ -59,7 +58,7 @@ class S3PublisherTest {
   }
 
   @Test
-  void noUploadsDueToAlreadyExist() throws IOException, GeneralSecurityException, MinioException {
+  void noUploadsDueToAlreadyExist() throws IOException {
     when(objectStoreAccess.getObjectsWithPrefix("version")).thenReturn(allExistAllSame());
 
     createTestPublisher().publish();
@@ -68,7 +67,7 @@ class S3PublisherTest {
   }
 
   @Test
-  void uploadAllOtherFilesDifferentNames() throws IOException, GeneralSecurityException, MinioException {
+  void uploadAllOtherFilesDifferentNames() throws IOException {
     when(objectStoreAccess.getObjectsWithPrefix("version")).thenReturn(otherExisting());
 
     createTestPublisher().publish();
@@ -77,7 +76,7 @@ class S3PublisherTest {
   }
 
   @Test
-  void uploadOneDueToOneChanged() throws IOException, GeneralSecurityException, MinioException {
+  void uploadOneDueToOneChanged() throws IOException {
     when(objectStoreAccess.getObjectsWithPrefix("version")).thenReturn(twoIdenticalOneOtherOneChange());
 
     createTestPublisher().publish();

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/S3RetentionPolicyTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/S3RetentionPolicyTest.java
@@ -28,9 +28,7 @@ import static org.mockito.Mockito.when;
 
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig.ObjectStore;
-import io.minio.errors.MinioException;
-import java.io.IOException;
-import java.security.GeneralSecurityException;
+import app.coronawarn.server.services.distribution.objectstore.client.S3Object;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -57,7 +55,7 @@ class S3RetentionPolicyTest {
   @Autowired DistributionServiceConfig distributionServiceConfig;
 
   @Test
-  void shouldDeleteOldFiles() throws IOException, GeneralSecurityException, MinioException {
+  void shouldDeleteOldFiles() {
     String expectedFileToBeDeleted = generateFileName(LocalDate.now().minusDays(2));
 
     when(objectStoreAccess.getObjectsWithPrefix(any())).thenReturn(List.of(
@@ -71,7 +69,7 @@ class S3RetentionPolicyTest {
   }
 
   @Test
-  void shouldNotDeleteFilesIfAllAreValid() throws IOException, GeneralSecurityException, MinioException {
+  void shouldNotDeleteFilesIfAllAreValid() {
     when(objectStoreAccess.getObjectsWithPrefix(any())).thenReturn(List.of(
         new S3Object(generateFileName(LocalDate.now().minusDays(1))),
         new S3Object(generateFileName(LocalDate.now().plusDays(1))),


### PR DESCRIPTION
In preparation of #363 this PR 

- Applies adapter pattern in order to decouple the S3 distribution code from any specific object store client implementations.
- Simplifies exception handling by introducing ``ObjectStoreOperationFailedException`` that replaces a number of checked minIO client specific exceptions.
- Removes unused method ``S3Object.getMetadata``.
- Creates ``[...].objectstore.client``package.

Additional tests will be included in the PR for #363 that replaces ``MinioClientWrapper`` with ``S3ClientWrapper``.