### PR TITLE
Set maximum total risk score to 255

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ParameterSpec.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ParameterSpec.java
@@ -52,4 +52,9 @@ public class ParameterSpec {
    * The allowed maximum value for a risk score.
    */
   public static final int RISK_SCORE_MAX = 4096;
+
+  /**
+   * The allowed maximum value for the total risk score.
+   */
+  public static final int TOTAL_RISK_SCORE_MAX = 255;
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidator.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidator.java
@@ -81,7 +81,7 @@ public class RiskScoreClassificationValidator extends ConfigurationValidator {
   }
 
   private void validateRiskScoreValueBounds(int value) {
-    if (!RiskScoreValidator.isInBounds(value)) {
+    if (value < 0 || value > ParameterSpec.TOTAL_RISK_SCORE_MAX) {
       errors.add(new RiskScoreClassificationValidationError("minRiskLevel/maxRiskLevel", value, VALUE_OUT_OF_BOUNDS));
     }
   }
@@ -99,7 +99,7 @@ public class RiskScoreClassificationValidator extends ConfigurationValidator {
         .mapToInt(riskScoreClass -> (riskScoreClass.getMax() - riskScoreClass.getMin() + 1))
         .sum();
 
-    if (partitionSum != ParameterSpec.RISK_SCORE_MAX + 1) {
+    if (partitionSum != ParameterSpec.TOTAL_RISK_SCORE_MAX + 1) {
       errors.add(new RiskScoreClassificationValidationError("covered value range", partitionSum, INVALID_PARTITIONING));
     }
   }

--- a/services/distribution/src/main/resources/master-config/risk-score-classification.yaml
+++ b/services/distribution/src/main/resources/master-config/risk-score-classification.yaml
@@ -12,10 +12,10 @@ risk-classes:
   -
     label: LOW
     min: 0
-    max: 2749
+    max: 150
     url: "https://www.coronawarn.app"
   -
     label: HIGH
-    min: 2750
-    max: 4096
+    min: 151
+    max: 255
     url: "https://www.coronawarn.app"

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidatorTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/RiskScoreClassificationValidatorTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class RiskScoreClassificationValidatorTest {
 
-  private final static int MAX_SCORE = ParameterSpec.RISK_SCORE_MAX;
+  private final static int MAX_SCORE = ParameterSpec.TOTAL_RISK_SCORE_MAX;
   private final static String VALID_LABEL = "myLabel";
   private final static String VALID_URL = "https://www.my.url";
 

--- a/services/distribution/src/test/resources/configtests/risk-score-class_ok.yaml
+++ b/services/distribution/src/test/resources/configtests/risk-score-class_ok.yaml
@@ -2,10 +2,10 @@ risk-classes:
   -
     label: LOW
     min: 0
-    max: 2749
+    max: 0
     url: "https://www.coronawarn.app"
   -
     label: HIGH
-    min: 2750
-    max: 4096
+    min: 1
+    max: 255
     url: "https://www.coronawarn.app"


### PR DESCRIPTION
Fixes #381 

- Adjusts the maximum total risk score.
- Adjusts tests.
- Adjusts master-config.