### PR TITLE
Add MinioWrapperTest and Clean-Up

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/structure/file/TemporaryExposureKeyExportFile.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/structure/file/TemporaryExposureKeyExportFile.java
@@ -26,8 +26,6 @@ import app.coronawarn.server.common.protocols.external.exposurenotification.Temp
 import app.coronawarn.server.services.distribution.assembly.structure.file.FileOnDisk;
 import app.coronawarn.server.services.distribution.assembly.structure.util.ImmutableStack;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
-import com.google.common.base.Strings;
-import com.google.common.primitives.Bytes;
 import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -101,7 +99,15 @@ public class TemporaryExposureKeyExportFile extends FileOnDisk {
   }
 
   private byte[] createKeyExportBytesWithHeader() {
-    return Bytes.concat(this.getHeaderBytes(), createTemporaryExposureKeyExportBytes());
+    byte[] headerBytes = this.getHeaderBytes();
+    byte[] temporaryExposureKeyExportBytes = createTemporaryExposureKeyExportBytes();
+    return concatenate(headerBytes, temporaryExposureKeyExportBytes);
+  }
+
+  private byte[] concatenate(byte[] arr1, byte[] arr2) {
+    var concatenatedBytes = Arrays.copyOf(arr1, arr1.length + arr2.length);
+    System.arraycopy(arr2, 0, concatenatedBytes, arr1.length, arr2.length);
+    return concatenatedBytes;
   }
 
   private byte[] createTemporaryExposureKeyExportBytes() {
@@ -132,7 +138,12 @@ public class TemporaryExposureKeyExportFile extends FileOnDisk {
   private byte[] getHeaderBytes() {
     String header = distributionServiceConfig.getTekExport().getFileHeader();
     int headerWidth = distributionServiceConfig.getTekExport().getFileHeaderWidth();
-    return Strings.padEnd(header, headerWidth, ' ').getBytes(StandardCharsets.UTF_8);
+    return padRight(header, headerWidth).getBytes(StandardCharsets.UTF_8);
+  }
+
+  private String padRight(String string, int padding) {
+    String format = "%1$-" + padding + "s";
+    return String.format(format, string);
   }
 
   /**

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
@@ -22,9 +22,10 @@ package app.coronawarn.server.services.distribution.objectstore;
 
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreClient;
+import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreClient.HeaderKey;
 import app.coronawarn.server.services.distribution.objectstore.client.S3Object;
 import app.coronawarn.server.services.distribution.objectstore.publish.LocalFile;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -97,7 +98,7 @@ public class ObjectStoreAccess {
    */
   public void putObject(LocalFile localFile, int maxAge) {
     String s3Key = localFile.getS3Key();
-    Map<String, String> headers = createHeaders(maxAge);
+    Map<HeaderKey, String> headers = createHeaders(maxAge);
 
     logger.info("... uploading {}", s3Key);
     this.client.putObject(bucket, s3Key, localFile.getFile(), headers);
@@ -128,10 +129,10 @@ public class ObjectStoreAccess {
     return client.getObjects(bucket, prefix);
   }
 
-  private Map<String, String> createHeaders(int maxAge) {
-    Map<String, String> headers = new HashMap<>(Map.of("cache-control", "public,max-age=" + maxAge));
+  private Map<HeaderKey, String> createHeaders(int maxAge) {
+    EnumMap<HeaderKey, String> headers = new EnumMap<>(Map.of(HeaderKey.CACHE_CONTROL, "public,max-age=" + maxAge));
     if (this.isSetPublicReadAclOnPutObject) {
-      headers.put("x-amz-acl", "public-read");
+      headers.put(HeaderKey.AMZ_ACL, "public-read");
     }
     return headers;
   }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClient.java
@@ -37,7 +37,7 @@ public interface ObjectStoreClient {
    * @return A list of objects from the object store that match the specified parameters.
    * @throws ObjectStoreOperationFailedException if the operation could not be performed.
    */
-  List<S3Object> getObjects(String bucket, String prefix) throws ObjectStoreOperationFailedException;
+  List<S3Object> getObjects(String bucket, String prefix);
 
   /**
    * Uploads data from the specified file to an object with the specified name.
@@ -48,8 +48,7 @@ public interface ObjectStoreClient {
    * @param headers    The headers to be used during upload.
    * @throws ObjectStoreOperationFailedException if the operation could not be performed.
    */
-  void putObject(String bucket, String objectName, Path filePath, Map<String, String> headers)
-      throws ObjectStoreOperationFailedException;
+  void putObject(String bucket, String objectName, Path filePath, Map<HeaderKey, String> headers);
 
   /**
    * Removes all the specified objects from the specified object store bucket.
@@ -58,7 +57,7 @@ public interface ObjectStoreClient {
    * @param objectNames The names of objects to delete.
    * @throws ObjectStoreOperationFailedException if the operation could not be performed.
    */
-  void removeObjects(String bucket, List<String> objectNames) throws ObjectStoreOperationFailedException;
+  void removeObjects(String bucket, List<String> objectNames);
 
   /**
    * Checks if an object store bucket with the specified name exists.
@@ -67,5 +66,19 @@ public interface ObjectStoreClient {
    * @return True if the bucket exists.
    * @throws ObjectStoreOperationFailedException if the operation could not be performed.
    */
-  boolean bucketExists(String bucket) throws ObjectStoreOperationFailedException;
+  boolean bucketExists(String bucket);
+
+  /**
+   * Provides the supported header keys.
+   */
+  enum HeaderKey {
+    CACHE_CONTROL("Cache-Control"),
+    AMZ_ACL("x-amz-acl");
+
+    public final String keyValue;
+
+    HeaderKey(String keyValue) {
+      this.keyValue = keyValue;
+    }
+  }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3Object.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3Object.java
@@ -21,8 +21,7 @@
 package app.coronawarn.server.services.distribution.objectstore.client;
 
 import io.minio.messages.Item;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents an object as discovered on S3.
@@ -33,11 +32,6 @@ public class S3Object {
    * the name of the object.
    */
   private final String objectName;
-
-  /**
-   * the available meta information.
-   */
-  private Map<String, String> metadata = new HashMap<>();
 
   /** The e-Tag of this S3 Object. */
   private String etag;
@@ -79,5 +73,22 @@ public class S3Object {
   public static S3Object of(Item item) {
     String etag = item.etag().replaceAll("\"", "");
     return new S3Object(item.objectName(), etag);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    S3Object s3Object = (S3Object) o;
+    return Objects.equals(objectName, s3Object.objectName) && Objects.equals(etag, s3Object.etag);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(objectName, etag);
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/publish/LocalFile.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/publish/LocalFile.java
@@ -20,10 +20,10 @@
 
 package app.coronawarn.server.services.distribution.objectstore.publish;
 
-import com.google.common.io.BaseEncoding;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.bouncycastle.util.encoders.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.DigestUtils;
@@ -77,7 +77,7 @@ public abstract class LocalFile {
   private String computeS3ETag() {
     try {
       String md5 = DigestUtils.md5DigestAsHex(Files.readAllBytes(file));
-      byte[] raw = BaseEncoding.base16().decode(md5.toUpperCase());
+      byte[] raw = Hex.decode(md5.toUpperCase());
 
       return DigestUtils.md5DigestAsHex(raw) + "-1";
     } catch (IOException e) {

--- a/services/distribution/src/main/resources/application.yaml
+++ b/services/distribution/src/main/resources/application.yaml
@@ -43,7 +43,7 @@ services:
     objectstore:
       access-key: ${CWA_OBJECTSTORE_ACCESSKEY:accessKey1}
       secret-key: ${CWA_OBJECTSTORE_SECRETKEY:verySecretKey1}
-      endpoint: ${CWA_OBJECTSTORE_ENDPOINT:http://localhost:8003}
+      endpoint: ${CWA_OBJECTSTORE_ENDPOINT:http://localhost}
       bucket: ${CWA_OBJECTSTORE_BUCKET:cwa}
       port: ${CWA_OBJECTSTORE_PORT:8003}
       set-public-read-acl-on-put-object: true

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccessUnitTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccessUnitTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreClient;
+import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreClient.HeaderKey;
 import app.coronawarn.server.services.distribution.objectstore.publish.LocalFile;
 import java.io.File;
 import java.nio.file.Path;
@@ -88,8 +89,8 @@ class ObjectStoreAccessUnitTest {
 
   @Test
   void testPutObjectSetsDefaultCacheControlHeader() {
-    ArgumentCaptor<Map<String, String>> headers = ArgumentCaptor.forClass(Map.class);
-    var expHeader = entry("cache-control", "public,max-age=" + ObjectStoreAccess.DEFAULT_MAX_CACHE_AGE);
+    ArgumentCaptor<Map<HeaderKey, String>> headers = ArgumentCaptor.forClass(Map.class);
+    var expHeader = entry(HeaderKey.CACHE_CONTROL, "public,max-age=" + ObjectStoreAccess.DEFAULT_MAX_CACHE_AGE);
 
     objectStoreAccess.putObject(testLocalFile);
 
@@ -100,9 +101,9 @@ class ObjectStoreAccessUnitTest {
 
   @Test
   void testPutObjectSetsSpecifiedCacheControlHeader() {
-    ArgumentCaptor<Map<String, String>> headers = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<HeaderKey, String>> headers = ArgumentCaptor.forClass(Map.class);
     var expMaxAge = 1337;
-    var expHeader = entry("cache-control", "public,max-age=" + expMaxAge);
+    var expHeader = entry(HeaderKey.CACHE_CONTROL, "public,max-age=" + expMaxAge);
 
     objectStoreAccess.putObject(testLocalFile, expMaxAge);
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/MinioClientWrapperTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/MinioClientWrapperTest.java
@@ -1,0 +1,235 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App
+ * ---
+ * Copyright (C) 2020 SAP SE and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.server.services.distribution.objectstore.client;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.util.IterableUtil.iterable;
+import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.Maps.newHashMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreClient.HeaderKey;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import io.minio.MinioClient;
+import io.minio.PutObjectOptions;
+import io.minio.Result;
+import io.minio.errors.ErrorResponseException;
+import io.minio.errors.InsufficientDataException;
+import io.minio.errors.InternalException;
+import io.minio.errors.InvalidBucketNameException;
+import io.minio.errors.InvalidResponseException;
+import io.minio.errors.XmlParserException;
+import io.minio.messages.DeleteError;
+import io.minio.messages.Item;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+
+class MinioClientWrapperTest {
+
+  private static final String VALID_BUCKET_NAME = "myBucket";
+  private static final String VALID_PREFIX = "prefix";
+  private static final String VALID_NAME = "object key";
+
+  private MinioClient minioClient;
+  private MinioClientWrapper minioClientWrapper;
+
+  @BeforeEach
+  public void setUpMocks() {
+    minioClient = mock(MinioClient.class);
+    minioClientWrapper = new MinioClientWrapper(minioClient);
+  }
+
+  @Test
+  void testBucketExistsIfBucketExists() throws Exception {
+    when(minioClient.bucketExists(any())).thenReturn(true);
+    assertThat(minioClientWrapper.bucketExists(VALID_BUCKET_NAME)).isTrue();
+  }
+
+  @Test
+  void testBucketExistsIfBucketDoesNotExist() throws Exception {
+    when(minioClient.bucketExists(any())).thenReturn(false);
+    assertThat(minioClientWrapper.bucketExists(VALID_BUCKET_NAME)).isFalse();
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {ErrorResponseException.class, InsufficientDataException.class,
+      InternalException.class, IllegalArgumentException.class, InvalidBucketNameException.class,
+      InvalidKeyException.class, InvalidResponseException.class,
+      IOException.class, NoSuchAlgorithmException.class, XmlParserException.class})
+  void bucketExistsThrowsObjectStoreOperationFailedExceptionIfClientThrows(Class<Exception> cause) throws Exception {
+    when(minioClient.bucketExists(any())).thenThrow(cause);
+    assertThatExceptionOfType(ObjectStoreOperationFailedException.class)
+        .isThrownBy(() -> minioClientWrapper.bucketExists(VALID_BUCKET_NAME));
+  }
+
+  @Test
+  void testGetObjectsSendsCorrectRequest() {
+    when(minioClient.listObjects(anyString(), anyString(), anyBoolean())).thenReturn(iterable());
+    minioClientWrapper.getObjects(VALID_BUCKET_NAME, VALID_PREFIX);
+    verify(minioClient, atLeastOnce()).listObjects(eq(VALID_BUCKET_NAME), eq(VALID_PREFIX), eq(true));
+  }
+
+  @ParameterizedTest
+  @MethodSource("createGetObjectsResults")
+  void testGetObjects(List<S3Object> expResult) throws Exception {
+    Iterable<Result<Item>> actResponse = buildListObjectsResponse(expResult);
+    when(minioClient.listObjects(anyString(), anyString(), anyBoolean())).thenReturn(actResponse);
+
+    List<S3Object> actResult = minioClientWrapper.getObjects(VALID_BUCKET_NAME, VALID_PREFIX);
+
+    assertThat(actResult).isEqualTo(expResult);
+  }
+
+  private static Stream<Arguments> createGetObjectsResults() {
+    return Stream.of(
+        Lists.emptyList(),
+        list(new S3Object("objName", "eTag")),
+        list(new S3Object("objName1", "eTag1"), new S3Object("objName2", "eTag2"))
+    ).map(Arguments::of);
+  }
+
+  private Iterable<Result<Item>> buildListObjectsResponse(List<S3Object> s3Objects) throws Exception {
+    List<Result<Item>> response = new ArrayList<>(s3Objects.size());
+
+    for (S3Object s3Object : s3Objects) {
+      Item item = mock(Item.class);
+      Result<Item> result = mock(Result.class);
+      when(result.get()).thenReturn(item);
+      when(item.etag()).thenReturn(s3Object.getEtag());
+      when(item.objectName()).thenReturn(s3Object.getObjectName());
+      response.add(result);
+    }
+
+    return iterable(response.toArray(new Result[response.size()]));
+  }
+
+  @Test
+  void getObjectsRemovesDoubleQuotesFromEtags() throws Exception {
+    String expEtag = "eTag";
+    Iterable<Result<Item>> actResponse = buildListObjectsResponse(
+        List.of(new S3Object(VALID_NAME, "\"" + expEtag + "\"")));
+    when(minioClient.listObjects(anyString(), anyString(), anyBoolean())).thenReturn(actResponse);
+
+    List<S3Object> actResult = minioClientWrapper.getObjects(VALID_BUCKET_NAME, VALID_PREFIX);
+
+    assertThat(actResult).isEqualTo(List.of(new S3Object(VALID_NAME, expEtag)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {ErrorResponseException.class, InsufficientDataException.class, XmlParserException.class,
+      InternalException.class, InvalidBucketNameException.class, InvalidKeyException.class, JsonParseException.class,
+      InvalidResponseException.class, JsonMappingException.class, IOException.class, NoSuchAlgorithmException.class,
+      IllegalArgumentException.class})
+  void getObjectsThrowsObjectStoreOperationFailedExceptionIfClientThrows(Class<Exception> cause) throws Exception {
+    Result<Item> actResult = mock(Result.class);
+    when(actResult.get()).thenThrow(cause);
+    when(minioClient.listObjects(anyString(), anyString(), anyBoolean())).thenReturn(iterable(actResult));
+    assertThatExceptionOfType(ObjectStoreOperationFailedException.class)
+        .isThrownBy(() -> minioClientWrapper.getObjects(VALID_BUCKET_NAME, VALID_PREFIX));
+  }
+
+  @Test
+  void testPutObjectForNoHeaders() throws Exception {
+    minioClientWrapper.putObject(VALID_BUCKET_NAME, VALID_NAME, Path.of(""), emptyMap());
+    ArgumentCaptor<PutObjectOptions> options = ArgumentCaptor.forClass(PutObjectOptions.class);
+    verify(minioClient, atLeastOnce()).putObject(eq(VALID_BUCKET_NAME), eq(VALID_NAME), eq(""), options.capture());
+    assertThat(options.getValue().headers()).isEmpty();
+  }
+
+  @Test
+  void testPutObjectForCacheControlHeader() throws Exception {
+    String expCacheControl = "foo-cache-control";
+
+    minioClientWrapper.putObject(VALID_BUCKET_NAME, VALID_NAME, Path.of(""),
+        newHashMap(HeaderKey.CACHE_CONTROL, expCacheControl));
+
+    ArgumentCaptor<PutObjectOptions> options = ArgumentCaptor.forClass(PutObjectOptions.class);
+    verify(minioClient, atLeastOnce()).putObject(eq(VALID_BUCKET_NAME), eq(VALID_NAME), eq(""), options.capture());
+    assertThat(options.getValue().headers()).hasSize(1);
+    assertThat(options.getValue().headers()).contains(entry(HeaderKey.CACHE_CONTROL.keyValue, expCacheControl));
+  }
+
+  @Test
+  void testPutObjectForAmzAclHeader() throws Exception {
+    String expAcl = "foo-acl";
+
+    minioClientWrapper.putObject(VALID_BUCKET_NAME, VALID_NAME, Path.of(""), newHashMap(HeaderKey.AMZ_ACL, expAcl));
+
+    ArgumentCaptor<PutObjectOptions> options = ArgumentCaptor.forClass(PutObjectOptions.class);
+    verify(minioClient, atLeastOnce()).putObject(eq(VALID_BUCKET_NAME), eq(VALID_NAME), eq(""), options.capture());
+    assertThat(options.getValue().headers()).hasSize(1);
+    assertThat(options.getValue().headers()).contains(entry(HeaderKey.AMZ_ACL.keyValue, expAcl));
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {ErrorResponseException.class, IllegalArgumentException.class, InsufficientDataException.class,
+      InternalException.class, InvalidBucketNameException.class, InvalidKeyException.class, XmlParserException.class,
+      IOException.class, NoSuchAlgorithmException.class, InvalidResponseException.class})
+  void putObjectsThrowsObjectStoreOperationFailedExceptionIfClientThrows(Class<Exception> cause) throws Exception {
+    doThrow(cause).when(minioClient).putObject(anyString(), anyString(), anyString(), any(PutObjectOptions.class));
+    assertThatExceptionOfType(ObjectStoreOperationFailedException.class)
+        .isThrownBy(() -> minioClientWrapper.putObject(VALID_BUCKET_NAME, VALID_PREFIX, Path.of(""), emptyMap()));
+  }
+
+  @Test
+  void testRemoveObjects() {
+    when(minioClient.removeObjects(anyString(), anyList())).thenReturn(iterable());
+    List<String> expObjectNames = List.of("obj1", "obj2");
+
+    minioClientWrapper.removeObjects(VALID_BUCKET_NAME, expObjectNames);
+
+    verify(minioClient, atLeastOnce()).removeObjects(eq(VALID_BUCKET_NAME), eq(expObjectNames));
+  }
+
+  @Test
+  void removeObjectsThrowsObjectStoreOperationFailedExceptionOnDeleteErrors() {
+    Result<DeleteError> result = mock(Result.class);
+    when(minioClient.removeObjects(anyString(), anyList())).thenReturn(iterable(result));
+    assertThatExceptionOfType(ObjectStoreOperationFailedException.class)
+        .isThrownBy(() -> minioClientWrapper.removeObjects(VALID_BUCKET_NAME, list(VALID_NAME)));
+  }
+}

--- a/services/distribution/src/test/resources/application.yaml
+++ b/services/distribution/src/test/resources/application.yaml
@@ -41,7 +41,7 @@ services:
     objectstore:
       access-key: ${CWA_OBJECTSTORE_ACCESSKEY:accessKey1}
       secret-key: ${CWA_OBJECTSTORE_SECRETKEY:verySecretKey1}
-      endpoint: ${CWA_OBJECTSTORE_ENDPOINT:http://localhost:8003}
+      endpoint: ${CWA_OBJECTSTORE_ENDPOINT:http://localhost}
       bucket: ${CWA_OBJECTSTORE_BUCKET:cwa}
       port: ${CWA_OBJECTSTORE_PORT:8003}
       set-public-read-acl-on-put-object: true


### PR DESCRIPTION
- Indroduce ``ObjectStoreClient. HeaderKey`` enum.
- Removes calls to ``google.common`` functionality. (since no explicit dependency)
- Remove ports from ``application.yaml`` object store endpoint: e.g. ``${CWA_OBJECTSTORE_ENDPOINT:http://localhost:8003}``
- Adds MinioClientWrapper tests