### PR TITLE
Remove listBuckets call

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
@@ -74,10 +74,6 @@ public class ObjectStoreAccess {
     this.client = objectStoreClient;
     this.bucket = distributionServiceConfig.getObjectStore().getBucket();
     this.isSetPublicReadAclOnPutObject = distributionServiceConfig.getObjectStore().isSetPublicReadAclOnPutObject();
-
-    if (!this.client.bucketExists(this.bucket)) {
-      throw new IllegalArgumentException("Supplied bucket does not exist " + bucket);
-    }
   }
 
   /**

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClientConfig.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClientConfig.java
@@ -47,7 +47,7 @@ public class ObjectStoreClientConfig {
   private ObjectStoreClient createClient(ObjectStore objectStore) {
     AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(
         AwsBasicCredentials.create(objectStore.getAccessKey(), objectStore.getSecretKey()));
-    String endpoint = removeTralingSlash(objectStore.getEndpoint()) + ":" + objectStore.getPort();
+    String endpoint = removeTrailingSlash(objectStore.getEndpoint()) + ":" + objectStore.getPort();
 
     return new S3ClientWrapper(S3Client.builder()
         .region(DEFAULT_REGION)
@@ -56,7 +56,7 @@ public class ObjectStoreClientConfig {
         .build());
   }
 
-  private String removeTralingSlash(String string) {
-    return (string.endsWith("/") ? string.substring(0, string.length() - 1) : string);
+  private String removeTrailingSlash(String string) {
+    return string.endsWith("/") ? string.substring(0, string.length() - 1) : string;
   }
 }


### PR DESCRIPTION
- Not much seems to be lost if we skip the ``bucketExists`` call at initialization time.
- ``bucketExists`` requires ``s3:ListBucket`` permissions, a lack of which should not crash the application.