### PR TITLE
Add logging of number of deleted/retrieved keys

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/DiagnosisKeyRepository.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/DiagnosisKeyRepository.java
@@ -32,9 +32,10 @@ public interface DiagnosisKeyRepository extends JpaRepository<DiagnosisKey, Long
   /**
    * Deletes all entries that have a submission timestamp lesser or equal to the specified one.
    *
-   * @param submissionTimestamp the submission timestamp up to which entries will be deleted.
+   * @param submissionTimestamp The submission timestamp up to which entries will be deleted.
+   * @return The number of rows that were deleted.
    */
-  void deleteBySubmissionTimestampIsLessThanEqual(long submissionTimestamp);
+  int deleteBySubmissionTimestampIsLessThanEqual(long submissionTimestamp);
 
   /**
    * Attempts to write the specified diagnosis key information into the database. If a row with the specified key data

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/RetentionPolicy.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/RetentionPolicy.java
@@ -73,7 +73,6 @@ public class RetentionPolicy implements ApplicationRunner {
       Application.killApplication(applicationContext);
     }
 
-    logger.debug("Retention policy applied successfully. Deleted all entries older than {} days.",
-        retentionDays);
+    logger.debug("Retention policy applied successfully.");
   }
 }


### PR DESCRIPTION
Adds log messages (INFO) that provide additional information during distribution runs on data retrieval result size and number of deleted keys during retention policy application.
```
2020-06-01T18:28:03+02:00 INFO  main a.c.s.c.p.s.DiagnosisKeyService[65291]: Deleted 1337 diagnosis key(s) with a submission timestamp older than 14 day(s) ago.
2020-06-01T18:28:03+02:00 INFO  main a.c.s.c.p.s.DiagnosisKeyService[65291]: Retrieved 4 diagnosis key(s). Discarded 2 diagnosis key(s) from the result as invalid.
```