### PR TITLE
Sonar: Using command line arguments is security-sensitive

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/Application.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/Application.java
@@ -47,7 +47,7 @@ public class Application {
   private static final Logger logger = LoggerFactory.getLogger(Application.class);
 
   public static void main(String[] args) {
-    SpringApplication.run(Application.class, args);
+    SpringApplication.run(Application.class);
   }
 
   /**

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/ServerApplication.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/ServerApplication.java
@@ -47,6 +47,6 @@ public class ServerApplication {
   }
 
   public static void main(String[] args) {
-    SpringApplication.run(ServerApplication.class, args);
+    SpringApplication.run(ServerApplication.class);
   }
 }


### PR DESCRIPTION
Removes ``args`` from ``SpringApplication.run`` calls.