### PR TITLE
Ensue consistent naming of Flyway user ENVs

### DIFF
--- a/services/distribution/src/main/resources/application-cloud.yaml
+++ b/services/distribution/src/main/resources/application-cloud.yaml
@@ -3,8 +3,8 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration/postgres
-    password: ${POSTGRES_PASSWORD_FLYWAY}
-    user: ${POSTGRES_USER_FLYWAY}
+    password: ${POSTGRESQL_PASSWORD_FLYWAY}
+    user: ${POSTGRESQL_USER_FLYWAY}
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://${POSTGRESQL_SERVICE_HOST}:${POSTGRESQL_SERVICE_PORT}/${POSTGRESQL_DATABASE}


### PR DESCRIPTION
This PR will fix a consistency issue regarding naming of env variables for fly postgres users in cloud profile.