### PR TITLE
Feature/s3 resilience

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
@@ -97,7 +97,11 @@ public class ObjectStoreAccess {
     Map<HeaderKey, String> headers = createHeaders(maxAge);
 
     logger.info("... uploading {}", s3Key);
-    this.client.putObject(bucket, s3Key, localFile.getFile(), headers);
+    try {
+      this.client.putObject(bucket, s3Key, localFile.getFile(), headers);
+    } catch (Exception e) {
+      logger.error("Can't upload file! ", e);
+    }
   }
 
   /**

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/S3Publisher.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/S3Publisher.java
@@ -79,7 +79,11 @@ public class S3Publisher {
 
     logger.info("Beginning upload... ");
     for (LocalFile file : diff) {
-      this.access.putObject(file);
+      try {
+        this.access.putObject(file);
+      } catch (Exception e) {
+        logger.error("Can't upload file! ", e);
+      }
     }
     logger.info("Upload completed.");
   }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
@@ -67,10 +67,10 @@ public class S3ClientWrapper implements ObjectStoreClient {
   public List<S3Object> getObjects(String bucket, String prefix) {
     int currentTry = 0;
 
-    while(true) {
+    while (true) {
       currentTry++;
       try {
-        ListObjectsV2Response response   =
+        ListObjectsV2Response response =
             s3Client.listObjectsV2(ListObjectsV2Request.builder().prefix(prefix).bucket(bucket).build());
         return response.contents().stream().map(S3ClientWrapper::buildS3Object).collect(toList());
       } catch (SdkException e) {
@@ -95,11 +95,12 @@ public class S3ClientWrapper implements ObjectStoreClient {
       requestBuilder.cacheControl(headers.get(HeaderKey.CACHE_CONTROL));
     }
 
-    while(true) {
+    while (true) {
       currentTry++;
 
       try {
         s3Client.putObject(requestBuilder.build(), bodyFile);
+        break;
       } catch (SdkException e) {
         if (currentTry > maxRetries) {
           throw new ObjectStoreOperationFailedException("Failed to upload object to object store", e);
@@ -120,8 +121,7 @@ public class S3ClientWrapper implements ObjectStoreClient {
     Collection<ObjectIdentifier> identifiers = objectNames.stream()
         .map(key -> ObjectIdentifier.builder().key(key).build()).collect(toList());
 
-
-    while(true) {
+    while (true) {
       currentTry++;
       try {
         // TODO
@@ -137,6 +137,8 @@ public class S3ClientWrapper implements ObjectStoreClient {
             throw new ObjectStoreOperationFailedException(errMessage);
           }
           logger.debug("Failed to remove objects from object store. Attempt " + currentTry + " of " + maxRetries);
+        } else {
+          break;
         }
       } catch (SdkException e) {
         if (currentTry > maxRetries) {

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
@@ -74,7 +74,7 @@ public class S3ClientWrapper implements ObjectStoreClient {
             s3Client.listObjectsV2(ListObjectsV2Request.builder().prefix(prefix).bucket(bucket).build());
         return response.contents().stream().map(S3ClientWrapper::buildS3Object).collect(toList());
       } catch (SdkException e) {
-        if (currentTry > maxRetries) {
+        if (currentTry >= maxRetries) {
           throw new ObjectStoreOperationFailedException("Failed to upload object to object store", e);
         }
         logger.debug("Failed to upload object to object store. Attempt " + currentTry + " of " + maxRetries);
@@ -97,12 +97,11 @@ public class S3ClientWrapper implements ObjectStoreClient {
 
     while (true) {
       currentTry++;
-
       try {
         s3Client.putObject(requestBuilder.build(), bodyFile);
         break;
       } catch (SdkException e) {
-        if (currentTry > maxRetries) {
+        if (currentTry >= maxRetries) {
           throw new ObjectStoreOperationFailedException("Failed to upload object to object store", e);
         }
         logger.debug("Failed to upload object to object store. Attempt " + currentTry + " of " + maxRetries);
@@ -124,7 +123,6 @@ public class S3ClientWrapper implements ObjectStoreClient {
     while (true) {
       currentTry++;
       try {
-        // TODO
         DeleteObjectsResponse response = s3Client.deleteObjects(
             DeleteObjectsRequest.builder()
                 .bucket(bucket)
@@ -132,7 +130,7 @@ public class S3ClientWrapper implements ObjectStoreClient {
 
         if (response.hasErrors()) {
           String errMessage = "Failed to remove objects from object store.";
-          if (currentTry > maxRetries) {
+          if (currentTry >= maxRetries) {
             logger.error("{} {}", errMessage, response.errors());
             throw new ObjectStoreOperationFailedException(errMessage);
           }
@@ -141,7 +139,7 @@ public class S3ClientWrapper implements ObjectStoreClient {
           break;
         }
       } catch (SdkException e) {
-        if (currentTry > maxRetries) {
+        if (currentTry >= maxRetries) {
           throw new ObjectStoreOperationFailedException("Failed to remove objects from object store.", e);
         }
         logger.debug("Failed to remove objects from object store. Attempt " + currentTry + " of " + maxRetries);

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
@@ -48,6 +48,8 @@ public class S3ClientWrapper implements ObjectStoreClient {
 
   private final S3Client s3Client;
 
+  private final int maxRetries = 3;
+
   public S3ClientWrapper(S3Client s3Client) {
     this.s3Client = s3Client;
   }
@@ -63,18 +65,27 @@ public class S3ClientWrapper implements ObjectStoreClient {
 
   @Override
   public List<S3Object> getObjects(String bucket, String prefix) {
-    try {
-      ListObjectsV2Response response =
-          s3Client.listObjectsV2(ListObjectsV2Request.builder().prefix(prefix).bucket(bucket).build());
-      return response.contents().stream().map(S3ClientWrapper::buildS3Object).collect(toList());
-    } catch (SdkException e) {
-      throw new ObjectStoreOperationFailedException("Failed to upload object to object store", e);
+    int currentTry = 0;
+
+    while(true) {
+      currentTry++;
+      try {
+        ListObjectsV2Response response   =
+            s3Client.listObjectsV2(ListObjectsV2Request.builder().prefix(prefix).bucket(bucket).build());
+        return response.contents().stream().map(S3ClientWrapper::buildS3Object).collect(toList());
+      } catch (SdkException e) {
+        if (currentTry > maxRetries) {
+          throw new ObjectStoreOperationFailedException("Failed to upload object to object store", e);
+        }
+        logger.debug("Failed to upload object to object store. Attempt " + currentTry + " of " + maxRetries);
+      }
     }
   }
 
   @Override
   public void putObject(String bucket, String objectName, Path filePath, Map<HeaderKey, String> headers) {
     RequestBody bodyFile = RequestBody.fromFile(filePath);
+    int currentTry = 0;
 
     var requestBuilder = PutObjectRequest.builder().bucket(bucket).key(objectName);
     if (headers.containsKey(HeaderKey.AMZ_ACL)) {
@@ -84,15 +95,24 @@ public class S3ClientWrapper implements ObjectStoreClient {
       requestBuilder.cacheControl(headers.get(HeaderKey.CACHE_CONTROL));
     }
 
-    try {
-      s3Client.putObject(requestBuilder.build(), bodyFile);
-    } catch (SdkException e) {
-      throw new ObjectStoreOperationFailedException("Failed to upload object to object store", e);
+    while(true) {
+      currentTry++;
+
+      try {
+        s3Client.putObject(requestBuilder.build(), bodyFile);
+      } catch (SdkException e) {
+        if (currentTry > maxRetries) {
+          throw new ObjectStoreOperationFailedException("Failed to upload object to object store", e);
+        }
+        logger.debug("Failed to upload object to object store. Attempt " + currentTry + " of " + maxRetries);
+      }
     }
   }
 
   @Override
   public void removeObjects(String bucket, List<String> objectNames) {
+    int currentTry = 0;
+
     if (objectNames.isEmpty()) {
       return;
     }
@@ -100,19 +120,30 @@ public class S3ClientWrapper implements ObjectStoreClient {
     Collection<ObjectIdentifier> identifiers = objectNames.stream()
         .map(key -> ObjectIdentifier.builder().key(key).build()).collect(toList());
 
-    try {
-      DeleteObjectsResponse response = s3Client.deleteObjects(
-          DeleteObjectsRequest.builder()
-              .bucket(bucket)
-              .delete(Delete.builder().objects(identifiers).build()).build());
 
-      if (response.hasErrors()) {
-        String errMessage = "Failed to remove objects from object store.";
-        logger.error("{} {}", errMessage, response.errors());
-        throw new ObjectStoreOperationFailedException(errMessage);
+    while(true) {
+      currentTry++;
+      try {
+        // TODO
+        DeleteObjectsResponse response = s3Client.deleteObjects(
+            DeleteObjectsRequest.builder()
+                .bucket(bucket)
+                .delete(Delete.builder().objects(identifiers).build()).build());
+
+        if (response.hasErrors()) {
+          String errMessage = "Failed to remove objects from object store.";
+          if (currentTry > maxRetries) {
+            logger.error("{} {}", errMessage, response.errors());
+            throw new ObjectStoreOperationFailedException(errMessage);
+          }
+          logger.debug("Failed to remove objects from object store. Attempt " + currentTry + " of " + maxRetries);
+        }
+      } catch (SdkException e) {
+        if (currentTry > maxRetries) {
+          throw new ObjectStoreOperationFailedException("Failed to remove objects from object store.", e);
+        }
+        logger.debug("Failed to remove objects from object store. Attempt " + currentTry + " of " + maxRetries);
       }
-    } catch (SdkException e) {
-      throw new ObjectStoreOperationFailedException("Failed to remove objects from object store.", e);
     }
   }
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -165,6 +166,16 @@ class S3ClientWrapperTest {
         .isThrownBy(() -> s3ClientWrapper.getObjects(VALID_BUCKET_NAME, VALID_PREFIX));
   }
 
+  @ParameterizedTest
+  @ValueSource(classes = {NoSuchBucketException.class, S3Exception.class, SdkClientException.class, SdkException.class})
+  void shouldAttemptToGetObjectsThreeTimesAndThenThrow(Class<Exception> cause) {
+    when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenThrow(cause);
+    assertThatExceptionOfType(ObjectStoreOperationFailedException.class)
+        .isThrownBy(() -> s3ClientWrapper.getObjects(VALID_BUCKET_NAME, VALID_PREFIX));
+
+    verify(s3Client, times(3)).listObjectsV2(any(ListObjectsV2Request.class));
+  }
+
   @Test
   void testPutObjectForNoHeaders() {
     s3ClientWrapper.putObject(VALID_BUCKET_NAME, VALID_NAME, Path.of(""), emptyMap());
@@ -202,6 +213,16 @@ class S3ClientWrapperTest {
         .isThrownBy(() -> s3ClientWrapper.putObject(VALID_BUCKET_NAME, VALID_PREFIX, Path.of(""), emptyMap()));
   }
 
+  @ParameterizedTest
+  @ValueSource(classes = {NoSuchBucketException.class, S3Exception.class, SdkClientException.class, SdkException.class})
+  void shouldAttemptToUploadObjectThreeTimesAndThenThrow(Class<Exception> cause) {
+    when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenThrow(cause);
+    assertThatExceptionOfType(ObjectStoreOperationFailedException.class)
+        .isThrownBy(() -> s3ClientWrapper.putObject(VALID_BUCKET_NAME, VALID_PREFIX, Path.of(""), emptyMap()));
+
+    verify(s3Client, times(3)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+  }
+
   @Test
   void testRemoveObjects() {
     when(s3Client.deleteObjects(any(DeleteObjectsRequest.class))).thenReturn(DeleteObjectsResponse.builder().build());
@@ -235,5 +256,15 @@ class S3ClientWrapperTest {
     when(s3Client.deleteObjects(any(DeleteObjectsRequest.class))).thenThrow(cause);
     assertThatExceptionOfType(ObjectStoreOperationFailedException.class)
         .isThrownBy(() -> s3ClientWrapper.removeObjects(VALID_BUCKET_NAME, List.of(VALID_NAME)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {NoSuchBucketException.class, S3Exception.class, SdkClientException.class, SdkException.class})
+  void shouldAttemptToRemoveObjectThreeTimesAndThenThrow(Class<Exception> cause) {
+    when(s3Client.deleteObjects(any(DeleteObjectsRequest.class))).thenThrow(cause);
+    assertThatExceptionOfType(ObjectStoreOperationFailedException.class)
+        .isThrownBy(() -> s3ClientWrapper.removeObjects(VALID_BUCKET_NAME, List.of(VALID_NAME)));
+
+    verify(s3Client, times(3)).deleteObjects(any(DeleteObjectsRequest.class));
   }
 }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+
 import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreClient.HeaderKey;
 import java.nio.file.Path;
 import java.util.ArrayList;


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

Allows the S3ClientWrapper to retry each operation up to 3 times before throwing an exception. The S3Publisher and ObjectStoreAccess will now catch any thrown exception and just log them as errors to the console. This allows the upload of following files, even though one might have failed.

Closes #151.