### PR TITLE
Fix crashes in docker-compose scenario

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
@@ -57,7 +57,7 @@ public class S3ClientWrapper implements ObjectStoreClient {
   public boolean bucketExists(String bucketName) {
     try {
       // using S3Client.listObjectsV2 instead of S3Client.listBuckets/headBucket in order to limit required permissions
-      s3Client.listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName).maxKeys(0).build());
+      s3Client.listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName).maxKeys(1).build());
       return true;
     } catch (NoSuchBucketException e) {
       return false;


### PR DESCRIPTION
The initial ``S3ClientWrapper.bucketExists`` call lead to an Exception when run via ``docker-compose``. It appears that the employed object store does not comply with the expected response format when the client limits the result size to 0 (see ``.keys(0)``).

This PR circumvents this by limitting the result size to 1 instead.
```
software.amazon.awssdk.core.exception.SdkClientException: Unable to unmarshall response (For input string: "").
```