### PR TITLE
Update AttenuationDuration spec

### DIFF
--- a/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/internal/attenuation_duration.proto
+++ b/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/internal/attenuation_duration.proto
@@ -6,6 +6,8 @@ option java_multiple_files = true;
 message AttenuationDuration {
   Thresholds thresholds = 1;
   Weights weights = 2;
+  int32 defaultBucketOffset = 3;
+  int32 riskScoreNormalizationDivisor = 4;
 }
 
 message Thresholds {

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/AttenuationDurationValidator.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/AttenuationDurationValidator.java
@@ -26,6 +26,10 @@ import static app.coronawarn.server.services.distribution.assembly.appconfig.val
 import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.ATTENUATION_DURATION_THRESHOLD_MIN;
 import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.ATTENUATION_DURATION_WEIGHT_MAX;
 import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.ATTENUATION_DURATION_WEIGHT_MIN;
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.DEFAULT_BUCKET_OFFSET_MAX;
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.DEFAULT_BUCKET_OFFSET_MIN;
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.RISK_SCORE_NORMALIZATION_DIVISOR_MAX;
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.RISK_SCORE_NORMALIZATION_DIVISOR_MIN;
 import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.WeightValidationError.ErrorType.OUT_OF_RANGE;
 import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.WeightValidationError.ErrorType.TOO_MANY_DECIMAL_PLACES;
 
@@ -49,6 +53,8 @@ public class AttenuationDurationValidator extends ConfigurationValidator {
 
     validateThresholds();
     validateWeights();
+    validateDefaultBucketOffset();
+    validateRiskScoreNormalizationDivisor();
 
     return errors;
   }
@@ -57,8 +63,8 @@ public class AttenuationDurationValidator extends ConfigurationValidator {
     int lower = attenuationDuration.getThresholds().getLower();
     int upper = attenuationDuration.getThresholds().getUpper();
 
-    checkThresholdBound("lower", lower);
-    checkThresholdBound("upper", upper);
+    checkValueRange("thresholds.lower", lower, ATTENUATION_DURATION_THRESHOLD_MIN, ATTENUATION_DURATION_THRESHOLD_MAX);
+    checkValueRange("thresholds.upper", upper, ATTENUATION_DURATION_THRESHOLD_MIN, ATTENUATION_DURATION_THRESHOLD_MAX);
 
     if (lower > upper) {
       String parameters = "attenuation-duration.thresholds.lower, attenuation-duration.thresholds.upper";
@@ -67,10 +73,10 @@ public class AttenuationDurationValidator extends ConfigurationValidator {
     }
   }
 
-  private void checkThresholdBound(String thresholdLabel, int thresholdValue) {
-    if (thresholdValue < ATTENUATION_DURATION_THRESHOLD_MIN || thresholdValue > ATTENUATION_DURATION_THRESHOLD_MAX) {
+  private void checkValueRange(String parameterLabel, int value, int min, int max) {
+    if (value < min || value > max) {
       this.errors.add(new GeneralValidationError(
-          "attenuation-duration.thresholds." + thresholdLabel, thresholdValue, VALUE_OUT_OF_BOUNDS));
+          "attenuation-duration." + parameterLabel, value, VALUE_OUT_OF_BOUNDS));
     }
   }
 
@@ -90,5 +96,16 @@ public class AttenuationDurationValidator extends ConfigurationValidator {
       this.errors.add(new WeightValidationError(
           "attenuation-duration.weights." + weightLabel, weightValue, TOO_MANY_DECIMAL_PLACES));
     }
+  }
+
+  private void validateDefaultBucketOffset() {
+    int bucketOffset = attenuationDuration.getDefaultBucketOffset();
+    checkValueRange("default-bucket-offset", bucketOffset, DEFAULT_BUCKET_OFFSET_MIN, DEFAULT_BUCKET_OFFSET_MAX);
+  }
+
+  private void validateRiskScoreNormalizationDivisor() {
+    int riskScoreNormalizationDivisor = attenuationDuration.getRiskScoreNormalizationDivisor();
+    checkValueRange("risk-score-normalization-divisor", riskScoreNormalizationDivisor,
+        RISK_SCORE_NORMALIZATION_DIVISOR_MIN, RISK_SCORE_NORMALIZATION_DIVISOR_MAX);
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ParameterSpec.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ParameterSpec.java
@@ -78,4 +78,25 @@ public class ParameterSpec {
    * Maximum number of allowed decimals for an attenuation weight.
    */
   public static final int ATTENUATION_DURATION_WEIGHT_MAX_DECIMALS = 3;
+
+
+  /**
+   * The allowed minimum value for a default bucket offset.
+   */
+  public static final int DEFAULT_BUCKET_OFFSET_MIN = 0;
+
+  /**
+   * The allowed maximum value for a default bucket offset.
+   */
+  public static final int DEFAULT_BUCKET_OFFSET_MAX = 1;
+
+  /**
+   * The allowed minimum value for a risk score normalization divisor.
+   */
+  public static final int RISK_SCORE_NORMALIZATION_DIVISOR_MIN = 0;
+
+  /**
+   * The allowed maximum value for a risk score normalization divisor.
+   */
+  public static final int RISK_SCORE_NORMALIZATION_DIVISOR_MAX = 1000;
 }

--- a/services/distribution/src/main/resources/master-config/attenuation-duration.yaml
+++ b/services/distribution/src/main/resources/master-config/attenuation-duration.yaml
@@ -4,6 +4,9 @@
 # Each of the aforementioned partitions has a weight in the range of [0, 1]
 # assigned to it. The number of decimal places is restricted to 3.
 #
+# default-bucket-offset value range: {0, 1}
+# risk-score-normalization-divisor value range: [1, 1000]
+#
 # Change this file with caution!
 
 thresholds:
@@ -13,3 +16,5 @@ weights:
   low: 1.0
   mid: 0.5
   high: 0.0
+default-bucket-offset: 0
+risk-score-normalization-divisor: 25

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/AttenuationDurationValidatorTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/AttenuationDurationValidatorTest.java
@@ -26,6 +26,10 @@ import static app.coronawarn.server.services.distribution.assembly.appconfig.val
 import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.ATTENUATION_DURATION_THRESHOLD_MIN;
 import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.ATTENUATION_DURATION_WEIGHT_MAX;
 import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.ATTENUATION_DURATION_WEIGHT_MIN;
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.DEFAULT_BUCKET_OFFSET_MAX;
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.DEFAULT_BUCKET_OFFSET_MIN;
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.RISK_SCORE_NORMALIZATION_DIVISOR_MAX;
+import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.ParameterSpec.RISK_SCORE_NORMALIZATION_DIVISOR_MIN;
 import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.RiskScoreClassificationValidatorTest.buildError;
 import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.RiskScoreClassificationValidatorTest.buildExpectedResult;
 import static app.coronawarn.server.services.distribution.assembly.appconfig.validation.WeightValidationError.ErrorType.OUT_OF_RANGE;
@@ -44,12 +48,14 @@ public class AttenuationDurationValidatorTest {
       buildThresholds(ATTENUATION_DURATION_THRESHOLD_MIN, ATTENUATION_DURATION_THRESHOLD_MAX);
   private static final Weights VALID_WEIGHTS =
       buildWeights(ATTENUATION_DURATION_WEIGHT_MAX, ATTENUATION_DURATION_WEIGHT_MAX, ATTENUATION_DURATION_WEIGHT_MAX);
+  private static final int VALID_BUCKET_OFFSET = DEFAULT_BUCKET_OFFSET_MAX;
+  private static final int VALID_NORMALIZATION_DIVISOR = RISK_SCORE_NORMALIZATION_DIVISOR_MIN;
 
   @ParameterizedTest
   @ValueSource(ints = {ATTENUATION_DURATION_THRESHOLD_MIN - 1, ATTENUATION_DURATION_THRESHOLD_MAX + 1})
   void failsIfAttenuationDurationThresholdOutOfBounds(int invalidThresholdValue) {
     AttenuationDurationValidator validator = buildValidator(
-        buildThresholds(invalidThresholdValue, invalidThresholdValue), VALID_WEIGHTS);
+        buildThresholds(invalidThresholdValue, invalidThresholdValue));
 
     ValidationResult expectedResult = buildExpectedResult(
         buildError("attenuation-duration.thresholds.lower", invalidThresholdValue, VALUE_OUT_OF_BOUNDS),
@@ -58,10 +64,35 @@ public class AttenuationDurationValidatorTest {
     assertThat(validator.validate()).isEqualTo(expectedResult);
   }
 
+  @ParameterizedTest
+  @ValueSource(ints = {DEFAULT_BUCKET_OFFSET_MIN - 1, DEFAULT_BUCKET_OFFSET_MAX + 1})
+  void failsIfBucketOffsetOutOfBounds(int invalidDefaultBucketOffsetValue) {
+    AttenuationDurationValidator validator = buildValidator(VALID_THRESHOLDS, VALID_WEIGHTS,
+        invalidDefaultBucketOffsetValue, VALID_NORMALIZATION_DIVISOR);
+
+    ValidationResult expectedResult = buildExpectedResult(
+        buildError("attenuation-duration.default-bucket-offset", invalidDefaultBucketOffsetValue, VALUE_OUT_OF_BOUNDS));
+
+    assertThat(validator.validate()).isEqualTo(expectedResult);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {RISK_SCORE_NORMALIZATION_DIVISOR_MIN - 1, RISK_SCORE_NORMALIZATION_DIVISOR_MAX + 1})
+  void failsIfRiskScoreNormalizationDivisorOutOfBounds(int invalidRiskScoreNormalizationDivisorValue) {
+    AttenuationDurationValidator validator = buildValidator(VALID_THRESHOLDS, VALID_WEIGHTS, VALID_BUCKET_OFFSET,
+        invalidRiskScoreNormalizationDivisorValue);
+
+    ValidationResult expectedResult = buildExpectedResult(
+        buildError("attenuation-duration.risk-score-normalization-divisor", invalidRiskScoreNormalizationDivisorValue,
+            VALUE_OUT_OF_BOUNDS));
+
+    assertThat(validator.validate()).isEqualTo(expectedResult);
+  }
+
   @Test
   void failsIfUpperAttenuationDurationThresholdLesserThanLower() {
     AttenuationDurationValidator validator = buildValidator(
-        buildThresholds(ATTENUATION_DURATION_THRESHOLD_MAX, ATTENUATION_DURATION_THRESHOLD_MIN), VALID_WEIGHTS);
+        buildThresholds(ATTENUATION_DURATION_THRESHOLD_MAX, ATTENUATION_DURATION_THRESHOLD_MIN));
 
     ValidationResult expectedResult = buildExpectedResult(
         new GeneralValidationError("attenuation-duration.thresholds.lower, attenuation-duration.thresholds.upper",
@@ -73,7 +104,7 @@ public class AttenuationDurationValidatorTest {
   @ParameterizedTest
   @ValueSource(doubles = {ATTENUATION_DURATION_WEIGHT_MIN - .1, ATTENUATION_DURATION_WEIGHT_MAX + .1})
   void failsIfWeightsOutOfBounds(double invalidWeightValue) {
-    AttenuationDurationValidator validator = buildValidator(VALID_THRESHOLDS,
+    AttenuationDurationValidator validator = buildValidator(
         buildWeights(invalidWeightValue, invalidWeightValue, invalidWeightValue));
 
     ValidationResult expectedResult = buildExpectedResult(
@@ -87,7 +118,7 @@ public class AttenuationDurationValidatorTest {
   @Test
   void failsIfWeightsHaveTooManyDecimalPlaces() {
     double invalidWeightValue = ATTENUATION_DURATION_WEIGHT_MAX - 0.0000001;
-    AttenuationDurationValidator validator = buildValidator(VALID_THRESHOLDS,
+    AttenuationDurationValidator validator = buildValidator(
         buildWeights(invalidWeightValue, invalidWeightValue, invalidWeightValue));
 
     ValidationResult expectedResult = buildExpectedResult(
@@ -98,10 +129,22 @@ public class AttenuationDurationValidatorTest {
     assertThat(validator.validate()).isEqualTo(expectedResult);
   }
 
-  private static AttenuationDurationValidator buildValidator(Thresholds thresholds, Weights weights) {
+  private static AttenuationDurationValidator buildValidator(Thresholds thresholds) {
+    return buildValidator(thresholds, VALID_WEIGHTS, VALID_BUCKET_OFFSET, VALID_NORMALIZATION_DIVISOR);
+  }
+
+  private static AttenuationDurationValidator buildValidator(Weights weights) {
+    return buildValidator(VALID_THRESHOLDS, weights, VALID_BUCKET_OFFSET, VALID_NORMALIZATION_DIVISOR);
+  }
+
+  private static AttenuationDurationValidator buildValidator(
+      Thresholds thresholds, Weights weights, int defaultBucketOffset, int riskScoreNormalizationDivisor) {
     return new AttenuationDurationValidator(AttenuationDuration.newBuilder()
         .setThresholds(thresholds)
-        .setWeights(weights).build());
+        .setWeights(weights)
+        .setDefaultBucketOffset(defaultBucketOffset)
+        .setRiskScoreNormalizationDivisor(riskScoreNormalizationDivisor)
+        .build());
   }
 
   private static Thresholds buildThresholds(int lower, int upper) {

--- a/services/distribution/src/test/resources/configtests/attenuation-duration.yaml
+++ b/services/distribution/src/test/resources/configtests/attenuation-duration.yaml
@@ -5,3 +5,5 @@ weights:
   low: 1.0
   mid: 0.5
   high: 0.0
+default-bucket-offset: 0
+risk-score-normalization-divisor: 25


### PR DESCRIPTION
Resolves #437 

Adds the _default bucket offset_ and _risk score normalization divisor_ fields to the attenuation/duration configuration protoBuf specification and respective configuration files.