### PR TITLE
Add indicator for signing phase

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/Assembly.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/Assembly.java
@@ -67,6 +67,7 @@ public class Assembly implements ApplicationRunner {
       outputDirectory.addWritable(cwaApiStructureProvider.getDirectory());
       this.outputDirectoryProvider.clear();
       logger.debug("Preparing files...");
+      logger.info("Start signing...");
       outputDirectory.prepare(new ImmutableStack<>());
       logger.debug("Writing files...");
       outputDirectory.write();


### PR DESCRIPTION
As agreed with monitoring team, we should give an indicator when we start signing.