### PR TITLE
Feature/skip large exports

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/structure/directory/DiagnosisKeysCountryDirectory.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/structure/directory/DiagnosisKeysCountryDirectory.java
@@ -67,6 +67,6 @@ public class DiagnosisKeysCountryDirectory extends IndexDirectoryOnDisk<String> 
 
   private IndexDirectory<LocalDate, WritableOnDisk> decorateDateDirectory(DiagnosisKeysDateDirectory dateDirectory) {
     return new DateAggregatingDecorator(new DateIndexingDecorator(dateDirectory, distributionServiceConfig),
-        cryptoProvider, distributionServiceConfig);
+        cryptoProvider, distributionServiceConfig, diagnosisKeyBundler);
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/structure/directory/decorator/DateAggregatingDecorator.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/structure/directory/decorator/DateAggregatingDecorator.java
@@ -25,6 +25,7 @@ import static app.coronawarn.server.services.distribution.assembly.structure.uti
 import app.coronawarn.server.common.protocols.external.exposurenotification.TemporaryExposureKey;
 import app.coronawarn.server.common.protocols.external.exposurenotification.TemporaryExposureKeyExport;
 import app.coronawarn.server.services.distribution.assembly.component.CryptoProvider;
+import app.coronawarn.server.services.distribution.assembly.diagnosiskeys.DiagnosisKeyBundler;
 import app.coronawarn.server.services.distribution.assembly.diagnosiskeys.structure.archive.decorator.singing.DiagnosisKeySigningDecorator;
 import app.coronawarn.server.services.distribution.assembly.diagnosiskeys.structure.file.TemporaryExposureKeyExportFile;
 import app.coronawarn.server.services.distribution.assembly.structure.Writable;
@@ -54,15 +55,17 @@ public class DateAggregatingDecorator extends IndexDirectoryDecorator<LocalDate,
 
   private final CryptoProvider cryptoProvider;
   private final DistributionServiceConfig distributionServiceConfig;
+  private final DiagnosisKeyBundler diagnosisKeyBundler;
 
   /**
    * Creates a new DateAggregatingDecorator.
    */
   public DateAggregatingDecorator(IndexDirectory<LocalDate, WritableOnDisk> directory, CryptoProvider cryptoProvider,
-      DistributionServiceConfig distributionServiceConfig) {
+      DistributionServiceConfig distributionServiceConfig, DiagnosisKeyBundler diagnosisKeyBundler) {
     super(directory);
     this.cryptoProvider = cryptoProvider;
     this.distributionServiceConfig = distributionServiceConfig;
+    this.diagnosisKeyBundler = diagnosisKeyBundler;
   }
 
   @Override
@@ -77,6 +80,7 @@ public class DateAggregatingDecorator extends IndexDirectoryDecorator<LocalDate,
     }
 
     Set<String> dates = this.getIndex(indices).stream()
+        .filter(diagnosisKeyBundler::numberOfKeysForDateBelowMaximum)
         .map(this.getIndexFormatter())
         .map(Object::toString)
         .collect(Collectors.toSet());

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/io/IO.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/io/IO.java
@@ -20,20 +20,15 @@
 
 package app.coronawarn.server.services.distribution.assembly.io;
 
-import app.coronawarn.server.services.distribution.assembly.diagnosiskeys.structure.file.TemporaryExposureKeyExportFile;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A class containing helper functions for general purpose file IO.
  */
 public class IO {
-
-  private static final Logger logger = LoggerFactory.getLogger(IO.class);
 
   /**
    * The maximum acceptable file size in bytes.

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/io/IO.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/io/IO.java
@@ -20,15 +20,25 @@
 
 package app.coronawarn.server.services.distribution.assembly.io;
 
+import app.coronawarn.server.services.distribution.assembly.diagnosiskeys.structure.file.TemporaryExposureKeyExportFile;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A class containing helper functions for general purpose file IO.
  */
 public class IO {
+
+  private static final Logger logger = LoggerFactory.getLogger(IO.class);
+
+  /**
+   * The maximum acceptable file size in bytes.
+   */
+  public static final int MAXIMUM_FILE_SIZE = 16000000;
 
   private IO() {
   }
@@ -51,12 +61,20 @@ public class IO {
   }
 
   /**
-   * Writes bytes into a file.
+   * Writes bytes into a file. If the resulting file would exceed the specified maximum file size, it is not written but
+   * removed instead.
    *
    * @param bytes      The content to write
    * @param outputFile The file to write the content into.
    */
   public static void writeBytesToFile(byte[] bytes, File outputFile) {
+    if (bytes.length > MAXIMUM_FILE_SIZE) {
+      String fileName = outputFile.getName();
+      throw new UncheckedIOException(
+          new IOException(
+              "File size of " + bytes.length + " bytes exceeds the maximum file size. Deleting" + fileName));
+    }
+
     try (FileOutputStream outputFileStream = new FileOutputStream(outputFile)) {
       outputFileStream.write(bytes);
     } catch (IOException e) {

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/config/DistributionServiceConfig.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/config/DistributionServiceConfig.java
@@ -33,6 +33,7 @@ public class DistributionServiceConfig {
   private Integer retentionDays;
   private Integer expiryPolicyMinutes;
   private Integer shiftingPolicyThreshold;
+  private Integer maximumNumberOfKeysPerBundle;
   private String outputFileName;
   private Boolean includeIncompleteDays;
   private Boolean includeIncompleteHours;
@@ -79,6 +80,14 @@ public class DistributionServiceConfig {
 
   public void setShiftingPolicyThreshold(Integer shiftingPolicyThreshold) {
     this.shiftingPolicyThreshold = shiftingPolicyThreshold;
+  }
+
+  public Integer getMaximumNumberOfKeysPerBundle() {
+    return this.maximumNumberOfKeysPerBundle;
+  }
+
+  public void setMaximumNumberOfKeysPerBundle(Integer maximumNumberOfKeysPerBundle) {
+    this.maximumNumberOfKeysPerBundle = maximumNumberOfKeysPerBundle;
   }
 
   public String getOutputFileName() {

--- a/services/distribution/src/main/resources/application.yaml
+++ b/services/distribution/src/main/resources/application.yaml
@@ -13,6 +13,7 @@ services:
     retention-days: 14
     expiry-policy-minutes: 120
     shifting-policy-threshold: 140
+    maximum-number-of-keys-per-bundle: 600000
     include-incomplete-days: false
     include-incomplete-hours: false
     paths:

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/io/IOTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/io/IOTest.java
@@ -24,12 +24,10 @@ package app.coronawarn.server.services.distribution.assembly.io;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.UncheckedIOException;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class IOTest {

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/io/IOTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/io/IOTest.java
@@ -1,0 +1,44 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App
+ * ---
+ * Copyright (C) 2020 SAP SE and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.server.services.distribution.assembly.io;
+
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.io.UncheckedIOException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class IOTest {
+
+  @Test
+  void doesNotWriteIfMaximumFileSize() {
+    File file = mock(File.class);
+    assertThatExceptionOfType(UncheckedIOException.class)
+        .isThrownBy(() -> IO.writeBytesToFile(new byte[IO.MAXIMUM_FILE_SIZE + 1], file));
+    verify(file, never()).getPath();
+  }
+}

--- a/services/distribution/src/test/resources/application.yaml
+++ b/services/distribution/src/test/resources/application.yaml
@@ -11,6 +11,7 @@ services:
     retention-days: 14
     expiry-policy-minutes: 120
     shifting-policy-threshold: 5
+    maximum-number-of-keys-per-bundle: 600000
     include-incomplete-days: false
     include-incomplete-hours: false
     paths:


### PR DESCRIPTION
Resolves #444 
- Limits exposure key bundles to 600,000 keys or 16 MB