### PR TITLE
Adherence to micrometer naming conventions

### DIFF
--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
@@ -178,10 +178,10 @@ public class SubmissionController {
   }
 
   /**
-   * Gets the current fake delay. Used for monitoring.
+   * Gets the current fake delay in seconds. Used for monitoring.
    * @return the current fake delay
    */
-  public Double getFakeDelay() {
-    return fakeDelay;
+  public Double getFakeDelayInSeconds() {
+    return fakeDelay / 1000.;
   }
 }

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/monitoring/BatchCounter.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/monitoring/BatchCounter.java
@@ -29,7 +29,7 @@ import io.micrometer.core.instrument.MeterRegistry;
  */
 public class BatchCounter {
 
-  private static final String SUBMISSION_CONTROLLER_REQUESTS_COUNTER_NAME = "submissionController.requests";
+  private static final String SUBMISSION_CONTROLLER_REQUESTS_COUNTER_NAME = "submission_controller.requests";
   private static final String SUBMISSION_CONTROLLER_REQUESTS_COUNTER_DESCRIPTION
       = "Counts requests to the Submission Controller.";
 

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/monitoring/SubmissionControllerMonitor.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/monitoring/SubmissionControllerMonitor.java
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "services.submission.monitoring")
 public class SubmissionControllerMonitor {
-  private static final String SUBMISSION_CONTROLLER_CURRENT_FAKE_DELAY = "submissionController.fakeDelay";
+  private static final String SUBMISSION_CONTROLLER_CURRENT_FAKE_DELAY = "submission_controller.fake_delay_seconds";
 
   private final MeterRegistry meterRegistry;
 
@@ -79,7 +79,7 @@ public class SubmissionControllerMonitor {
    */
   public void initializeGauges(SubmissionController submissionController) {
     Gauge.builder(SUBMISSION_CONTROLLER_CURRENT_FAKE_DELAY, submissionController,
-        __ -> submissionController.getFakeDelay())
+        __ -> submissionController.getFakeDelayInSeconds())
         .description("The time that fake requests are delayed to make them indistinguishable from real requests.")
         .register(meterRegistry);
   }


### PR DESCRIPTION
Since this is relevant for monitoring, we may want to consider pulling this into 1.0 and 1.1

Docu: https://prometheus.io/docs/practices/naming/#base-units