### PR TITLE
Optimize Docker build with mvn go-offline

### DIFF
--- a/services/distribution/Dockerfile
+++ b/services/distribution/Dockerfile
@@ -2,7 +2,7 @@ FROM maven:3.6.3-jdk-11 as build
 
 ARG WORK_DIR=/build
 
-# copy the pom and config files only which do not change very often
+# copy the pom and config files first (which do not change very often)
 COPY ./.mvn ${WORK_DIR}/.mvn
 COPY ./pom.xml ${WORK_DIR}/pom.xml
 COPY ./common/pom.xml ${WORK_DIR}/common/pom.xml
@@ -12,10 +12,10 @@ COPY ./services/pom.xml ${WORK_DIR}/services/pom.xml
 COPY ./services/distribution/pom.xml ${WORK_DIR}/services/distribution/pom.xml
 COPY ./services/submission/pom.xml ${WORK_DIR}/services/submission/pom.xml
 
-# build all dependencies for offline use and let Docker cache them against above file set
+# build all dependencies for offline use
 RUN mvn dependency:go-offline --file ${WORK_DIR}/pom.xml -B
 
-# copy rest of files - any changes in those will invalidate Docker cache for following mvn clean install
+# copy rest of files
 COPY . ${WORK_DIR}/
 
 RUN mkdir -p /root/.m2 /usr/sap/distribution-service

--- a/services/distribution/Dockerfile
+++ b/services/distribution/Dockerfile
@@ -2,6 +2,20 @@ FROM maven:3.6.3-jdk-11 as build
 
 ARG WORK_DIR=/build
 
+# copy the pom and config files only which do not change very often
+COPY ./.mvn ${WORK_DIR}/.mvn
+COPY ./pom.xml ${WORK_DIR}/pom.xml
+COPY ./common/pom.xml ${WORK_DIR}/common/pom.xml
+COPY ./common/protocols/pom.xml ${WORK_DIR}/common/protocols/pom.xml
+COPY ./common/persistence/pom.xml ${WORK_DIR}/common/persistence/pom.xml
+COPY ./services/pom.xml ${WORK_DIR}/services/pom.xml
+COPY ./services/distribution/pom.xml ${WORK_DIR}/services/distribution/pom.xml
+COPY ./services/submission/pom.xml ${WORK_DIR}/services/submission/pom.xml
+
+# build all dependencies for offline use and let Docker cache them against above file set
+RUN mvn dependency:go-offline --file ${WORK_DIR}/pom.xml -B
+
+# copy rest of files - any changes in those will invalidate Docker cache for following mvn clean install
 COPY . ${WORK_DIR}/
 
 RUN mkdir -p /root/.m2 /usr/sap/distribution-service

--- a/services/submission/Dockerfile
+++ b/services/submission/Dockerfile
@@ -2,7 +2,7 @@ FROM maven:3.6.3-jdk-11 as build
 
 ARG WORK_DIR=/build
 
-# copy the pom and config files only which do not change very often
+# copy the pom and config files first (which do not change very often)
 COPY ./.mvn ${WORK_DIR}/.mvn
 COPY ./pom.xml ${WORK_DIR}/pom.xml
 COPY ./common/pom.xml ${WORK_DIR}/common/pom.xml
@@ -12,10 +12,10 @@ COPY ./services/pom.xml ${WORK_DIR}/services/pom.xml
 COPY ./services/distribution/pom.xml ${WORK_DIR}/services/distribution/pom.xml
 COPY ./services/submission/pom.xml ${WORK_DIR}/services/submission/pom.xml
 
-# build all dependencies for offline use and let Docker cache them against above file set
+# build all dependencies for offline use
 RUN mvn dependency:go-offline --file ${WORK_DIR}/pom.xml -B
 
-# copy rest of files - any changes in those will invalidate Docker cache for following mvn clean install
+# copy rest of files
 COPY . ${WORK_DIR}/
 
 RUN mkdir -p /root/.m2 /usr/sap/submission-service

--- a/services/submission/Dockerfile
+++ b/services/submission/Dockerfile
@@ -2,6 +2,20 @@ FROM maven:3.6.3-jdk-11 as build
 
 ARG WORK_DIR=/build
 
+# copy the pom and config files only which do not change very often
+COPY ./.mvn ${WORK_DIR}/.mvn
+COPY ./pom.xml ${WORK_DIR}/pom.xml
+COPY ./common/pom.xml ${WORK_DIR}/common/pom.xml
+COPY ./common/protocols/pom.xml ${WORK_DIR}/common/protocols/pom.xml
+COPY ./common/persistence/pom.xml ${WORK_DIR}/common/persistence/pom.xml
+COPY ./services/pom.xml ${WORK_DIR}/services/pom.xml
+COPY ./services/distribution/pom.xml ${WORK_DIR}/services/distribution/pom.xml
+COPY ./services/submission/pom.xml ${WORK_DIR}/services/submission/pom.xml
+
+# build all dependencies for offline use and let Docker cache them against above file set
+RUN mvn dependency:go-offline --file ${WORK_DIR}/pom.xml -B
+
+# copy rest of files - any changes in those will invalidate Docker cache for following mvn clean install
 COPY . ${WORK_DIR}/
 
 RUN mkdir -p /root/.m2 /usr/sap/submission-service


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

Optimizes Docker build by leveraging Docker cache to reuse maven dependencies when possible.

The pom files are copied first (which rarely change), and allow Docker to cache state of `mvn dependency:go-offline` (the project's entire dependencies, except for `org.opencwa.*`) against those pom files. Therefore, on subsequent builds where pom files do not change, this step is very fast.

Next, the rest of the files are copied over and `mvn clean install` state is cached against the container's entire file contents. On subsequent builds, if any file (other than the pom files) is changed, then the Docker cache is invalidated and `mvn clean install` rebuilds only the `org.opencwa.*` modules.

Improvement (on my machine):
- A full `docker-compose build` (no cache) takes 12 mins
- A subsequent full `docker-compose build` (with cache) takes only **2 mins** when any source file is changed
- A subsequent full `docker-compose build` (with cache) takes again 12 mins when any pom file is changed (since the entire cache is invalidated, as expected)

This is particularly handy for development env, where frequent branch switches occur (typically with no change to pom files) and testing them against a local Docker build is required.

Notes: 
- An additional potential optimization could be having both submission and distribution Docker containers sharing the same maven repository as currently each has its own separate repository. Such an optimization can work nicely in conjunction with this one to both share and better cache dependencies.
- If for whatever reason no cache use is wanted, one can run `docker-compose build --no-cache`
