### PR TITLE
Number of bytes should not depend on Locale

### DIFF
--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilderTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilderTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import app.coronawarn.server.common.persistence.exception.InvalidDiagnosisKeyException;
 import app.coronawarn.server.common.protocols.external.exposurenotification.TemporaryExposureKey;
 import com.google.protobuf.ByteString;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class DiagnosisKeyBuilderTest {
 
-  private final byte[] expKeyData = "16-bytelongarray".getBytes(Charset.defaultCharset());
+  private final byte[] expKeyData = "16-bytelongarray".getBytes(StandardCharsets.US_ASCII);
   private final int expRollingStartIntervalNumber = 73800;
   private final int expTransmissionRiskLevel = 1;
   private final long expSubmissionTimestamp = 2L;
@@ -179,13 +179,13 @@ class DiagnosisKeyBuilderTest {
   @ValueSource(strings = {"17--bytelongarray", "", "1"})
   void keyDataMustHaveValidLength(String invalidKeyString) {
     assertThat(
-        catchThrowable(() -> keyWithKeyData(invalidKeyString.getBytes(Charset.defaultCharset()))))
+        catchThrowable(() -> keyWithKeyData(invalidKeyString.getBytes(StandardCharsets.US_ASCII))))
         .isInstanceOf(InvalidDiagnosisKeyException.class);
   }
 
   @Test
   void keyDataDoesNotThrowOnValid() {
-    assertThatCode(() -> keyWithKeyData("16-bytelongarray".getBytes(Charset.defaultCharset())))
+    assertThatCode(() -> keyWithKeyData("16-bytelongarray".getBytes(StandardCharsets.US_ASCII)))
         .doesNotThrowAnyException();
   }
 

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyServiceMockedRepositoryTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyServiceMockedRepositoryTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 
 import app.coronawarn.server.common.persistence.repository.DiagnosisKeyRepository;
 import app.coronawarn.server.common.persistence.service.DiagnosisKeyService;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -39,7 +39,7 @@ import org.springframework.data.domain.Sort.Direction;
 @DataJpaTest
 class DiagnosisKeyServiceMockedRepositoryTest {
 
-  static final byte[] expKeyData = "16-bytelongarray".getBytes(Charset.defaultCharset());
+  static final byte[] expKeyData = "16-bytelongarray".getBytes(StandardCharsets.US_ASCII);
   static final int expRollingStartIntervalNumber = 73800;
   static final int expTransmissionRiskLevel = 1;
 
@@ -89,7 +89,7 @@ class DiagnosisKeyServiceMockedRepositoryTest {
   }
 
   private DiagnosisKey invalidKey(long expSubmissionTimestamp) {
-    byte[] expKeyData = "17--bytelongarray".getBytes(Charset.defaultCharset());
+    byte[] expKeyData = "17--bytelongarray".getBytes(StandardCharsets.US_ASCII);
     return new DiagnosisKey(expKeyData, expRollingStartIntervalNumber,
         DiagnosisKey.EXPECTED_ROLLING_PERIOD, expTransmissionRiskLevel, expSubmissionTimestamp);
   }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +35,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class DiagnosisKeyTest {
 
-  final static byte[] expKeyData = "testKey111111111".getBytes(Charset.defaultCharset());
+  final static byte[] expKeyData = "testKey111111111".getBytes(StandardCharsets.US_ASCII);
   final static int expRollingStartIntervalNumber = 1;
   final static int expRollingPeriod = 2;
   final static int expTransmissionRiskLevel = 3;

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/structure/directory/decorator/indexing/IndexingDecoratorOnDisk.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/structure/directory/decorator/indexing/IndexingDecoratorOnDisk.java
@@ -25,6 +25,7 @@ import app.coronawarn.server.services.distribution.assembly.structure.directory.
 import app.coronawarn.server.services.distribution.assembly.structure.file.FileOnDisk;
 import app.coronawarn.server.services.distribution.assembly.structure.file.FileOnDiskWithChecksum;
 import app.coronawarn.server.services.distribution.assembly.structure.util.ImmutableStack;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -46,6 +47,6 @@ public class IndexingDecoratorOnDisk<T> extends AbstractIndexingDecorator<T, Wri
         .sorted()
         .collect(Collectors.toList());
     array.addAll(elements);
-    return new FileOnDiskWithChecksum(indexFileName, array.toJSONString().getBytes());
+    return new FileOnDiskWithChecksum(indexFileName, array.toJSONString().getBytes(StandardCharsets.UTF_8));
   }
 }


### PR DESCRIPTION
Charset.defaultCharset() depends on the locale
of the JVM and OS. Tests would fail e.g. with
UTF-16 (2 byte per character) encoding. Use US-ASCII
instead to make it obvious we use a 1 byte per
character encoding for test data.