### PR TITLE
Fix grep command

### DIFF
--- a/scripts/wait-for-it/wait-for-it.sh
+++ b/scripts/wait-for-it/wait-for-it.sh
@@ -150,7 +150,7 @@ if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
     WAITFORIT_ISBUSY=1
     # Check if busybox timeout uses -t flag
     # (recent Alpine versions don't support -t anymore)
-    if timeout &>/dev/stdout | grep -q -e '-t '; then
+    if timeout &>/dev/stdout | grep -q -e -- '-t '; then
         WAITFORIT_BUSYTIMEFLAG="-t"
     fi
 else


### PR DESCRIPTION
Without "--", grep interprets search string "-t" as flag

Fixes #480 