### PR TITLE
Fix CVE-2020-13692 in services too

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -89,6 +89,13 @@
       <artifactId>snakeyaml</artifactId>
       <version>1.26</version>
     </dependency>
+    <dependency>
+      <!-- https://nvd.nist.gov/vuln/detail/CVE-2020-13692 -->
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.13</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/services/submission/pom.xml
+++ b/services/submission/pom.xml
@@ -68,7 +68,6 @@
       <version>2.26.3</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <build>


### PR DESCRIPTION
related to https://github.com/corona-warn-app/cwa-server/pull/477