### PR TITLE
Set root log level to 'off' for distribution tests

### DIFF
--- a/services/distribution/src/test/resources/application.yaml
+++ b/services/distribution/src/test/resources/application.yaml
@@ -3,7 +3,7 @@ logging:
   level:
     org:
       springframework: off
-    root: info
+    root: off
 
 services:
   distribution:


### PR DESCRIPTION
- disable "chatty" tests
- same as submission service test log settings