### PR TITLE
Declutter SubmissionController

### DIFF
--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/config/SubmissionServiceConfig.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/config/SubmissionServiceConfig.java
@@ -30,8 +30,8 @@ public class SubmissionServiceConfig {
 
   // Exponential moving average of the last N real request durations (in ms), where
   // N = fakeDelayMovingAverageSamples.
-  private Double initialFakeDelayMilliseconds;
-  private Double fakeDelayMovingAverageSamples;
+  private Long initialFakeDelayMilliseconds;
+  private Long fakeDelayMovingAverageSamples;
   private Integer retentionDays;
   private Integer connectionPoolSize;
   private Payload payload;
@@ -39,19 +39,19 @@ public class SubmissionServiceConfig {
   private Monitoring monitoring;
   private Client client;
 
-  public Double getInitialFakeDelayMilliseconds() {
+  public Long getInitialFakeDelayMilliseconds() {
     return initialFakeDelayMilliseconds;
   }
 
-  public void setInitialFakeDelayMilliseconds(Double initialFakeDelayMilliseconds) {
+  public void setInitialFakeDelayMilliseconds(Long initialFakeDelayMilliseconds) {
     this.initialFakeDelayMilliseconds = initialFakeDelayMilliseconds;
   }
 
-  public Double getFakeDelayMovingAverageSamples() {
+  public Long getFakeDelayMovingAverageSamples() {
     return fakeDelayMovingAverageSamples;
   }
 
-  public void setFakeDelayMovingAverageSamples(Double fakeDelayMovingAverageSamples) {
+  public void setFakeDelayMovingAverageSamples(Long fakeDelayMovingAverageSamples) {
     this.fakeDelayMovingAverageSamples = fakeDelayMovingAverageSamples;
   }
 

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/FakeDelayManager.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/FakeDelayManager.java
@@ -1,0 +1,62 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App
+ * ---
+ * Copyright (C) 2020 SAP SE and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.server.services.submission.controller;
+
+import app.coronawarn.server.services.submission.config.SubmissionServiceConfig;
+import org.apache.commons.math3.distribution.PoissonDistribution;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link FakeDelayManager} instances manage the response delay in the processing of fake (or "dummy") requests.
+ */
+@Component
+public class FakeDelayManager {
+
+  private final long movingAverageSampleSize;
+  private long fakeDelay;
+
+  public FakeDelayManager(SubmissionServiceConfig submissionServiceConfig) {
+    this.fakeDelay = submissionServiceConfig.getInitialFakeDelayMilliseconds();
+    this.movingAverageSampleSize = submissionServiceConfig.getFakeDelayMovingAverageSamples();
+  }
+
+  /**
+   * Returns the current fake delay after applying random jitter.
+   */
+  public long getJitteredFakeDelay() {
+    return new PoissonDistribution(fakeDelay).sample();
+  }
+
+  /**
+   * Updates the moving average for the request duration with the specified value.
+   */
+  public void updateFakeRequestDelay(long realRequestDuration) {
+    final long currentDelay = fakeDelay;
+    fakeDelay = currentDelay + (realRequestDuration - currentDelay) / movingAverageSampleSize;
+  }
+
+  /**
+   * Returns the current fake delay in seconds. Used for monitoring.
+   */
+  public Double getFakeDelayInSeconds() {
+    return fakeDelay / 1000.;
+  }
+}

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/FakeRequestController.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/FakeRequestController.java
@@ -1,0 +1,69 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App
+ * ---
+ * Copyright (C) 2020 SAP SE and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.server.services.submission.controller;
+
+import static app.coronawarn.server.services.submission.controller.SubmissionController.SUBMISSION_ROUTE;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import app.coronawarn.server.services.submission.monitoring.SubmissionMonitor;
+import io.micrometer.core.annotation.Timed;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.async.DeferredResult;
+
+@RestController
+@RequestMapping("/version/v1")
+public class FakeRequestController {
+
+  private final ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(4);
+  private final SubmissionMonitor submissionMonitor;
+  private final FakeDelayManager fakeDelayManager;
+
+  FakeRequestController(SubmissionMonitor submissionMonitor, FakeDelayManager fakeDelayManager) {
+    this.submissionMonitor = submissionMonitor;
+    this.fakeDelayManager = fakeDelayManager;
+  }
+
+  /**
+   * Handles "fake" requests. The concept of fake (or "dummy") requests is a privacy preserving measure which is
+   * characterized by having corona warn app send "dummy" requests in randomized intervals. These requests are not
+   * triggering any diagnosis key processing/storage on the server but simply result in an HTTP response with status
+   * code 200 (OK) after a dynamically calculated delay.
+   *
+   * @param fake The header flag, marking fake requests.
+   * @return An empty response body and HTTP status code 200 (OK).
+   */
+  @PostMapping(value = SUBMISSION_ROUTE, headers = {"cwa-fake!=0"})
+  @Timed(description = "Time spent handling fake submission.")
+  public DeferredResult<ResponseEntity<Void>> fakeRequest(@RequestHeader("cwa-fake") Integer fake) {
+    submissionMonitor.incrementRequestCounter();
+    submissionMonitor.incrementFakeRequestCounter();
+    long delay = fakeDelayManager.getJitteredFakeDelay();
+    DeferredResult<ResponseEntity<Void>> deferredResult = new DeferredResult<>();
+    scheduledExecutor.schedule(() -> deferredResult.setResult(ResponseEntity.ok().build()), delay, MILLISECONDS);
+    return deferredResult;
+  }
+}

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/monitoring/SubmissionMonitor.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/monitoring/SubmissionMonitor.java
@@ -21,23 +21,22 @@
 package app.coronawarn.server.services.submission.monitoring;
 
 import app.coronawarn.server.services.submission.config.SubmissionServiceConfig;
-import app.coronawarn.server.services.submission.controller.SubmissionController;
+import app.coronawarn.server.services.submission.controller.FakeDelayManager;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 /**
- * Provides functionality for monitoring the application logic of the
- * {@link app.coronawarn.server.services.submission.controller.SubmissionController}.
+ * Provides functionality for monitoring the diagnosis key submission handling logic.
  */
 @Component
 @ConfigurationProperties(prefix = "services.submission.monitoring")
-public class SubmissionControllerMonitor {
+public class SubmissionMonitor {
+
   private static final String SUBMISSION_CONTROLLER_CURRENT_FAKE_DELAY = "submission_controller.fake_delay_seconds";
 
   private final MeterRegistry meterRegistry;
-
   private final long batchSize;
   private BatchCounter requests;
   private BatchCounter realRequests;
@@ -45,20 +44,23 @@ public class SubmissionControllerMonitor {
   private BatchCounter invalidTanRequests;
 
   /**
-   * Constructor for {@link SubmissionControllerMonitor}. Initializes all counters to 0 upon being called.
+   * Constructor for {@link SubmissionMonitor}. Initializes all counters to 0 upon being called.
    *
    * @param meterRegistry the meterRegistry
+   * @param fakeDelayManager the fake delay manager whose fake delay will be monitored
    */
-  protected SubmissionControllerMonitor(MeterRegistry meterRegistry, SubmissionServiceConfig submissionServiceConfig) {
+  protected SubmissionMonitor(
+      MeterRegistry meterRegistry, SubmissionServiceConfig submissionServiceConfig, FakeDelayManager fakeDelayManager) {
     this.meterRegistry = meterRegistry;
     this.batchSize = submissionServiceConfig.getMonitoringBatchSize();
     initializeCounters();
+    initializeGauges(fakeDelayManager);
   }
 
   /**
    * We count the following values.
    *  <ul>
-   *    <li> All requests that come in to the {@link SubmissionController}.
+   *    <li> All requests that reach the controllers.
    *    <li> As part of all, the number of requests that are not fake.
    *    <li> As part of all, the number of requests that are fake.
    *    <li> As part of all, the number of requests for that the TAN-validation failed.
@@ -72,14 +74,14 @@ public class SubmissionControllerMonitor {
   }
 
   /**
-   * Initializes the gauges for the {@link SubmissionController} that is being monitored. Currently, only the delay time
-   * of fake requests is measured.
+   * Initializes the gauges for the {@link FakeDelayManager} that is being monitored. Currently, only the delay time of
+   * fake requests is measured.
    *
-   * @param submissionController the submission controller for which the gauges shall be initialized
+   * @param fakeDelayManager the fake request handler for which the gauges shall be initialized
    */
-  public void initializeGauges(SubmissionController submissionController) {
-    Gauge.builder(SUBMISSION_CONTROLLER_CURRENT_FAKE_DELAY, submissionController,
-        __ -> submissionController.getFakeDelayInSeconds())
+  private void initializeGauges(FakeDelayManager fakeDelayManager) {
+    Gauge.builder(SUBMISSION_CONTROLLER_CURRENT_FAKE_DELAY, fakeDelayManager,
+        __ -> fakeDelayManager.getFakeDelayInSeconds())
         .description("The time that fake requests are delayed to make them indistinguishable from real requests.")
         .register(meterRegistry);
   }

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/FakeDelayManagerTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/FakeDelayManagerTest.java
@@ -1,0 +1,83 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App
+ * ---
+ * Copyright (C) 2020 SAP SE and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.server.services.submission.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import app.coronawarn.server.services.submission.config.SubmissionServiceConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FakeDelayManagerTest {
+
+  private static final long VALID_DELAY = 1000L;
+  private static final long VALID_SAMPLE_SIZE = 1L;
+  private final SubmissionServiceConfig config = mock(SubmissionServiceConfig.class);
+
+  @BeforeEach
+  void setup() {
+    reset(config);
+  }
+
+  @Test
+  void jitteredFakeDelayGreaterThanOrEqualZero() {
+    FakeDelayManager fakeDelayManager = buildFakeDelayManager(1L, 1L);
+    long actFakeDelay = fakeDelayManager.getJitteredFakeDelay();
+    assertThat(actFakeDelay).isGreaterThanOrEqualTo(0L);
+  }
+
+  @Test
+  void testUpdateFakeDelayForSampleSizeOne() {
+    FakeDelayManager fakeDelayManager = buildFakeDelayManager(1000L, 1L);
+    fakeDelayManager.updateFakeRequestDelay(2000L);
+    assertThat(fakeDelayManager.getFakeDelayInSeconds()).isEqualTo(2d);
+  }
+
+  @Test
+  void testUpdateFakeDelayForSampleSizeTwo() {
+    FakeDelayManager fakeDelayManager = buildFakeDelayManager(1000L, 2L);
+    fakeDelayManager.updateFakeRequestDelay(3000L);
+    assertThat(fakeDelayManager.getFakeDelayInSeconds()).isEqualTo(2d);
+  }
+
+  @Test
+  void testUpdateFakeDelayForConstantRequestTime() {
+    FakeDelayManager fakeDelayManager = buildFakeDelayManager(1000L, 3L);
+    fakeDelayManager.updateFakeRequestDelay(1000L);
+    fakeDelayManager.updateFakeRequestDelay(1000L);
+    assertThat(fakeDelayManager.getFakeDelayInSeconds()).isEqualTo(1d);
+  }
+
+  @Test
+  void testGetFakeDelayInSecondsForInitialDelay() {
+    FakeDelayManager fakeDelayManager = buildFakeDelayManager(VALID_DELAY, VALID_SAMPLE_SIZE);
+    assertThat(fakeDelayManager.getFakeDelayInSeconds()).isEqualTo(VALID_DELAY / 1000d);
+  }
+
+  private FakeDelayManager buildFakeDelayManager(long initialDelay, long movingAverageSampleSize) {
+    when(config.getInitialFakeDelayMilliseconds()).thenReturn(initialDelay);
+    when(config.getFakeDelayMovingAverageSamples()).thenReturn(movingAverageSampleSize);
+    return new FakeDelayManager(config);
+  }
+}

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/FakeRequestControllerTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/FakeRequestControllerTest.java
@@ -1,0 +1,86 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App
+ * ---
+ * Copyright (C) 2020 SAP SE and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.server.services.submission.controller;
+
+import static app.coronawarn.server.services.submission.controller.RequestExecutor.buildOkHeaders;
+import static app.coronawarn.server.services.submission.controller.RequestExecutor.buildPayloadWithOneKey;
+import static app.coronawarn.server.services.submission.controller.RequestExecutor.setCwaFakeHeader;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.OK;
+
+import app.coronawarn.server.services.submission.monitoring.SubmissionMonitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"disable-ssl-client-verification", "disable-ssl-client-verification-verify-hostname"})
+class FakeRequestControllerTest {
+
+  @Autowired
+  private RequestExecutor executor;
+
+  @MockBean
+  private FakeDelayManager fakeDelayManager;
+
+  @MockBean
+  private SubmissionMonitor submissionMonitor;
+
+  @BeforeEach
+  public void setUpMocks() {
+    when(fakeDelayManager.getJitteredFakeDelay()).thenReturn(1000L);
+  }
+
+  @Test
+  void fakeRequestHandling() {
+    HttpHeaders headers = buildOkHeaders();
+    setCwaFakeHeader(headers, "1");
+
+    ResponseEntity<Void> actResponse = executor.executePost(buildPayloadWithOneKey(), headers);
+
+    verify(fakeDelayManager, times(1)).getJitteredFakeDelay();
+    verify(fakeDelayManager, never()).updateFakeRequestDelay(anyLong());
+    assertThat(actResponse.getStatusCode()).isEqualTo(OK);
+  }
+
+  @Test
+  void checkFakeRequestHandlingIsMonitored() {
+    HttpHeaders headers = buildOkHeaders();
+    setCwaFakeHeader(headers, "1");
+
+    executor.executePost(buildPayloadWithOneKey(), headers);
+
+    verify(submissionMonitor, times(1)).incrementRequestCounter();
+    verify(submissionMonitor, never()).incrementRealRequestCounter();
+    verify(submissionMonitor, times(1)).incrementFakeRequestCounter();
+    verify(submissionMonitor, never()).incrementInvalidTanRequestCounter();
+  }
+}

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/PayloadValidationTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/PayloadValidationTest.java
@@ -63,13 +63,13 @@ class PayloadValidationTest {
 
   @Test
   void check400ResponseStatusForMissingKeys() {
-    ResponseEntity<Void> actResponse = executor.executeRequest(Lists.emptyList(), buildOkHeaders());
+    ResponseEntity<Void> actResponse = executor.executePost(Lists.emptyList(), buildOkHeaders());
     assertThat(actResponse.getStatusCode()).isEqualTo(BAD_REQUEST);
   }
 
   @Test
   void check400ResponseStatusForTooManyKeys() {
-    ResponseEntity<Void> actResponse = executor.executeRequest(buildPayloadWithTooManyKeys(), buildOkHeaders());
+    ResponseEntity<Void> actResponse = executor.executePost(buildPayloadWithTooManyKeys(), buildOkHeaders());
 
     assertThat(actResponse.getStatusCode()).isEqualTo(BAD_REQUEST);
   }
@@ -89,7 +89,7 @@ class PayloadValidationTest {
         buildTemporaryExposureKey(VALID_KEY_DATA_1, rollingStartIntervalNumber, 1),
         buildTemporaryExposureKey(VALID_KEY_DATA_2, rollingStartIntervalNumber, 2));
 
-    ResponseEntity<Void> actResponse = executor.executeRequest(keysWithDuplicateStartIntervalNumber, buildOkHeaders());
+    ResponseEntity<Void> actResponse = executor.executePost(keysWithDuplicateStartIntervalNumber, buildOkHeaders());
 
     assertThat(actResponse.getStatusCode()).isEqualTo(BAD_REQUEST);
   }
@@ -104,7 +104,7 @@ class PayloadValidationTest {
         buildTemporaryExposureKey(VALID_KEY_DATA_3, rollingStartIntervalNumber3, 3),
         buildTemporaryExposureKey(VALID_KEY_DATA_2, rollingStartIntervalNumber2, 2));
 
-    ResponseEntity<Void> actResponse = executor.executeRequest(keysWithDuplicateStartIntervalNumber, buildOkHeaders());
+    ResponseEntity<Void> actResponse = executor.executePost(keysWithDuplicateStartIntervalNumber, buildOkHeaders());
 
     assertThat(actResponse.getStatusCode()).isEqualTo(OK);
   }
@@ -117,7 +117,7 @@ class PayloadValidationTest {
         buildTemporaryExposureKey(VALID_KEY_DATA_1, rollingStartIntervalNumber1, 1),
         buildTemporaryExposureKey(VALID_KEY_DATA_2, rollingStartIntervalNumber2, 2));
 
-    ResponseEntity<Void> actResponse = executor.executeRequest(keysWithDuplicateStartIntervalNumber, buildOkHeaders());
+    ResponseEntity<Void> actResponse = executor.executePost(keysWithDuplicateStartIntervalNumber, buildOkHeaders());
 
     assertThat(actResponse.getStatusCode()).isEqualTo(BAD_REQUEST);
   }
@@ -132,7 +132,7 @@ class PayloadValidationTest {
         buildTemporaryExposureKey(VALID_KEY_DATA_3, rollingStartIntervalNumber3, 3),
         buildTemporaryExposureKey(VALID_KEY_DATA_2, rollingStartIntervalNumber2, 2));
 
-    ResponseEntity<Void> actResponse = executor.executeRequest(keysWithDuplicateStartIntervalNumber, buildOkHeaders());
+    ResponseEntity<Void> actResponse = executor.executePost(keysWithDuplicateStartIntervalNumber, buildOkHeaders());
 
     assertThat(actResponse.getStatusCode()).isEqualTo(OK);
   }

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/RequestExecutor.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/RequestExecutor.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.Collections;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -43,21 +44,25 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class RequestExecutor {
+
   public static final String VALID_KEY_DATA_1 = "testKey111111111";
   public static final String VALID_KEY_DATA_2 = "testKey222222222";
   public static final String VALID_KEY_DATA_3 = "testKey333333333";
   private static final URI SUBMISSION_URL = URI.create("/version/v1/diagnosis-keys");
+
   private final TestRestTemplate testRestTemplate;
 
   public RequestExecutor(TestRestTemplate testRestTemplate) {
     this.testRestTemplate = testRestTemplate;
   }
 
-  public ResponseEntity<Void> executeRequest(Collection<TemporaryExposureKey> keys, HttpHeaders headers) {
+  public ResponseEntity<Void> execute(HttpMethod method, RequestEntity<SubmissionPayload> requestEntity) {
+    return testRestTemplate.exchange(SUBMISSION_URL, method, requestEntity, Void.class);
+  }
+
+  public ResponseEntity<Void> executePost(Collection<TemporaryExposureKey> keys, HttpHeaders headers) {
     SubmissionPayload body = SubmissionPayload.newBuilder().addAllKeys(keys).build();
-    RequestEntity<SubmissionPayload> request =
-        new RequestEntity<>(body, headers, HttpMethod.POST, SUBMISSION_URL);
-    return testRestTemplate.postForEntity(SUBMISSION_URL, request, Void.class);
+    return execute(HttpMethod.POST, new RequestEntity<>(body, headers, HttpMethod.POST, SUBMISSION_URL));
   }
 
   public static HttpHeaders buildOkHeaders() {
@@ -94,5 +99,9 @@ public class RequestExecutor {
         .ofInstant(Instant.now(), UTC)
         .minusDays(daysAgo).atStartOfDay()
         .toEpochSecond(UTC) / (60 * 10));
+  }
+
+  public static Collection<TemporaryExposureKey> buildPayloadWithOneKey() {
+    return Collections.singleton(buildTemporaryExposureKey(VALID_KEY_DATA_1, 1, 3));
   }
 }

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/monitoring/SubmissionMonitorTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/monitoring/SubmissionMonitorTest.java
@@ -1,0 +1,78 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App
+ * ---
+ * Copyright (C) 2020 SAP SE and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.server.services.submission.monitoring;
+
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import app.coronawarn.server.services.submission.config.SubmissionServiceConfig;
+import app.coronawarn.server.services.submission.controller.FakeDelayManager;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MeterRegistryMock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SubmissionMonitorTest {
+
+  private final Counter meterCounter = mock(Counter.class);
+  private final SubmissionServiceConfig submissionServiceConfig = mock(SubmissionServiceConfig.class);
+  private MeterRegistry meterRegistry;
+  private SubmissionMonitor submissionMonitor;
+
+  @BeforeEach
+  void setup() {
+    reset(meterCounter);
+    reset(submissionServiceConfig);
+    meterRegistry = spy(new MeterRegistryMock(meterCounter));
+    when(submissionServiceConfig.getMonitoringBatchSize()).thenReturn(1L);
+    submissionMonitor = new SubmissionMonitor(meterRegistry, submissionServiceConfig, mock(FakeDelayManager.class));
+  }
+
+  @Test
+  void incrementFakeRequestCounterIncrementsEnclosedCounter() {
+    submissionMonitor.incrementFakeRequestCounter();
+    verify(meterCounter, times(1)).increment(anyDouble());
+  }
+
+  @Test
+  void incrementInvalidTanRequestCounterIncrementsEnclosedCounter() {
+    submissionMonitor.incrementInvalidTanRequestCounter();
+    verify(meterCounter, times(1)).increment(anyDouble());
+  }
+
+  @Test
+  void incrementRealRequestCounterIncrementsEnclosedCounter() {
+    submissionMonitor.incrementRealRequestCounter();
+    verify(meterCounter, times(1)).increment(anyDouble());
+  }
+
+  @Test
+  void incrementRequestCounterIncrementsEnclosedCounter() {
+    submissionMonitor.incrementRequestCounter();
+    verify(meterCounter, times(1)).increment(anyDouble());
+  }
+}


### PR DESCRIPTION
- Extracts logic for managing fake requests into ``FakeRequestController`` and ``FakeDelayManager``.
- Renames ``SubmissionControllerMonitor`` to ``SubmissionMonitor``
- Adds tests.

Results:
- Fewer responsibilities and state bundled in ``SubmissionController``.
- Better tested fake request handling.