### PR TITLE
rename package 'decorators' to 'decorator' (issue #545)

### DIFF
--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/structure/directory/decorator/DirectoryDecoratorTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/structure/directory/decorator/DirectoryDecoratorTest.java
@@ -18,7 +18,7 @@
  * ---license-end
  */
 
-package app.coronawarn.server.services.distribution.assembly.structure.directory.decorators;
+package app.coronawarn.server.services.distribution.assembly.structure.directory.decorator;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.verify;
 import app.coronawarn.server.services.distribution.assembly.structure.WritableOnDisk;
 import app.coronawarn.server.services.distribution.assembly.structure.directory.Directory;
 import app.coronawarn.server.services.distribution.assembly.structure.directory.DirectoryOnDisk;
-import app.coronawarn.server.services.distribution.assembly.structure.directory.decorator.DirectoryDecorator;
 import app.coronawarn.server.services.distribution.assembly.structure.util.ImmutableStack;
 import org.junit.jupiter.api.Test;
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/structure/directory/decorator/indexing/IndexingDecoratorTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/structure/directory/decorator/indexing/IndexingDecoratorTest.java
@@ -18,7 +18,7 @@
  * ---license-end
  */
 
-package app.coronawarn.server.services.distribution.assembly.structure.directory.decorators.indexing;
+package app.coronawarn.server.services.distribution.assembly.structure.directory.decorator.indexing;
 
 import static app.coronawarn.server.services.distribution.common.Helpers.prepareAndWrite;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,7 +28,6 @@ import app.coronawarn.server.services.distribution.assembly.structure.directory.
 import app.coronawarn.server.services.distribution.assembly.structure.directory.DirectoryOnDisk;
 import app.coronawarn.server.services.distribution.assembly.structure.directory.IndexDirectory;
 import app.coronawarn.server.services.distribution.assembly.structure.directory.IndexDirectoryOnDisk;
-import app.coronawarn.server.services.distribution.assembly.structure.directory.decorator.indexing.IndexingDecoratorOnDisk;
 import app.coronawarn.server.services.distribution.assembly.structure.file.FileOnDiskWithChecksum;
 import java.io.File;
 import java.io.FileReader;


### PR DESCRIPTION
Resolves #545.


