### PR TITLE
Add Anchore container vulnerability scanning

### DIFF
--- a/.github/workflows/docker-images-analysis.yaml
+++ b/.github/workflows/docker-images-analysis.yaml
@@ -1,0 +1,55 @@
+name: Docker Images Analysis
+on:
+  push:
+    paths:
+      - '**/Dockerfile'
+      - '.github/workflows/docker-images-analysis.yaml'
+  schedule:
+      - cron: '0 5 * * 4'
+jobs:
+  distribution-docker-image-scan:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v2
+      - name: Build the Docker image
+        run: docker build . --file services/distribution/Dockerfile --tag localbuild/testimage:latest
+      - uses: anchore/scan-action@master
+        with:
+          image-reference: "localbuild/testimage:latest"
+          dockerfile-path: "services/distribution/Dockerfile"
+          fail-build: true
+          acs-report-enable: true
+          acs-report-severity-cutoff: "High"
+      - name: anchore inline scan JSON results
+        run: for j in `ls ./anchore-reports/*.json`; do echo "---- ${j} ----"; cat ${j}; echo; done
+      - name: Prepare SARIF report for distribution Dockerfile
+        run: |
+          sed -i.bak -e 's|"name": "Anchore Container Vulnerability Report"|"name": "Anchore Distribution Docker"|g' results.sarif
+          cat results.sarif
+      - name: upload Anchore scan SARIF report
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: results.sarif
+  submission-docker-image-scan:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v2
+      - name: Build the Docker image
+        run: docker build . --file services/submission/Dockerfile --tag localbuild/testimage:latest
+      - uses: anchore/scan-action@master
+        with:
+          image-reference: "localbuild/testimage:latest"
+          dockerfile-path: "services/submission/Dockerfile"
+          fail-build: true
+          acs-report-enable: true
+          acs-report-severity-cutoff: "High"
+      - name: anchore inline scan JSON results
+        run: for j in `ls ./anchore-reports/*.json`; do echo "---- ${j} ----"; cat ${j}; echo; done
+      - name: Prepare SARIF report for submission dockerfile
+        run: |
+          sed -i.bak -e 's|"name": "Anchore Container Vulnerability Report"|"name": "Anchore Submission Docker"|g' results.sarif
+          cat results.sarif
+      - name: upload Anchore scan SARIF report
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

[cwa-server](https://github.com/jonico/cwa-server) uses two Docker images - the [submission](https://github.com/corona-warn-app/cwa-server/blob/master/services/submission/Dockerfile) and the [distribution image](https://github.com/corona-warn-app/cwa-server/blob/master/services/distribution/Dockerfile) - that may contain vulnerable components.
This PR introduces Docker container vulnerability scanning based on the [Open Source Anchore Scanning GitHub Action](https://anchore.com/blog/anchore-action-integrated-github-experience/) and report its findings into the Code scanning alert section of the security tab:

![image](https://user-images.githubusercontent.com/1872314/84502980-a2e40080-acb9-11ea-981c-2a884c2bc0e1.png)

For each Docker image, one section is added. At the moment, 22 negligible findings (lowest warning level) show up - so the used base image (`gcr.io/distroless/java:11`) has no known security vulnerabilities 🎉 

The GitHub Action workflow triggers are designed that
* they run once a week to check whether there is any new vulnerability in the built Docker images
* they run whenever a Dockerfile is changed to check the differences
* they run whenever the GitHub Actions workflow file is changed itself

If this workflow should ever encounter a vulnerability with a severity > Medium, it will fail with an error; [the severity cut-off policy can be adjusted](https://github.com/anchore/scan-action#action-inputs) if needed.
