### PR TITLE
Updated timestamp format

### DIFF
--- a/services/distribution/src/main/resources/log4j2-dev.xml
+++ b/services/distribution/src/main/resources/log4j2-dev.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
   <Properties>
     <Property name="LOG_EXCEPTION_CONVERSION_WORD">%xwEx</Property>
-    <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssXXX</Property>
+    <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
     <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
   </Properties>
   <Appenders>

--- a/services/distribution/src/main/resources/log4j2.xml
+++ b/services/distribution/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
   <Properties>
-    <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssXXX</Property>
+    <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
     <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %m %replace{%rException}{\n}{\u2028}%n</Property>
   </Properties>
   <Appenders>

--- a/services/submission/src/main/resources/log4j2-dev.xml
+++ b/services/submission/src/main/resources/log4j2-dev.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
   <Properties>
     <Property name="LOG_EXCEPTION_CONVERSION_WORD">%xwEx</Property>
-    <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssXXX</Property>
+    <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
     <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
   </Properties>
   <Appenders>

--- a/services/submission/src/main/resources/log4j2.xml
+++ b/services/submission/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
   <Properties>
-    <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssXXX</Property>
+    <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
     <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %m %replace{%rException}{\n}{\u2028}%n</Property>
   </Properties>
   <Appenders>


### PR DESCRIPTION
This change ensures that log timestamp is always the same length, regardless of the machine's time zone:

`2020-06-12T13:39:23+0200`
`2020-06-12T13:39:23+0000` (rather than `2020-06-12T13:39:23Z` )