### PR TITLE
Fix fake delay updates

### DIFF
--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
@@ -113,20 +113,21 @@ public class SubmissionController {
   private DeferredResult<ResponseEntity<Void>> buildRealDeferredResult(SubmissionPayload exposureKeys, String tan) {
     DeferredResult<ResponseEntity<Void>> deferredResult = new DeferredResult<>();
 
+    StopWatch stopWatch = new StopWatch();
+    stopWatch.start();
     try {
-      StopWatch stopWatch = new StopWatch();
-      stopWatch.start();
       if (!this.tanVerifier.verifyTan(tan)) {
         submissionControllerMonitor.incrementInvalidTanRequestCounter();
         deferredResult.setResult(buildTanInvalidResponseEntity());
       } else {
         persistDiagnosisKeysPayload(exposureKeys);
         deferredResult.setResult(buildSuccessResponseEntity());
-        stopWatch.stop();
-        updateFakeDelay(stopWatch.getTotalTimeMillis());
       }
     } catch (Exception e) {
       deferredResult.setErrorResult(e);
+    } finally {
+      stopWatch.stop();
+      updateFakeDelay(stopWatch.getTotalTimeMillis());
     }
 
     return deferredResult;

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
@@ -60,7 +60,7 @@ public class SubmissionController {
   public static final String SUBMISSION_ROUTE = "/diagnosis-keys";
 
   private final SubmissionControllerMonitor submissionControllerMonitor;
-  private final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+  private final ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(4);
   private final DiagnosisKeyService diagnosisKeyService;
   private final TanVerifier tanVerifier;
   private final Double fakeDelayMovingAverageSamples;


### PR DESCRIPTION
### Before:
- Fake delay only gets updated on requests with valid TAN
- Scheduled executor becomes flooded with tasks and introduces additional delay
- This causes fake requests to be distinguishable from real requests under high load

Low load:
![image](https://user-images.githubusercontent.com/8984460/84566188-94582080-ad6f-11ea-8145-7c0dd9992c5f.png)

High load:
![image](https://user-images.githubusercontent.com/8984460/84566213-c36e9200-ad6f-11ea-9b2f-ed9d5d252664.png)

### After:
- Fake delay gets updated on all requests (valid or invalid TAN)
- Scheduled executor gets more threads to reduce additional delay
- Fake requests are indistinguishable from real requests even under high load

Low load:
![image](https://user-images.githubusercontent.com/8984460/84566417-26acf400-ad71-11ea-8ad5-4313e1804a29.png)

High load:
![image](https://user-images.githubusercontent.com/8984460/84566079-b1d8ba80-ad6e-11ea-8681-a1acba8cbaba.png)

### Note:
- Under extreme load (DDoS scenario), fake requests might still become slower than "real" requests, because also the 4 threads will eventually be flooded with tasks (although with this PR, that will happen a bit later). Not sure if there is a solution to this, other than request throttling or just outscaling the attack. Increasing the scheduled executor service thread pool size even more might improve this up to some point, but will also level off eventually.

Closes #474 