### PR TITLE
S3 Continuation Token

### DIFF
--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
@@ -129,8 +129,7 @@ class S3ClientWrapperTest {
 
   @Test
   void testGetObjectsSendsCorrectRequest() {
-    when(s3Client.listObjectsV2(any(ListObjectsV2Request.class)))
-        .thenReturn(ListObjectsV2Response.builder().isTruncated(false).build());
+    when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(ListObjectsV2Response.builder().build());
 
     s3ClientWrapper.getObjects(VALID_BUCKET_NAME, VALID_PREFIX);
 
@@ -183,7 +182,7 @@ class S3ClientWrapperTest {
         s3Object -> software.amazon.awssdk.services.s3.model.S3Object.builder()
             .key(s3Object.getObjectName()))
         .map(SdkBuilder::build).collect(Collectors.toList());
-    return ListObjectsV2Response.builder().isTruncated(false).contents(responseObjects).build();
+    return ListObjectsV2Response.builder().contents(responseObjects).build();
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Adds handling of `isTruncated`, which might be returned by `listObjectsV2`. Requests will be repeated until all objects are retrieved.

Closes #562 