### PR TITLE
Add validator for submissionTimestamp (closes #557)

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
@@ -24,6 +24,7 @@ import static java.time.ZoneOffset.UTC;
 
 import app.coronawarn.server.common.persistence.domain.DiagnosisKeyBuilders.Builder;
 import app.coronawarn.server.common.persistence.domain.validation.ValidRollingStartIntervalNumber;
+import app.coronawarn.server.common.persistence.domain.validation.ValidSubmissionTimestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -70,6 +71,7 @@ public class DiagnosisKey {
   @Range(min = 0, max = 8, message = "Risk level must be between 0 and 8.")
   private int transmissionRiskLevel;
 
+  @ValidSubmissionTimestamp
   private long submissionTimestamp;
 
   protected DiagnosisKey() {

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilder.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilder.java
@@ -24,6 +24,7 @@ import static app.coronawarn.server.common.persistence.domain.DiagnosisKeyBuilde
 import static app.coronawarn.server.common.persistence.domain.DiagnosisKeyBuilders.FinalBuilder;
 import static app.coronawarn.server.common.persistence.domain.DiagnosisKeyBuilders.RollingStartIntervalNumberBuilder;
 import static app.coronawarn.server.common.persistence.domain.DiagnosisKeyBuilders.TransmissionRiskLevelBuilder;
+import static app.coronawarn.server.common.persistence.domain.validation.ValidSubmissionTimestampValidator.SECONDS_PER_HOUR;
 
 import app.coronawarn.server.common.persistence.exception.InvalidDiagnosisKeyException;
 import app.coronawarn.server.common.protocols.external.exposurenotification.TemporaryExposureKey;
@@ -47,7 +48,7 @@ public class DiagnosisKeyBuilder implements
   private int rollingStartIntervalNumber;
   private int rollingPeriod = DiagnosisKey.EXPECTED_ROLLING_PERIOD;
   private int transmissionRiskLevel;
-  private long submissionTimestamp = -1L;
+  private Long submissionTimestamp = null;
 
   DiagnosisKeyBuilder() {
   }
@@ -93,9 +94,9 @@ public class DiagnosisKeyBuilder implements
 
   @Override
   public DiagnosisKey build() {
-    if (submissionTimestamp < 0) {
+    if (submissionTimestamp == null) {
       // hours since epoch
-      submissionTimestamp = Instant.now().getEpochSecond() / 3600L;
+      submissionTimestamp = Instant.now().getEpochSecond() / SECONDS_PER_HOUR;
     }
 
     var diagnosisKey = new DiagnosisKey(

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/validation/ValidSubmissionTimestamp.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/validation/ValidSubmissionTimestamp.java
@@ -1,0 +1,58 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App
+ * ---
+ * Copyright (C) 2020 SAP SE and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.server.common.persistence.domain.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Constraint(validatedBy = ValidSubmissionTimestampValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ValidSubmissionTimestamp {
+
+  /**
+   * Error message.
+   *
+   * @return the error message
+   */
+  String message() default "Submission timestamp (hours since epoch)"
+      + " must be greater or equal 0 and cannot be in the future.";
+
+  /**
+   * Groups.
+   *
+   * @return
+   */
+  Class<?>[] groups() default {};
+
+  /**
+   * Payload.
+   *
+   * @return
+   */
+  Class<? extends Payload>[] payload() default {};
+}

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/validation/ValidSubmissionTimestampValidator.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/validation/ValidSubmissionTimestampValidator.java
@@ -1,0 +1,38 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App
+ * ---
+ * Copyright (C) 2020 SAP SE and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.server.common.persistence.domain.validation;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ValidSubmissionTimestampValidator
+    implements ConstraintValidator<ValidSubmissionTimestamp, Long> {
+
+  public static final long SECONDS_PER_HOUR = TimeUnit.HOURS.toSeconds(1);
+
+  @Override
+  public boolean isValid(Long submissionTimestamp, ConstraintValidatorContext constraintValidatorContext) {
+    long currentHoursSinceEpoch = Instant.now().getEpochSecond() / SECONDS_PER_HOUR;
+    return submissionTimestamp >= 0L && submissionTimestamp <= currentHoursSinceEpoch;
+  }
+}

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
@@ -20,6 +20,7 @@
 
 package app.coronawarn.server.common.persistence.service;
 
+import static app.coronawarn.server.common.persistence.domain.validation.ValidSubmissionTimestampValidator.SECONDS_PER_HOUR;
 import static java.time.ZoneOffset.UTC;
 
 import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
@@ -109,7 +110,7 @@ public class DiagnosisKeyService {
     long threshold = LocalDateTime
         .ofInstant(Instant.now(), UTC)
         .minusDays(daysToRetain)
-        .toEpochSecond(UTC) / 3600L;
+        .toEpochSecond(UTC) / SECONDS_PER_HOUR;
     int numberOfDeletions = keyRepository.deleteBySubmissionTimestampIsLessThanEqual(threshold);
     logger.info("Deleted {} diagnosis key(s) with a submission timestamp older than {} day(s) ago.",
         numberOfDeletions, daysToRetain);

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilderTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilderTest.java
@@ -20,17 +20,19 @@
 
 package app.coronawarn.server.common.persistence.domain;
 
+import static app.coronawarn.server.common.persistence.domain.validation.ValidSubmissionTimestampValidator.SECONDS_PER_HOUR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.catchThrowable;
-
 import app.coronawarn.server.common.persistence.exception.InvalidDiagnosisKeyException;
 import app.coronawarn.server.common.protocols.external.exposurenotification.TemporaryExposureKey;
 import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -189,6 +191,33 @@ class DiagnosisKeyBuilderTest {
         .doesNotThrowAnyException();
   }
 
+  @ParameterizedTest
+  @ValueSource(longs = {-1L, Long.MAX_VALUE})
+  void submissionTimestampMustBeValid(long submissionTimestamp) {
+    assertThat(
+        catchThrowable(() -> keyWithSubmissionTimestamp(submissionTimestamp)))
+        .isInstanceOf(InvalidDiagnosisKeyException.class);
+  }
+
+  @Test
+  void submissionTimestampMustNotBeInTheFuture() {
+    assertThat(catchThrowable(
+        () -> keyWithSubmissionTimestamp(getCurrentHoursSinceEpoch() + 1)))
+            .isInstanceOf(InvalidDiagnosisKeyException.class);
+    assertThat(catchThrowable(() -> keyWithSubmissionTimestamp(
+        Instant.now().getEpochSecond() /* accidentally forgot to divide by SECONDS_PER_HOUR */)))
+            .isInstanceOf(InvalidDiagnosisKeyException.class);
+  }
+
+  @Test
+  void submissionTimestampDoesNotThrowOnValid() {
+    assertThatCode(() -> keyWithSubmissionTimestamp(0L)).doesNotThrowAnyException();
+    assertThatCode(() -> keyWithSubmissionTimestamp(getCurrentHoursSinceEpoch())).doesNotThrowAnyException();
+    assertThatCode(
+        () -> keyWithSubmissionTimestamp(Instant.now().minus(Duration.ofHours(2)).getEpochSecond() / SECONDS_PER_HOUR))
+            .doesNotThrowAnyException();
+  }
+  
   private DiagnosisKey keyWithKeyData(byte[] expKeyData) {
     return DiagnosisKey.builder()
         .withKeyData(expKeyData)
@@ -218,12 +247,20 @@ class DiagnosisKeyBuilderTest {
         .withTransmissionRiskLevel(expTransmissionRiskLevel).build();
   }
 
+  private DiagnosisKey keyWithSubmissionTimestamp(long submissionTimestamp) {
+    return DiagnosisKey.builder()
+        .withKeyData(expKeyData)
+        .withRollingStartIntervalNumber(expRollingStartIntervalNumber)
+        .withTransmissionRiskLevel(expTransmissionRiskLevel)
+        .withSubmissionTimestamp(submissionTimestamp).build();
+  }
+
   private void assertDiagnosisKeyEquals(DiagnosisKey actDiagnosisKey) {
     assertDiagnosisKeyEquals(actDiagnosisKey, getCurrentHoursSinceEpoch());
   }
 
   private long getCurrentHoursSinceEpoch() {
-    return Instant.now().getEpochSecond() / 3600L;
+    return Instant.now().getEpochSecond() / SECONDS_PER_HOUR;
   }
 
   private void assertDiagnosisKeyEquals(DiagnosisKey actDiagnosisKey, long expSubmissionTimestamp) {

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTest.java
@@ -21,6 +21,8 @@
 package app.coronawarn.server.common.persistence.service;
 
 import static app.coronawarn.server.common.persistence.service.DiagnosisKeyServiceTestHelper.assertDiagnosisKeysEqual;
+import static app.coronawarn.server.common.persistence.service.DiagnosisKeyServiceTestHelper.buildDiagnosisKeyForDateTime;
+import static app.coronawarn.server.common.persistence.service.DiagnosisKeyServiceTestHelper.buildDiagnosisKeyForSubmissionTimestamp;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -33,7 +35,6 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -170,20 +171,5 @@ class DiagnosisKeyServiceTest {
 
     assertThat(actKeys.size()).isEqualTo(1);
     assertThat(actKeys.iterator().next().getTransmissionRiskLevel()).isEqualTo(2);
-  }
-
-  public static DiagnosisKey buildDiagnosisKeyForSubmissionTimestamp(long submissionTimeStamp) {
-    byte[] randomBytes = new byte[16];
-    Random random = new Random(submissionTimeStamp);
-    random.nextBytes(randomBytes);
-    return DiagnosisKey.builder()
-        .withKeyData(randomBytes)
-        .withRollingStartIntervalNumber(600)
-        .withTransmissionRiskLevel(2)
-        .withSubmissionTimestamp(submissionTimeStamp).build();
-  }
-
-  public static DiagnosisKey buildDiagnosisKeyForDateTime(OffsetDateTime dateTime) {
-    return buildDiagnosisKeyForSubmissionTimestamp(dateTime.toEpochSecond() / 3600);
   }
 }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTestHelper.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTestHelper.java
@@ -23,7 +23,9 @@ package app.coronawarn.server.common.persistence.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Random;
 
 public class DiagnosisKeyServiceTestHelper {
 
@@ -47,5 +49,20 @@ public class DiagnosisKeyServiceTestHelper {
       assertThat(actKey.getSubmissionTimestamp()).withFailMessage("submissionTimestamp mismatch")
           .isEqualTo(expKey.getSubmissionTimestamp());
     }
+  }
+
+  public static DiagnosisKey buildDiagnosisKeyForSubmissionTimestamp(long submissionTimeStamp) {
+    byte[] randomBytes = new byte[16];
+    Random random = new Random(submissionTimeStamp);
+    random.nextBytes(randomBytes);
+    return DiagnosisKey.builder()
+        .withKeyData(randomBytes)
+        .withRollingStartIntervalNumber(600)
+        .withTransmissionRiskLevel(2)
+        .withSubmissionTimestamp(submissionTimeStamp).build();
+  }
+
+  public static DiagnosisKey buildDiagnosisKeyForDateTime(OffsetDateTime dateTime) {
+    return buildDiagnosisKeyForSubmissionTimestamp(dateTime.toEpochSecond() / 3600);
   }
 }


### PR DESCRIPTION
Similar to ValidRollingStartIntervalNumberValidator,
add ValidSubmissionTimestampValidator for field
submissionTimestamp.
Valid values are between 0 and the current hours since epoch.
Change field type in DiagnosisKeyBuilder to Long
object in order to distinguish a non-set default value
(null) from a negative value.

Fixes https://github.com/corona-warn-app/cwa-server/issues/557