### PR TITLE
Integration Testing on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,9 @@ jobs:
           paths:
             - ~/.m2
           key: cwa-server-{{ checksum "~/pom-checksum" }}
-      - run: mvn --batch-mode package
+      - run:
+          name: Test and Package
+          command: mvn failsafe:integration-test --batch-mode package
       - run:
           name: Save test results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 jobs:
   build:
     working_directory: ~/cwa-server
-    docker:
-      - image: circleci/openjdk:11-jdk
+    machine:
+      image: ubuntu-1604:202004-01
     steps:
       - checkout
       - run:
@@ -16,6 +16,12 @@ jobs:
           key: cwa-server-{{ checksum "~/pom-checksum" }}
       - run: mvn --batch-mode dependency:go-offline
       - run:
+          name: Update to OpenJDK 11
+          command: |
+            sudo apt-get install openjdk-11-jre
+            sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+            java -version
+      - run:
           name: Analyze on SonarCloud
           command: mvn --batch-mode verify sonar:sonar --fail-never
       - save_cache:
@@ -23,8 +29,11 @@ jobs:
             - ~/.m2
           key: cwa-server-{{ checksum "~/pom-checksum" }}
       - run:
-          name: Test and Package
-          command: mvn failsafe:integration-test --batch-mode package
+          name: Run all tests on Docker
+          command: |
+            docker-compose -f docker-compose-it.yaml up -d objectstore
+            docker-compose -f docker-compose-it.yaml up -d create-bucket
+            docker-compose -f docker-compose-it.yaml run run-tests
       - run:
           name: Save test results
           command: |

--- a/docker-compose-it.yaml
+++ b/docker-compose-it.yaml
@@ -1,0 +1,41 @@
+version: '3'
+services:
+  objectstore:
+    image: "zenko/cloudserver"
+    volumes:
+      - objectstore_volume:/data
+    ports:
+      - "8003:8000"
+    environment:
+      ENDPOINT: objectstore
+      REMOTE_MANAGEMENT_DISABLE: 1
+      SCALITY_ACCESS_KEY_ID: ${OBJECTSTORE_ACCESSKEY}
+      SCALITY_SECRET_ACCESS_KEY: ${OBJECTSTORE_SECRETKEY}
+  create-bucket:
+    image: amazon/aws-cli
+    environment:
+      - AWS_ACCESS_KEY_ID=${OBJECTSTORE_ACCESSKEY}
+      - AWS_SECRET_ACCESS_KEY=${OBJECTSTORE_SECRETKEY}
+    entrypoint: ["/root/scripts/wait-for-it/wait-for-it.sh", "objectstore:8000", "-t", "30", "--"]
+    volumes:
+      - ./scripts/wait-for-it:/root/scripts/wait-for-it
+    command: aws s3api create-bucket --bucket cwa --endpoint-url http://objectstore:8000 --acl public-read
+    depends_on:
+      - objectstore
+  run-tests:
+    stop_signal: SIGKILL
+    working_dir: $PWD
+    environment:
+      - CWA_OBJECTSTORE_ENDPOINT=http://objectstore
+      - CWA_OBJECTSTORE_PORT=8000
+    depends_on:
+     - objectstore
+     - create-bucket
+    image: maven:3.6.3-jdk-11
+    command: mvn failsafe:integration-test --batch-mode package
+    volumes:
+      - $PWD:$PWD
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ~/.m2:/root/.m2
+volumes:
+  objectstore_volume:

--- a/services/distribution/pom.xml
+++ b/services/distribution/pom.xml
@@ -18,6 +18,18 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>3.0.0-M4</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M3</version>

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccessIT.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccessIT.java
@@ -46,7 +46,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @SpringBootTest(classes = {ObjectStoreAccess.class, ObjectStorePublishingConfig.class})
 @EnableConfigurationProperties(value = DistributionServiceConfig.class)
 @Tag("s3-integration")
-class ObjectStoreAccessTest {
+class ObjectStoreAccessIT {
 
   private static final String testRunId = "testing/cwa/" + UUID.randomUUID().toString() + "/";
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/S3PublisherIT.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/S3PublisherIT.java
@@ -44,7 +44,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @SpringBootTest(classes = {ObjectStoreAccess.class, ObjectStorePublishingConfig.class, S3Publisher.class})
 @EnableConfigurationProperties(value = DistributionServiceConfig.class)
 @Tag("s3-integration")
-class S3PublisherIntegrationTest {
+class S3PublisherIT {
 
   private final String rootTestFolder = "objectstore/publisher/";
 


### PR DESCRIPTION
Adds Failsafe Maven plugin to run the integration tests. Renames the integration test files to the naming convention. Adds `docker-compose-it.yml` for running integration tests via `docker-compose`. Changes the executor for circleCI to machine, as docker setup was not working. 