### PR TITLE
Multi-line Exception logging: Replace all CR, LF and CRLF

### DIFF
--- a/services/distribution/src/main/resources/log4j2.xml
+++ b/services/distribution/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %m %replace{%rException}{\n}{\u2028}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %m %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">

--- a/services/submission/src/main/resources/log4j2.xml
+++ b/services/submission/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %m %replace{%rException}{\n}{\u2028}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %m %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

We replace all EOL's with `\u2028` in logged Exceptions. This is in order to avoid multiple log entries in monitoring tools for error message with multi-lined exception.

This PR makes sure to replace all possible combinations of EOL's - CR, LF and CRLF
