### PR TITLE
Use non-root user inside the containers

### DIFF
--- a/services/distribution/Dockerfile
+++ b/services/distribution/Dockerfile
@@ -28,4 +28,5 @@ FROM gcr.io/distroless/java:11
 COPY --from=build /DpkgHelper.java .
 COPY --from=build /usr/sap/distribution-service/distribution.jar .
 RUN ["java", "DpkgHelper.java"]
+USER 65534:65534
 CMD ["distribution.jar"]

--- a/services/submission/Dockerfile
+++ b/services/submission/Dockerfile
@@ -1,5 +1,4 @@
 FROM maven:3.6.3-jdk-11 as build
-
 ARG WORK_DIR=/build
 
 # copy the pom and config files first (which do not change very often)
@@ -28,4 +27,5 @@ FROM gcr.io/distroless/java:11
 COPY --from=build /DpkgHelper.java .
 COPY --from=build /usr/sap/submission-service/submission.jar .
 RUN ["java", "DpkgHelper.java"]
+USER 65534:65534
 CMD ["submission.jar"]


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

Use non-root user in distroless base images to run the applications. Due to the nature of distroless images, the potential threat should not be as high as for non-distroless images, but we want to mitigate this nevertheless. 

See [this isssue](https://github.com/GoogleContainerTools/distroless/issues/332) in the distroless repository for details.

Addressing #593 