### PR TITLE
Add missing blanks in warn messages

### DIFF
--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/ServerApplication.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/ServerApplication.java
@@ -73,18 +73,18 @@ public class ServerApplication implements EnvironmentAware {
     }
     if (profiles.contains("disable-ssl-client-postgres")) {
       logger.warn(
-          "The submission service is started with postgres connection TLS disabled. This should never be used in"
-              + "PRODUCTION!");
+          "The submission service is started with postgres connection TLS disabled. "
+              + "This should never be used in PRODUCTION!");
     }
     if (profiles.contains("disable-ssl-client-verification")) {
       logger.warn(
-          "The submission service is started with verification service connection TLS disabled. This should never be"
-              + "used in PRODUCTION!");
+          "The submission service is started with verification service connection TLS disabled. "
+              + "This should never be used in PRODUCTION!");
     }
     if (profiles.contains("disable-ssl-client-verification-verify-hostname")) {
       logger.warn(
-          "The submission service is started with verification service TLS hostname validation disabled. This should"
-              + "never be used in PRODUCTION!");
+          "The submission service is started with verification service TLS hostname validation disabled. "
+              + "This should never be used in PRODUCTION!");
     }
   }
 }


### PR DESCRIPTION
This fixes three alerts reported by LGTM:
https://lgtm.com/projects/g/corona-warn-app/cwa-server/?mode=list

Signed-off-by: Stefan Weil <sw@weilnetz.de>
