### PR TITLE
Submission Svc: Timeout handling 

### DIFF
--- a/services/submission/src/main/resources/application.yaml
+++ b/services/submission/src/main/resources/application.yaml
@@ -102,3 +102,10 @@ server:
     key-store-password: ${SSL_SUBMISSION_KEYSTORE_PASSWORD}
     key-store-provider: SUN
     key-store-type: JKS
+
+feign:
+  client:
+    config:
+      default:
+        connect-timeout: 5000
+        read-timeout: 5000

--- a/services/submission/src/main/resources/application.yaml
+++ b/services/submission/src/main/resources/application.yaml
@@ -28,6 +28,8 @@ services:
       batch-size: 5
 
 spring:
+  transaction:
+    default-timeout: 20
   jpa:
     hibernate:
       ddl-auto: validate

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/verification/TanVerifierTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/verification/TanVerifierTest.java
@@ -130,4 +130,14 @@ class TanVerifierTest {
     assertThatExceptionOfType(FeignException.class).isThrownBy(() -> tanVerifier.verifyTan(randomUUID));
   }
 
+  @Test
+  void checkTimeout() {
+    server.stubFor(
+        post(urlEqualTo(verificationPath))
+            .withRequestBody(matchingJsonPath("tan", equalTo(randomUUID)))
+            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON.toString()))
+            .willReturn(aResponse().withStatus(HttpStatus.OK.value()).withFixedDelay(1000)));
+
+    assertThatExceptionOfType(FeignException.class).isThrownBy(() -> tanVerifier.verifyTan(randomUUID));
+  }
 }

--- a/services/submission/src/test/resources/application.yaml
+++ b/services/submission/src/test/resources/application.yaml
@@ -47,3 +47,10 @@ management:
   health:
     probes:
       enabled: true
+
+feign:
+  client:
+    config:
+      default:
+        connect-timeout: 500
+        read-timeout: 500


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

This PR is a proposal taking into account the analyses in #423  

Introduces two submission service related timeouts:

# FeignClient timeouts

```
feign:
  client:
    config:
      default:
        connect-timeout: 5000
        read-timeout: 5000
```

- These timeouts are required in order to prevent blocked submission service worker threads in the case where the `cwa-verification-server` does not respond in timely fashion, likely due to a flood of invalid TAN requests.
- The above values are similar to those in [cwa-verification-portal](https://github.com/corona-warn-app/cwa-verification-portal/blob/c460acaac3001d430080eecde5f76d256f4bde82/src/main/resources/application.yml#L5-L10) and considerably less than the 60 second default value.
- A FeignClient timeout results in `Feign.RetyrableExeption` which gets handed over to `DeferredResult` and then immediately interrupts the synchronous endpoint execution, resulting in a `HTTP 500 Internal Server Error`.

# Transaction timeout

```
spring:
  transaction:
    default-timeout: 20
```

- This timeout is required in order to prevent blocked submission service worker threads in the case where the database does not respond in a timely fashion. Note that this is not as likely to happen as much as a `cwa-verification-server` slow response, however if the database does not respond for whatever reason, the thread will continue waiting for it indefinitely (This was tested this introducing a large delay into the SQL INSERT INTO statement)
- The above value (in seconds) was chosen as the maximum amount of time that the diagnosis key insertion transaction should reasonably be concluded by.
- A transaction timeout results in `org.springframework.transaction.TransactionTimedOutException` which gets handed over to `DeferredResult` and then immediately interrupts the synchronous endpoint execution, resulting in a `HTTP 500 Internal Server Error`.

Note: There is no need to set a timeout on `DeferredResult` or the submission service endpoint itself since due to the submission endpoint currently being implemented synchronously, a timeout on `DeferredResult` has no effect. As noted, the above 2 timeouts will be handed over to `DeferredResult` which would interrupt the synchronous endpoint execution immediately.


