### PR TITLE
Add random key padding

### DIFF
--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/config/SubmissionServiceConfig.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/config/SubmissionServiceConfig.java
@@ -33,6 +33,7 @@ public class SubmissionServiceConfig {
   private Long initialFakeDelayMilliseconds;
   private Long fakeDelayMovingAverageSamples;
   private Integer retentionDays;
+  private Integer randomKeyPaddingMultiplier;
   private Integer connectionPoolSize;
   private Payload payload;
   private Verification verification;
@@ -61,6 +62,14 @@ public class SubmissionServiceConfig {
 
   public void setRetentionDays(Integer retentionDays) {
     this.retentionDays = retentionDays;
+  }
+
+  public Integer getRandomKeyPaddingMultiplier() {
+    return randomKeyPaddingMultiplier;
+  }
+
+  public void setRandomKeyPaddingMultiplier(Integer randomKeyPaddingMultiplier) {
+    this.randomKeyPaddingMultiplier = randomKeyPaddingMultiplier;
   }
 
   public Integer getConnectionPoolSize() {

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/config/SubmissionServiceConfig.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/config/SubmissionServiceConfig.java
@@ -21,11 +21,15 @@
 package app.coronawarn.server.services.submission.config;
 
 import java.io.File;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 @Component
 @ConfigurationProperties(prefix = "services.submission")
+@Validated
 public class SubmissionServiceConfig {
 
   // Exponential moving average of the last N real request durations (in ms), where
@@ -33,6 +37,8 @@ public class SubmissionServiceConfig {
   private Long initialFakeDelayMilliseconds;
   private Long fakeDelayMovingAverageSamples;
   private Integer retentionDays;
+  @Min(1)
+  @Max(100)
   private Integer randomKeyPaddingMultiplier;
   private Integer connectionPoolSize;
   private Payload payload;

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
@@ -29,8 +29,11 @@ import app.coronawarn.server.services.submission.monitoring.SubmissionMonitor;
 import app.coronawarn.server.services.submission.validation.ValidSubmissionPayload;
 import app.coronawarn.server.services.submission.verification.TanVerifier;
 import io.micrometer.core.annotation.Timed;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -59,6 +62,7 @@ public class SubmissionController {
   private final DiagnosisKeyService diagnosisKeyService;
   private final TanVerifier tanVerifier;
   private final Integer retentionDays;
+  private final Integer randomKeyPaddingMultiplier;
   private final FakeDelayManager fakeDelayManager;
 
   SubmissionController(
@@ -69,6 +73,7 @@ public class SubmissionController {
     this.submissionMonitor = submissionMonitor;
     this.fakeDelayManager = fakeDelayManager;
     retentionDays = submissionServiceConfig.getRetentionDays();
+    randomKeyPaddingMultiplier = submissionServiceConfig.getRandomKeyPaddingMultiplier();
   }
 
   /**
@@ -130,6 +135,26 @@ public class SubmissionController {
       }
     }
 
-    diagnosisKeyService.saveDiagnosisKeys(diagnosisKeys);
+    diagnosisKeyService.saveDiagnosisKeys(padDiagnosisKeys(diagnosisKeys));
+  }
+
+  private List<DiagnosisKey> padDiagnosisKeys(List<DiagnosisKey> diagnosisKeys) {
+    List<DiagnosisKey> paddedDiagnosisKeys = new ArrayList<>();
+    diagnosisKeys.forEach(diagnosisKey -> {
+      paddedDiagnosisKeys.add(diagnosisKey);
+      IntStream.range(1, randomKeyPaddingMultiplier)
+          .mapToObj(index -> {
+            byte[] randomKeyData = new byte[16];
+            new SecureRandom().nextBytes(randomKeyData);
+            return DiagnosisKey.builder()
+                .withKeyData(randomKeyData)
+                .withRollingStartIntervalNumber(diagnosisKey.getRollingStartIntervalNumber())
+                .withTransmissionRiskLevel(diagnosisKey.getTransmissionRiskLevel())
+                .withRollingPeriod(diagnosisKey.getRollingPeriod())
+                .build();
+          })
+          .forEach(paddedDiagnosisKeys::add);
+    });
+    return paddedDiagnosisKeys;
   }
 }

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
@@ -32,7 +32,6 @@ import io.micrometer.core.annotation.Timed;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/services/submission/src/main/resources/application.yaml
+++ b/services/submission/src/main/resources/application.yaml
@@ -15,6 +15,12 @@ services:
     fake-delay-moving-average-samples: 10
     # The retention threshold for acceptable diagnosis keys during submission.
     retention-days: 14
+    # The number of keys to save to the DB for every real submitted key.
+    # Example: If the 'random-key-padding-multiplier' is set to 10, and 5 keys are being submitted,
+    # then the 5 real submitted keys will be saved to the DB, plus an additional 45 keys with
+    # random 'key_data'. All properties, besides the 'key_data', of the additional keys will be
+    # identical to the real key.
+    random-key-padding-multiplier: 10
     # The ApacheHttpClient's connection pool size.
     connection-pool-size: 200
     payload:

--- a/services/submission/src/main/resources/application.yaml
+++ b/services/submission/src/main/resources/application.yaml
@@ -20,7 +20,7 @@ services:
     # then the 5 real submitted keys will be saved to the DB, plus an additional 45 keys with
     # random 'key_data'. All properties, besides the 'key_data', of the additional keys will be
     # identical to the real key.
-    random-key-padding-multiplier: 10
+    random-key-padding-multiplier: ${RANDOM_KEY_PADDING_MULTIPLIER:1}
     # The ApacheHttpClient's connection pool size.
     connection-pool-size: 200
     payload:

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/SubmissionControllerTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/SubmissionControllerTest.java
@@ -186,7 +186,7 @@ class SubmissionControllerTest {
     return Arrays.stream(HttpMethod.values())
         .filter(method -> method != HttpMethod.POST)
         .filter(method -> method != HttpMethod.PATCH) /* not supported by Rest Template */
-        .map(elem -> Arguments.of(elem));
+        .map(Arguments::of);
   }
 
   @Test

--- a/services/submission/src/test/resources/application.yaml
+++ b/services/submission/src/test/resources/application.yaml
@@ -25,6 +25,7 @@ services:
     initial-fake-delay-milliseconds: 1
     fake-delay-moving-average-samples: 1
     retention-days: 14
+    random-key-padding-multiplier: 10
     connection-pool-size: 200
     payload:
       max-number-of-keys: 14


### PR DESCRIPTION
### Summary:
- Generate a fixed number of random diagnosis keys for every real submitted key
  - Random diagnosis keys share all properties of the real key, except for the `key_data`
- Add configurable `random-key-padding-multiplier` property
- Improves https://github.com/corona-warn-app/cwa-server/issues/108
- Related to https://github.com/corona-warn-app/cwa-documentation/issues/236
- Addresses CCC "Prüfstein" Point 9 "Unlinkability" without introducing additional delay:
  - https://github.com/corona-warn-app/cwa-documentation/blob/master/pruefsteine.md#unlinkability

Documentation for the `random-key-padding-multiplier` property from [application.yaml](https://github.com/corona-warn-app/cwa-server/pull/609/files#diff-561c3bb602ad52bed235b8f76cd8a437R23):
```yaml
# The number of keys to save to the DB for every real submitted key.
# Example: If the 'random-key-padding-multiplier' is set to 10, and 5 keys are being submitted,
# then the 5 real submitted keys will be saved to the DB, plus an additional 45 keys with
# random 'key_data'. All properties, besides the 'key_data', of the additional keys will be
# identical to the real key.
```

### To be decided
- [ ] What value should we set as the `random-key-padding-multiplier`? (currently set to `10`)
- [ ] Can we remove (or at least reduce) the "shifting policy threshold"? (currently set to `140`)