### PR TITLE
Enchantments - Increase test coverage

### DIFF
--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/validation/ValidSubmissionPayload.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/validation/ValidSubmissionPayload.java
@@ -88,11 +88,6 @@ public @interface ValidSubmissionPayload {
       List<TemporaryExposureKey> exposureKeys = submissionPayload.getKeysList();
       validatorContext.disableDefaultConstraintViolation();
 
-      if (Objects.isNull(exposureKeys)) {
-        addViolation(validatorContext, "Field 'keys' points to Null.");
-        return false;
-      }
-
       boolean isValid = checkKeyCollectionSize(exposureKeys, validatorContext);
       isValid &= checkUniqueStartIntervalNumbers(exposureKeys, validatorContext);
       isValid &= checkNoOverlapsInTimeWindow(exposureKeys, validatorContext);

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/monitoring/VerificationServiceHealthIndicatorTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/monitoring/VerificationServiceHealthIndicatorTest.java
@@ -57,8 +57,15 @@ class VerificationServiceHealthIndicatorTest {
   }
 
   @Test
-  void checkIsHealthyIfVerificationServerIsRunning() throws Exception {
+  void checkIsHealthyIfVerificationServerIsRunningAndExceptionIsThrown() throws Exception {
     when(verificationServerClient.verifyTan(any())).thenThrow(FeignException.NotFound.class);
+    mvc.perform(get("/actuator/health"))
+        .andExpect(status().is2xxSuccessful()).andReturn();
+  }
+
+  @Test
+  void checkIsHealthyIfVerificationServerIsRunning() throws Exception {
+    when(verificationServerClient.verifyTan(any())).thenReturn("ok");
     mvc.perform(get("/actuator/health"))
         .andExpect(status().is2xxSuccessful()).andReturn();
   }


### PR DESCRIPTION
<!-- 
Thank you for supporting us with your Pull Request! 🙌 ❤️ 

Before submitting, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unncessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new `.java` source file you add has a correct license header.

-->

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->

Increase project test coverage:
1) Added a new scenario to `VerificationServiceHealthIndicatorTest.java` to cover the case where no exception is thrown and the app is also healthy.
2) I realise there was coverage missing in the `ValidSubmissionPayload.java` for the check `Objects.isNull(exposureKeys)`.
But in fact it can't be null since it's a proto list, and by default it will be converted in a empty list. I suggest to remove the validation in this case to keep the code cleaner.
From [proto3 documentation](https://developers.google.com/protocol-buffers/docs/proto3#default):
> The default value for repeated fields is empty (generally an empty list in the appropriate language).