### PR TITLE
Index Files: Incorrect mime type closes #608

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
@@ -140,6 +140,8 @@ public class ObjectStoreAccess {
       headers.put(HeaderKey.CWA_HASH, file.getChecksum());
     }
 
+    headers.put(HeaderKey.CONTENT_TYPE, file.getContentType());
+
     return headers;
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClient.java
@@ -23,6 +23,7 @@ package app.coronawarn.server.services.distribution.objectstore.client;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import software.amazon.awssdk.http.Header;
 
 /**
  * Simple Storage Service (aka S3) client to perform bucket and object operations.
@@ -74,7 +75,12 @@ public interface ObjectStoreClient {
   enum HeaderKey {
     CACHE_CONTROL("Cache-Control"),
     AMZ_ACL("x-amz-acl"),
-    CWA_HASH("cwa-hash");
+    CWA_HASH("cwa-hash"),
+    /**
+     * To control which content type is sent, when objects are retrieved from the object store.
+     */
+    CONTENT_TYPE(Header.CONTENT_TYPE)
+    ;
 
     public final String keyValue;
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
@@ -118,6 +118,9 @@ public class S3ClientWrapper implements ObjectStoreClient {
     if (headers.containsKey(HeaderKey.CWA_HASH)) {
       requestBuilder.metadata(Map.of(HeaderKey.CWA_HASH.withMetaPrefix(), headers.get(HeaderKey.CWA_HASH)));
     }
+    if (headers.containsKey(HeaderKey.CONTENT_TYPE)) {
+      requestBuilder.contentType(headers.get(HeaderKey.CONTENT_TYPE));
+    }
 
     RequestBody bodyFile = RequestBody.fromFile(filePath);
     s3Client.putObject(requestBuilder.build(), bodyFile);

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/publish/LocalFile.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/publish/LocalFile.java
@@ -86,4 +86,22 @@ public abstract class LocalFile {
     Path relativePath = rootFolder.relativize(file);
     return relativePath.toString().replaceAll("\\\\", "/");
   }
+
+  /**
+   * Value for the <code>content-type</code> header.
+   * 
+   * @return Either <a href="https://www.iana.org/assignments/media-types/application/zip">zip</a> or
+   *         <a href="https://www.iana.org/assignments/media-types/application/json">json</a>.
+   */
+  public String getContentType() {
+    if (s3Key.endsWith("app_config")) {
+      return "application/zip";
+    }
+    if (s3Key.matches(".*\\d")) {
+      // date and hourly diagnosis key files
+      return "application/zip";
+    }
+    // list of versions, dates, hours
+    return "application/json";
+  }
 }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
@@ -213,6 +213,17 @@ class S3ClientWrapperTest {
   }
 
   @Test
+  void testPutObjectForContentTypeHeader() {
+    final String contentType = "foo-content-type";
+    s3ClientWrapper.putObject(VALID_BUCKET_NAME, VALID_NAME, Path.of(""), 
+        newHashMap(HeaderKey.CONTENT_TYPE, contentType));
+
+    PutObjectRequest expRequest =
+        PutObjectRequest.builder().bucket(VALID_BUCKET_NAME).key(VALID_NAME).contentType(contentType).build();
+    verify(s3Client, atLeastOnce()).putObject(eq(expRequest), any(RequestBody.class));
+  }
+
+  @Test
   void testPutObjectForCacheControlHeader() {
     var expCacheControl = "foo-cache-control";
     s3ClientWrapper

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/publish/LocalFileTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/publish/LocalFileTest.java
@@ -1,0 +1,51 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App
+ * ---
+ * Copyright (C) 2020 SAP SE and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.server.services.distribution.objectstore.publish;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+final class LocalFileTest {
+  @ParameterizedTest
+  @ValueSource(strings = { 
+      "version", 
+      "version/v1/configuration/country", 
+      "version/v1/diagnosis-keys/country",
+      "version/v1/diagnosis-keys/country/DE/date", 
+      "version/v1/diagnosis-keys/country/DE/date/2020-06-11/hour" })
+  void testGetContentTypeJson(final String path) {
+    final LocalFile test = new LocalIndexFile(Path.of("/root", path, "/index"), Path.of("/root"));
+    assertEquals("application/json", test.getContentType());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { 
+      "version/v1/configuration/country/DE/app_config", 
+      "version/v1/diagnosis-keys/country/DE/date/2020-06-11", 
+      "version/v1/diagnosis-keys/country/DE/date/2020-06-11/hour/13" })
+  void testGetContentTypeZip(final String path) {
+    final LocalFile test = new LocalIndexFile(Path.of("/root", path, "/index"), Path.of("/root"));
+    assertEquals("application/zip", test.getContentType());
+  }
+}


### PR DESCRIPTION
## Description

#608 

Based upon the s3Key, it figures out what to use as content-type header.
