### PR TITLE
Replace data-jpa with data-jdbc

### DIFF
--- a/common/persistence/pom.xml
+++ b/common/persistence/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <artifactId>spring-boot-starter-data-jdbc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
@@ -30,21 +30,16 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Set;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.constraints.Size;
 import org.hibernate.validator.constraints.Range;
+import org.springframework.data.annotation.Id;
 
 /**
  * A key generated for advertising over a window of time.
  */
-@Entity
-@Table(name = "diagnosis_key")
 public class DiagnosisKey {
 
   /**
@@ -58,7 +53,6 @@ public class DiagnosisKey {
 
   @Id
   @Size(min = 16, max = 16, message = "Key data must be a byte array of length 16.")
-  @Column(unique = true)
   private byte[] keyData;
 
   @ValidRollingStartIntervalNumber

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
@@ -53,23 +53,20 @@ public class DiagnosisKey {
 
   @Id
   @Size(min = 16, max = 16, message = "Key data must be a byte array of length 16.")
-  private byte[] keyData;
+  private final byte[] keyData;
 
   @ValidRollingStartIntervalNumber
-  private int rollingStartIntervalNumber;
+  private final int rollingStartIntervalNumber;
 
   @Range(min = EXPECTED_ROLLING_PERIOD, max = EXPECTED_ROLLING_PERIOD,
       message = "Rolling period must be " + EXPECTED_ROLLING_PERIOD + ".")
-  private int rollingPeriod;
+  private final int rollingPeriod;
 
   @Range(min = 0, max = 8, message = "Risk level must be between 0 and 8.")
-  private int transmissionRiskLevel;
+  private final int transmissionRiskLevel;
 
   @ValidSubmissionTimestamp
-  private long submissionTimestamp;
-
-  protected DiagnosisKey() {
-  }
+  private final long submissionTimestamp;
 
   /**
    * Should be called by builders.

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
@@ -22,6 +22,7 @@ package app.coronawarn.server.common.persistence.service;
 
 import static app.coronawarn.server.common.persistence.domain.validation.ValidSubmissionTimestampValidator.SECONDS_PER_HOUR;
 import static java.time.ZoneOffset.UTC;
+import static org.springframework.data.util.StreamUtils.createStreamFromIterator;
 
 import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
 import app.coronawarn.server.common.persistence.repository.DiagnosisKeyRepository;
@@ -70,7 +71,8 @@ public class DiagnosisKeyService {
    * Returns all valid persisted diagnosis keys, sorted by their submission timestamp.
    */
   public List<DiagnosisKey> getDiagnosisKeys() {
-    List<DiagnosisKey> diagnosisKeys = keyRepository.findAll(Sort.by(Direction.ASC, "submissionTimestamp"));
+    List<DiagnosisKey> diagnosisKeys = createStreamFromIterator(
+        keyRepository.findAll(Sort.by(Direction.ASC, "submissionTimestamp")).iterator()).collect(Collectors.toList());
     List<DiagnosisKey> validDiagnosisKeys =
         diagnosisKeys.stream().filter(DiagnosisKeyService::isDiagnosisKeyValid).collect(Collectors.toList());
 

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyServiceMockedRepositoryTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyServiceMockedRepositoryTest.java
@@ -31,12 +31,12 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 
-@DataJpaTest
+@DataJdbcTest
 class DiagnosisKeyServiceMockedRepositoryTest {
 
   static final byte[] expKeyData = "16-bytelongarray".getBytes(StandardCharsets.US_ASCII);

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTest.java
@@ -42,9 +42,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 
-@DataJpaTest
+@DataJdbcTest
 class DiagnosisKeyServiceTest {
 
   @Autowired

--- a/common/persistence/src/test/resources/application.yaml
+++ b/common/persistence/src/test/resources/application.yaml
@@ -4,13 +4,8 @@ spring:
     database:
       replace: none
   flyway:
-    enabled: false
-  jpa:
-    hibernate:
-      ddl-auto: create
-    properties:
-      hibernate:
-        show_sql: false
+    enabled: true
+    locations: classpath:/db/migration, classpath:/db/specific/{vendor}
   datasource:
     url: jdbc:h2:mem:test;MODE=PostgreSQL
     driverClassName: org.h2.Driver

--- a/common/persistence/src/test/resources/application.yaml
+++ b/common/persistence/src/test/resources/application.yaml
@@ -1,8 +1,5 @@
 ---
 spring:
-  test:
-    database:
-      replace: none
   flyway:
     enabled: true
     locations: classpath:/db/migration, classpath:/db/specific/{vendor}
@@ -10,6 +7,10 @@ spring:
     url: jdbc:h2:mem:test;MODE=PostgreSQL
     driverClassName: org.h2.Driver
     platform: h2
+  test:
+    database:
+      # Use datasource as defined above.
+      replace: none
   main:
     banner-mode: off
 logging:

--- a/services/distribution/pom.xml
+++ b/services/distribution/pom.xml
@@ -95,6 +95,10 @@
       <groupId>org.springframework.retry</groupId>
       <version>1.3.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/Application.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/Application.java
@@ -35,7 +35,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.env.Environment;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 
 /**
  * The retrieval, assembly and distribution of configuration and diagnosis key data is handled by a chain of {@link
@@ -43,7 +43,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
  * the chain execution.
  */
 @SpringBootApplication
-@EnableJpaRepositories(basePackages = "app.coronawarn.server.common.persistence")
+@EnableJdbcRepositories(basePackages = "app.coronawarn.server.common.persistence")
 @EntityScan(basePackages = "app.coronawarn.server.common.persistence")
 @ComponentScan({"app.coronawarn.server.common.persistence", "app.coronawarn.server.services.distribution"})
 @EnableConfigurationProperties({DistributionServiceConfig.class})

--- a/services/distribution/src/main/resources/application.yaml
+++ b/services/distribution/src/main/resources/application.yaml
@@ -84,9 +84,6 @@ spring:
   main:
     web-application-type: NONE
   # Postgres configuration
-  jpa:
-    hibernate:
-      ddl-auto: validate
   flyway:
     enabled: true
     locations: classpath:/db/migration, classpath:/db/specific/{vendor}

--- a/services/distribution/src/test/resources/application.yaml
+++ b/services/distribution/src/test/resources/application.yaml
@@ -54,8 +54,10 @@ services:
 spring:
   main:
     banner-mode: off
-  flyway:
-    enabled: true
-  jpa:
-    hibernate:
-      ddl-auto: validate
+  datasource:
+    url: jdbc:h2:mem:test;MODE=PostgreSQL
+    driverClassName: org.h2.Driver
+    platform: h2
+  test:
+    database:
+      replace: none

--- a/services/distribution/src/test/resources/application.yaml
+++ b/services/distribution/src/test/resources/application.yaml
@@ -60,4 +60,5 @@ spring:
     platform: h2
   test:
     database:
+      # Use datasource as defined above.
       replace: none

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/ServerApplication.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/ServerApplication.java
@@ -36,11 +36,11 @@ import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.env.Environment;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.http.converter.protobuf.ProtobufHttpMessageConverter;
 
 @SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
-@EnableJpaRepositories(basePackages = "app.coronawarn.server.common.persistence")
+@EnableJdbcRepositories(basePackages = "app.coronawarn.server.common.persistence")
 @EntityScan(basePackages = "app.coronawarn.server.common.persistence")
 @ComponentScan({"app.coronawarn.server.common.persistence",
     "app.coronawarn.server.services.submission"})

--- a/services/submission/src/main/resources/application.yaml
+++ b/services/submission/src/main/resources/application.yaml
@@ -36,10 +36,6 @@ services:
 spring:
   transaction:
     default-timeout: 20
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    open-in-view: false
   flyway:
     enabled: true
     locations: classpath:/db/migration, classpath:/db/specific/{vendor}

--- a/services/submission/src/test/resources/application.yaml
+++ b/services/submission/src/test/resources/application.yaml
@@ -7,8 +7,6 @@ logging:
 spring:
   main:
     banner-mode: off
-  flyway:
-    enabled: true
   datasource:
     url: jdbc:h2:mem:test;MODE=PostgreSQL
     driverClassName: org.h2.Driver
@@ -16,9 +14,6 @@ spring:
   test:
     database:
       replace: none
-  jpa:
-    hibernate:
-      ddl-auto: validate
 
 services:
   submission:

--- a/services/submission/src/test/resources/application.yaml
+++ b/services/submission/src/test/resources/application.yaml
@@ -13,6 +13,7 @@ spring:
     platform: h2
   test:
     database:
+      # Use datasource as defined above.
       replace: none
 
 services:


### PR DESCRIPTION
Given our current implementation and requirements, the more lightweight Spring Data JDBC dependency can provide feature parity without increasing code complexity.

- Switches from Spring Data JPA to Data JDBC.
- Enables flyway migration for unit tests
- Adds Spring-AOP as a dependency to distribution (previously provided transitively).

See Spring Data JDBC documentation for an introduction:
- [Spring Data JDBC - Reference Documentation](https://docs.spring.io/spring-data/jdbc/docs/2.0.1.RELEASE/reference/html/#reference)
- [Spring Data JDBC - References and Aggregates](https://spring.io/blog/2018/09/24/spring-data-jdbc-references-and-aggregates)