### PR TITLE
Mitigate CVE-2020-11996

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.0.RELEASE</version>
+    <version>2.3.1.RELEASE</version>
     <relativePath></relativePath>
   </parent>
 


### PR DESCRIPTION
## Description

MItigate [CVE-2020-11996](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11996). Updates spring-boot-starter-parent to `2.3.1.RELEASE` which [bumps Apache Tomcat to 9.0.36](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-tomcat/2.3.1.RELEASE) (see [mitigation](https://lists.apache.org/thread.html/r5541ef6b6b68b49f76fc4c45695940116da2bcbe0312ef204a00a2e0%40%3Cannounce.tomcat.apache.org%3E))