### PR TITLE
Mitigate CVE-2020-11996

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -96,6 +96,12 @@
       <version>42.2.13</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <!-- https://nvd.nist.gov/vuln/detail/CVE-2020-11996 -->
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+      <version>9.0.36</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Description

MItigate [CVE-2020-11996](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11996). Bumps Apache Tomcat to 9.0.36 (see [mitigation](https://lists.apache.org/thread.html/r5541ef6b6b68b49f76fc4c45695940116da2bcbe0312ef204a00a2e0%40%3Cannounce.tomcat.apache.org%3E))