### PR TITLE
[QUICKFIX] Revert "Consistently use UTC for LocalDateTime (#488)"

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/DiagnosisKeysStructureProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/DiagnosisKeysStructureProvider.java
@@ -28,7 +28,6 @@ import app.coronawarn.server.services.distribution.assembly.structure.WritableOn
 import app.coronawarn.server.services.distribution.assembly.structure.directory.Directory;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import org.slf4j.Logger;
@@ -68,8 +67,7 @@ public class DiagnosisKeysStructureProvider {
   public Directory<WritableOnDisk> getDiagnosisKeys() {
     logger.debug("Querying diagnosis keys from the database...");
     Collection<DiagnosisKey> diagnosisKeys = diagnosisKeyService.getDiagnosisKeys();
-    diagnosisKeyBundler.setDiagnosisKeys(diagnosisKeys,
-        LocalDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS));
+    diagnosisKeyBundler.setDiagnosisKeys(diagnosisKeys, LocalDateTime.now().truncatedTo(ChronoUnit.HOURS));
     return new DiagnosisKeysDirectory(diagnosisKeyBundler, cryptoProvider, distributionServiceConfig);
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/TestDataGeneration.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/TestDataGeneration.java
@@ -144,7 +144,7 @@ public class TestDataGeneration implements ApplicationRunner {
    * this function would return the timestamp for today 14:00 UTC.
    */
   private long getGeneratorEndTimestamp() {
-    return (LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC) / ONE_HOUR_INTERVAL_SECONDS) - 1;
+    return (LocalDateTime.now().toEpochSecond(ZoneOffset.UTC) / ONE_HOUR_INTERVAL_SECONDS) - 1;
   }
 
   /**
@@ -153,7 +153,7 @@ public class TestDataGeneration implements ApplicationRunner {
    * 14 days ago (from now) at 00:00 UTC.
    */
   private long getRetentionStartTimestamp() {
-    return LocalDate.now(ZoneOffset.UTC).minusDays(retentionDays).atStartOfDay()
+    return LocalDate.now().minusDays(retentionDays).atStartOfDay()
         .toEpochSecond(ZoneOffset.UTC) / ONE_HOUR_INTERVAL_SECONDS;
   }
 


### PR DESCRIPTION
This reverts commit ec099f3510165f65cbfd6c6d2e6a5fcd6cbdcb2e.

## Description
PR #488 introduced a bug in which too few hour packages are being assembled on non-UTC machines.

Example:
- Generate testdata up to (and including) the current hour
- Run the distribution module on a machine in the CEST time zone (-2h offset to UTC) at 10 a.m.
- Expected behavior: Hour files up until hour 8
- Actual behavior: Hour files up until hour 6

The problem seems to be that the CEST to UTC conversion is happening twice. This PR is only a quick fix. To properly fix the issue, we should rethink our timezone handling, remove all unnecessary uses of `LocalDateTime.now(...)` (only do this once and then pass it around) and introduce proper unit tests that include machine time zones other than UTC.