### PR TITLE
Fix JavaDoc search bad URL redirection issue

### DIFF
--- a/common/persistence/pom.xml
+++ b/common/persistence/pom.xml
@@ -119,6 +119,18 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.2.0</version>
+        <configuration>
+          <bottom>
+            <![CDATA[
+                    <script>
+                    if (typeof useModuleDirectories !== 'undefined') {
+                      useModuleDirectories = false;
+                    }
+                    </script>
+                ]]>
+          </bottom>
+          <additionalJOption>--allow-script-in-comments</additionalJOption>
+        </configuration>
       </plugin>
     </plugins>
   </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,18 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.2.0</version>
+        <configuration>
+          <bottom>
+            <![CDATA[
+                    <script>
+                    if (typeof useModuleDirectories !== 'undefined') {
+                      useModuleDirectories = false;
+                    }
+                    </script>
+                ]]>
+          </bottom>
+          <additionalJOption>--allow-script-in-comments</additionalJOption>
+        </configuration>
       </plugin>
     </plugins>
   </reporting>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -109,6 +109,18 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.2.0</version>
+        <configuration>
+          <bottom>
+            <![CDATA[
+                    <script>
+                    if (typeof useModuleDirectories !== 'undefined') {
+                      useModuleDirectories = false;
+                    }
+                    </script>
+                ]]>
+          </bottom>
+          <additionalJOption>--allow-script-in-comments</additionalJOption>
+        </configuration>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

Currently there is a bug with generated JavaDoc which causes a search result (via search box) to redirect to “/undefined/..” URL and therefore a 404 error.

This bug and workaround the fix is based on is discussed in https://stackoverflow.com/questions/52326318/maven-javadoc-search-redirects-to-undefined-url

