### PR TITLE
Mitigate CVE-2020-13935 and CVE-2020-13934

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -101,6 +101,12 @@
       <version>42.2.13</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <!-- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13935 -->
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+      <version>9.0.37</version>
+    </dependency>
   </dependencies>
 
   <reporting>


### PR DESCRIPTION
## Description:
Mitigate [CVE-2020-13934](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13934) and [CVE-2020-13935](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13935).
Bump Apache Tomcat to 9.0.37. ([mitigation](https://lists.apache.org/thread.html/r61f411cf82488d6ec213063fc15feeeb88e31b0ca9c29652ee4f962e%40%3Cannounce.tomcat.apache.org%3E)).