### PR TITLE
Fix documentation for risk-score-classification

### DIFF
--- a/services/distribution/src/main/resources/master-config/risk-score-classification.yaml
+++ b/services/distribution/src/main/resources/master-config/risk-score-classification.yaml
@@ -1,10 +1,15 @@
-# This is the Risk Score Classification master file which partitions the risk
-# score value range (0-72) into distinct risk classes that will be used to by
-# the app in order to present the correct risk classification in a user
-# friendly manner, based on the underlying total risk score, to the user.
+# This is the Risk Score Classification master file. It partitions the risk
+# score value range (0.000 - 72.000) into 2 distinct risk classes. These are
+# used by the respective app in order to present the correct risk classification
+# in a user friendly manner, based on the underlying total risk score.
+#
+# Currently, the implementation assumes the following with regards to
+# inclusiveness/exclusiveness of bounds:
+# - "LOW" class: [min, max[
+# - "HIGH" class: [min, max]
 #
 # The risk classes must not overlap and
-# cover the full risk score value range (0-72).
+# cover the full risk score value range (0.000 - 72.000).
 #
 # Change this file with caution!
 


### PR DESCRIPTION
Resolves #630 

Updates the documentation in `risk-score-classification.yaml` to match the expected specification.