### PR TITLE
Mitigate CVE-2020-13935

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.1.RELEASE</version>
+    <version>2.3.2.RELEASE</version>
     <relativePath></relativePath>
   </parent>
 
@@ -100,12 +100,6 @@
       <artifactId>postgresql</artifactId>
       <version>42.2.13</version>
       <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <!-- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13935 -->
-      <groupId>org.apache.tomcat.embed</groupId>
-      <artifactId>tomcat-embed-core</artifactId>
-      <version>9.0.37</version>
     </dependency>
   </dependencies>
 

--- a/services/submission/src/test/resources/application.yaml
+++ b/services/submission/src/test/resources/application.yaml
@@ -43,6 +43,8 @@ management:
       exposure:
         include: 'health'
   health:
+    livenessstate:
+      enabled: true
     probes:
       enabled: true
 


### PR DESCRIPTION
## Description:
* Mitigate [CVE-2020-13935](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13935).
* Bump spring-boot-starter-parent version. ([mitigation](https://lists.apache.org/thread.html/rd48c72bd3255bda87564d4da3791517c074d94f8a701f93b85752651%40%3Cannounce.tomcat.apache.org%3E))