### PR TITLE
use same version for spring-boot-starter-parent across all components

### DIFF
--- a/common/persistence/pom.xml
+++ b/common/persistence/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.1.RELEASE</version>
+    <version>2.3.2.RELEASE</version>
     <relativePath></relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
we missed to update the spring boot starter parent at the persistence pom