### PR TITLE
Fix/700 retention policy

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/DiagnosisKeyRepository.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/DiagnosisKeyRepository.java
@@ -36,7 +36,7 @@ public interface DiagnosisKeyRepository extends PagingAndSortingRepository<Diagn
    * @param submissionTimestamp The submission timestamp up to which entries will be expired.
    * @return The number of expired keys.
    */
-  @Query("SELECT COUNT(*) FROM diagnosis_key WHERE submission_timestamp<=:threshold")
+  @Query("SELECT COUNT(*) FROM diagnosis_key WHERE submission_timestamp<:threshold")
   int countOlderThanOrEqual(@Param("threshold") long submissionTimestamp);
 
   /**
@@ -45,7 +45,7 @@ public interface DiagnosisKeyRepository extends PagingAndSortingRepository<Diagn
    * @param submissionTimestamp The submission timestamp up to which entries will be deleted.
    */
   @Modifying
-  @Query("DELETE FROM diagnosis_key WHERE submission_timestamp<=:threshold")
+  @Query("DELETE FROM diagnosis_key WHERE submission_timestamp<:threshold")
   void deleteOlderThanOrEqual(@Param("threshold") long submissionTimestamp);
 
   /**

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/DiagnosisKeyRepository.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/DiagnosisKeyRepository.java
@@ -37,7 +37,7 @@ public interface DiagnosisKeyRepository extends PagingAndSortingRepository<Diagn
    * @return The number of expired keys.
    */
   @Query("SELECT COUNT(*) FROM diagnosis_key WHERE submission_timestamp<:threshold")
-  int countOlderThanOrEqual(@Param("threshold") long submissionTimestamp);
+  int countOlderThan(@Param("threshold") long submissionTimestamp);
 
   /**
    * Deletes all entries that have a submission timestamp less or equal than the specified one.
@@ -46,7 +46,7 @@ public interface DiagnosisKeyRepository extends PagingAndSortingRepository<Diagn
    */
   @Modifying
   @Query("DELETE FROM diagnosis_key WHERE submission_timestamp<:threshold")
-  void deleteOlderThanOrEqual(@Param("threshold") long submissionTimestamp);
+  void deleteOlderThan(@Param("threshold") long submissionTimestamp);
 
   /**
    * Attempts to write the specified diagnosis key information into the database. If a row with the specified key data

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
@@ -113,9 +113,9 @@ public class DiagnosisKeyService {
         .ofInstant(Instant.now(), UTC)
         .minusDays(daysToRetain)
         .toEpochSecond(UTC) / SECONDS_PER_HOUR;
-    int numberOfDeletions = keyRepository.countOlderThanOrEqual(threshold);
+    int numberOfDeletions = keyRepository.countOlderThan(threshold);
     logger.info("Deleting {} diagnosis key(s) with a submission timestamp older than {} day(s) ago.",
         numberOfDeletions, daysToRetain);
-    keyRepository.deleteOlderThanOrEqual(threshold);
+    keyRepository.deleteOlderThan(threshold);
   }
 }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTest.java
@@ -114,7 +114,7 @@ class DiagnosisKeyServiceTest {
 
   @Test
   void testApplyRetentionPolicyForOneNotApplicableEntry() {
-    var expKeys = List.of(buildDiagnosisKeyForDateTime(OffsetDateTime.now(UTC).minusHours(23)));
+    var expKeys = List.of(buildDiagnosisKeyForDateTime(OffsetDateTime.now(UTC).minusDays(1L)));
 
     diagnosisKeyService.saveDiagnosisKeys(expKeys);
     diagnosisKeyService.applyRetentionPolicy(1);
@@ -125,7 +125,7 @@ class DiagnosisKeyServiceTest {
 
   @Test
   void testApplyRetentionPolicyForOneApplicableEntry() {
-    var keys = List.of(buildDiagnosisKeyForDateTime(OffsetDateTime.now(UTC).minusDays(1L)));
+    var keys = List.of(buildDiagnosisKeyForDateTime(OffsetDateTime.now(UTC).minusDays(1L).minusHours(1)));
 
     diagnosisKeyService.saveDiagnosisKeys(keys);
     diagnosisKeyService.applyRetentionPolicy(1);

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/TestDataGeneration.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/TestDataGeneration.java
@@ -98,7 +98,7 @@ public class TestDataGeneration implements ApplicationRunner {
 
     // Timestamps in hours since epoch. Test data generation starts one hour after the latest diagnosis key in the
     // database and ends one hour before the current one.
-    long startTimestamp = getGeneratorStartTimestamp(existingDiagnosisKeys) + 1; // Inclusive
+    long startTimestamp = getGeneratorStartTimestamp(existingDiagnosisKeys); // Inclusive
     long endTimestamp = getGeneratorEndTimestamp(); // Inclusive
 
     // Add the startTimestamp to the seed. Otherwise we would generate the same data every hour.
@@ -134,7 +134,7 @@ public class TestDataGeneration implements ApplicationRunner {
       return getRetentionStartTimestamp();
     } else {
       DiagnosisKey latestDiagnosisKey = diagnosisKeys.get(diagnosisKeys.size() - 1);
-      return latestDiagnosisKey.getSubmissionTimestamp();
+      return latestDiagnosisKey.getSubmissionTimestamp() + 1;
     }
   }
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/integration/ObjectStoreFilePreservationIT.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/integration/ObjectStoreFilePreservationIT.java
@@ -132,7 +132,7 @@ class ObjectStoreFilePreservationIT {
 
     triggerRetentionPolicy(testStartDate);
 
-    // Trigger second distrubution after data retention policies were applied
+    // Trigger second distribution after data retention policies were applied
     assembleAndDistribute(testOutputFolder.newFolder("output-after-retention"));
     List<S3Object> filesAfterRetention = getPublishedFiles();
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/runner/TestDataGenerationTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/runner/TestDataGenerationTest.java
@@ -25,7 +25,9 @@ import app.coronawarn.server.common.persistence.service.DiagnosisKeyService;
 import app.coronawarn.server.services.distribution.assembly.structure.util.TimeUtils;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig.TestData;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -74,6 +76,11 @@ class TestDataGenerationTest {
     testData.setSeed(0);
     distributionServiceConfig.setRetentionDays(1);
     distributionServiceConfig.setTestData(testData);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TimeUtils.setNow(null);
   }
 
   @Test


### PR DESCRIPTION
This pull request fixes issue #700 (internal tracking 104).

The retention policy for keys runs one hour too early. We were keeping 13 days and 23 hours of keys in the system other than full 14 days. 

For an overview of why this change was made, check [this comment and thread](https://github.com/corona-warn-app/cwa-server/issues/700#issuecomment-674057872).