### PR TITLE
Retrieve uploadable keys using new service in persistence module

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyService.java
@@ -1,0 +1,53 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App
+ * ---
+ * Copyright (C) 2020 SAP SE and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.server.common.persistence.service;
+
+import static org.springframework.data.util.StreamUtils.createStreamFromIterator;
+
+import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
+import app.coronawarn.server.common.persistence.repository.FederationUploadKeyRepository;
+import app.coronawarn.server.common.persistence.service.common.ValidDiagnosisKeyFilter;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class FederationUploadKeyService {
+
+  private final FederationUploadKeyRepository keyRepository;
+  private final ValidDiagnosisKeyFilter validationFilter;
+
+  public FederationUploadKeyService(FederationUploadKeyRepository keyRepository, ValidDiagnosisKeyFilter filter) {
+    this.keyRepository = keyRepository;
+    this.validationFilter = filter;
+  }
+
+  /**
+   * Returns all valid persisted diagnosis keys which are ready to be uploaded
+   * to the external Federation Gateway service.
+   */
+  public List<DiagnosisKey> getPendingUploadKeys() {
+    List<DiagnosisKey> diagnosisKeys = createStreamFromIterator(
+        keyRepository.findAllUploadableKeys().iterator()).collect(Collectors.toList());
+    return validationFilter.filter(diagnosisKeys);
+  }
+}

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/common/ValidDiagnosisKeyFilter.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/common/ValidDiagnosisKeyFilter.java
@@ -1,0 +1,46 @@
+package app.coronawarn.server.common.persistence.service.common;
+
+
+import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.validation.ConstraintViolation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ValidDiagnosisKeyFilter {
+
+  private static final Logger logger = LoggerFactory.getLogger(ValidDiagnosisKeyFilter.class);
+
+  /**
+   * Rerturns a subset of diagnosis keys from the given list which have
+   * passed the default entity validation.
+   */
+  public List<DiagnosisKey> filter(List<DiagnosisKey> diagnosisKeys) {
+    List<DiagnosisKey> validDiagnosisKeys =
+        diagnosisKeys.stream().filter(ValidDiagnosisKeyFilter::isDiagnosisKeyValid).collect(Collectors.toList());
+
+    int numberOfDiscardedKeys = diagnosisKeys.size() - validDiagnosisKeys.size();
+    logger.info("Retrieved {} diagnosis key(s). Discarded {} diagnosis key(s) from the result as invalid.",
+        diagnosisKeys.size(), numberOfDiscardedKeys);
+
+    return validDiagnosisKeys;
+  }
+
+  private static boolean isDiagnosisKeyValid(DiagnosisKey diagnosisKey) {
+    Collection<ConstraintViolation<DiagnosisKey>> violations = diagnosisKey.validate();
+    boolean isValid = violations.isEmpty();
+
+    if (!isValid) {
+      List<String> violationMessages =
+          violations.stream().map(ConstraintViolation::getMessage).collect(Collectors.toList());
+      logger.warn("Validation failed for diagnosis key from database. Violations: {}", violationMessages);
+    }
+
+    return isValid;
+  }
+
+}

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/TestApplication.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/TestApplication.java
@@ -21,7 +21,11 @@
 package app.coronawarn.server.common.persistence;
 
 import app.coronawarn.server.common.persistence.repository.DiagnosisKeyRepository;
+import app.coronawarn.server.common.persistence.repository.FederationUploadKeyRepository;
 import app.coronawarn.server.common.persistence.service.DiagnosisKeyService;
+import app.coronawarn.server.common.persistence.service.FederationUploadKeyService;
+import app.coronawarn.server.common.persistence.service.common.ValidDiagnosisKeyFilter;
+
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,8 +33,19 @@ import org.springframework.context.annotation.Configuration;
 @SpringBootApplication
 @Configuration
 public class TestApplication {
+
+  @Bean
+  ValidDiagnosisKeyFilter validKeysFilter() {
+    return new ValidDiagnosisKeyFilter();
+  }
+
   @Bean
   DiagnosisKeyService createDiagnosisKeyService(DiagnosisKeyRepository keyRepository) {
-    return new DiagnosisKeyService(keyRepository);
+    return new DiagnosisKeyService(keyRepository, validKeysFilter());
+  }
+
+  @Bean
+  FederationUploadKeyService createFederationUploadKeyService(FederationUploadKeyRepository keyRepository) {
+    return new FederationUploadKeyService(keyRepository, validKeysFilter());
   }
 }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyServiceTest.java
@@ -33,7 +33,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import app.coronawarn.server.common.persistence.repository.FederationUploadKeyRepository;
 
 @DataJdbcTest
-public class FederationUploadKeyServiceTest {
+class FederationUploadKeyServiceTest {
 
   @Autowired
   private FederationUploadKeyService uploadKeyService;

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyServiceTest.java
@@ -18,45 +18,36 @@
  * ---license-end
  */
 
-package app.coronawarn.server.services.federation.upload.runner;
+package app.coronawarn.server.common.persistence.service;
 
-import static app.coronawarn.server.services.federation.upload.utils.MockData.*;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static app.coronawarn.server.common.persistence.service.DiagnosisKeyServiceTestHelper.assertDiagnosisKeysEqual;
+import static app.coronawarn.server.common.persistence.service.DiagnosisKeyServiceTestHelper.buildDiagnosisKeyForSubmissionTimestamp;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
 import app.coronawarn.server.common.persistence.repository.FederationUploadKeyRepository;
-import app.coronawarn.server.services.federation.upload.DiagnosisKeyBatchAssembler;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest
-class UploadTest {
+@DataJdbcTest
+public class FederationUploadKeyServiceTest {
 
   @Autowired
-  private Upload upload;
+  private FederationUploadKeyService uploadKeyService;
 
   @MockBean
   private FederationUploadKeyRepository uploadKeyRepository;
 
-  @SpyBean
-  private DiagnosisKeyBatchAssembler batchAssembler;
-
   @Test
-  void batchesShouldBeCreatedFromPendingUploadKeys() throws Exception {
-    List<DiagnosisKey> testKeys = generateRandomDiagnosisKeys(true, 20);
+  void testRetrievalOfPendingUploadKeys() {
+    var testKeys = new ArrayList<>(List.of(
+        buildDiagnosisKeyForSubmissionTimestamp(1L),
+        buildDiagnosisKeyForSubmissionTimestamp(0L)));
     Mockito.when(uploadKeyRepository.findAllUploadableKeys()).thenReturn(testKeys);
-    upload.run(null);
-    verify(batchAssembler, times(1)).assembleDiagnosisKeyBatch(testKeys);
+    var actKeys = uploadKeyService.getPendingUploadKeys();
+    assertDiagnosisKeysEqual(testKeys, actKeys);
   }
-
 }

--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/Application.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/Application.java
@@ -30,6 +30,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.env.Environment;
@@ -57,6 +58,15 @@ public class Application implements EnvironmentAware, DisposableBean {
   public void destroy() {
     logger.info("Shutting down log4j2.");
     LogManager.shutdown();
+  }
+
+  /**
+   * Terminates this application with exit code 1 (general error).
+   */
+  public static void killApplication(ApplicationContext appContext) {
+    SpringApplication.exit(appContext);
+    logger.error("Federation Upload Service terminated abnormally.");
+    System.exit(1);
   }
 
   @Override

--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/runner/Upload.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/runner/Upload.java
@@ -1,9 +1,16 @@
 package app.coronawarn.server.services.federation.upload.runner;
 
+import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
+import app.coronawarn.server.common.persistence.service.FederationUploadKeyService;
+import app.coronawarn.server.common.protocols.external.exposurenotification.DiagnosisKeyBatch;
+import app.coronawarn.server.services.federation.upload.Application;
+import app.coronawarn.server.services.federation.upload.DiagnosisKeyBatchAssembler;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -11,11 +18,28 @@ import org.springframework.stereotype.Component;
 @Order(1)
 public class Upload implements ApplicationRunner {
 
-  private static final Logger logger = LoggerFactory
-      .getLogger(Upload.class);
+  private static final Logger logger = LoggerFactory.getLogger(Upload.class);
+
+  private final FederationUploadKeyService uploadKeyService;
+  private final ApplicationContext applicationContext;
+  private final DiagnosisKeyBatchAssembler batchAssembler;
+
+  Upload(FederationUploadKeyService uploadKeyService, ApplicationContext applicationContext,
+      DiagnosisKeyBatchAssembler batchAssembler) {
+    this.uploadKeyService = uploadKeyService;
+    this.applicationContext = applicationContext;
+    this.batchAssembler = batchAssembler;
+  }
 
   @Override
   public void run(ApplicationArguments args) throws Exception {
     logger.info("Running Upload Job");
+    try {
+      List<DiagnosisKey> pendingUploadKeys = uploadKeyService.getPendingUploadKeys();
+      List<DiagnosisKeyBatch> batches = batchAssembler.assembleDiagnosisKeyBatch(pendingUploadKeys);
+    } catch (Exception e) {
+      logger.error("Upload diagnosis key data failed.", e);
+      Application.killApplication(applicationContext);
+    }
   }
 }

--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/runner/Upload.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/runner/Upload.java
@@ -2,7 +2,6 @@ package app.coronawarn.server.services.federation.upload.runner;
 
 import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
 import app.coronawarn.server.common.persistence.service.FederationUploadKeyService;
-import app.coronawarn.server.common.protocols.external.exposurenotification.DiagnosisKeyBatch;
 import app.coronawarn.server.services.federation.upload.Application;
 import app.coronawarn.server.services.federation.upload.DiagnosisKeyBatchAssembler;
 import java.util.List;
@@ -36,7 +35,7 @@ public class Upload implements ApplicationRunner {
     logger.info("Running Upload Job");
     try {
       List<DiagnosisKey> pendingUploadKeys = uploadKeyService.getPendingUploadKeys();
-      List<DiagnosisKeyBatch> batches = batchAssembler.assembleDiagnosisKeyBatch(pendingUploadKeys);
+      batchAssembler.assembleDiagnosisKeyBatch(pendingUploadKeys);
     } catch (Exception e) {
       logger.error("Upload diagnosis key data failed.", e);
       Application.killApplication(applicationContext);

--- a/services/upload/src/test/java/app/coronawarn/server/services/federation/upload/utils/MockData.java
+++ b/services/upload/src/test/java/app/coronawarn/server/services/federation/upload/utils/MockData.java
@@ -40,7 +40,7 @@ public class MockData {
   }
 
   public static DiagnosisKey generateRandomDiagnosisKey(boolean consentToShare) {
-    DiagnosisKey dummyKey = DiagnosisKey.builder().withKeyData(randomByteData())
+   return DiagnosisKey.builder().withKeyData(randomByteData())
                             .withRollingStartIntervalNumber(1)
                             .withTransmissionRiskLevel(2)
                             .withConsentToFederation(consentToShare)
@@ -50,7 +50,6 @@ public class MockData {
                             .withVisitedCountries(List.of("FR","DK"))
                             .withReportType(ReportType.CONFIRMED_TEST)
                             .build();
-    return dummyKey;
   }
 
   private static byte[] randomByteData() {

--- a/services/upload/src/test/java/app/coronawarn/server/services/federation/upload/utils/MockData.java
+++ b/services/upload/src/test/java/app/coronawarn/server/services/federation/upload/utils/MockData.java
@@ -1,0 +1,61 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App
+ * ---
+ * Copyright (C) 2020 SAP SE and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.server.services.federation.upload.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
+import app.coronawarn.server.common.protocols.external.exposurenotification.ReportType;
+
+public class MockData {
+
+  public static final String TEST_ORIGIN_COUNTRY = "DE";
+
+  public static List<DiagnosisKey> generateRandomDiagnosisKeys(boolean consentToShare, int numberOfKeys) {
+    List<DiagnosisKey> fakeKeys = new ArrayList<DiagnosisKey>();
+    while (numberOfKeys >= 0) {
+      fakeKeys.add(generateRandomDiagnosisKey(consentToShare));
+      numberOfKeys--;
+    }
+    return fakeKeys;
+  }
+
+  public static DiagnosisKey generateRandomDiagnosisKey(boolean consentToShare) {
+    DiagnosisKey dummyKey = DiagnosisKey.builder().withKeyData(randomByteData())
+                            .withRollingStartIntervalNumber(1)
+                            .withTransmissionRiskLevel(2)
+                            .withConsentToFederation(consentToShare)
+                            .withCountryCode(TEST_ORIGIN_COUNTRY)
+                            .withDaysSinceOnsetOfSymptoms(1)
+                            .withSubmissionTimestamp(12)
+                            .withVisitedCountries(List.of("FR","DK"))
+                            .withReportType(ReportType.CONFIRMED_TEST)
+                            .build();
+    return dummyKey;
+  }
+
+  private static byte[] randomByteData() {
+    byte[] keydata = new byte[16];
+    new Random().nextBytes(keydata);
+    return keydata;
+  }
+}


### PR DESCRIPTION
<!-- 
Thank you for supporting us with your Pull Request! 🙌 ❤️ 

Before submitting, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unncessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure each new `.java` source file you add has a correct license header.

-->

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

Changes to support the provisioning of pending upload keys to the DiagnosisKeyBatchAssembler when the upload job is running. There will be follow-up PRs whch deal with the filtered selection of uploadable keys, and enforcing of batch constraints.

