### PR TITLE
Rename "padding" to "requestPadding" in submission payload

### DIFF
--- a/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/internal/submission_payload.proto
+++ b/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/internal/submission_payload.proto
@@ -7,7 +7,7 @@ import "app/coronawarn/server/common/protocols/external/exposurenotification/dia
 
 message SubmissionPayload {
   repeated app.coronawarn.server.common.protocols.external.exposurenotification.TemporaryExposureKey keys = 1;
-  optional bytes padding = 2;
+  optional bytes requestPadding = 2;
   repeated string visitedCountries = 3;
   optional string origin = 4;
   optional app.coronawarn.server.common.protocols.external.exposurenotification.ReportType reportType = 5 [default = CONFIRMED_CLINICAL_DIAGNOSIS];

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/SubmissionPayloadMockData.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/SubmissionPayloadMockData.java
@@ -88,7 +88,7 @@ public final class SubmissionPayloadMockData {
         .addAllKeys(keys)
         .addAllVisitedCountries(List.of("FR","UK"))
         .setOrigin("DE")
-        .setPadding(ByteString.copyFrom(bytes))
+        .setRequestPadding(ByteString.copyFrom(bytes))
         .build();
   }
 


### PR DESCRIPTION
## Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

Renamed "padding" to "requestPadding" in the submission payload in order to harmonize the naming between mobile and backend. No functional change
