### PR TITLE
Feature/federation submission logging

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
@@ -77,7 +77,7 @@ public class DiagnosisKey {
 
   private final boolean consentToFederation;
 
-  @Size(max = 2)
+  @Size(max = 2, message = "Origin country code must have length of 2.")
   private final String originCountry;
 
   @ValidCountries

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/DiagnosisKeyRepository.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/DiagnosisKeyRepository.java
@@ -62,6 +62,7 @@ public interface DiagnosisKeyRepository extends PagingAndSortingRepository<Diagn
    * @param originCountry              The origin country from the app.
    * @param visitedCountries           The list of countries this transmissions is relevant for.
    * @param reportType                 The report type of the diagnosis key.
+   * @return {@literal true} if the diagnosis key was inserted successfully, {@literal false} otherwise.
    */
   @Modifying
   @Query("INSERT INTO diagnosis_key "
@@ -70,7 +71,7 @@ public interface DiagnosisKeyRepository extends PagingAndSortingRepository<Diagn
       + "VALUES (:keyData, :rollingStartIntervalNumber, :rollingPeriod, :submissionTimestamp, :transmissionRisk, "
       + ":origin_country, :visited_countries, :report_type, :days_since_onset_of_symptoms, :consent_to_federation) "
       + "ON CONFLICT DO NOTHING")
-  void saveDoNothingOnConflict(
+  boolean saveDoNothingOnConflict(
       @Param("keyData") byte[] keyData,
       @Param("rollingStartIntervalNumber") int rollingStartIntervalNumber,
       @Param("rollingPeriod") int rollingPeriod,

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyService.java
@@ -53,23 +53,39 @@ public class DiagnosisKeyService {
   }
 
   /**
-   * Persists the specified collection of {@link DiagnosisKey} instances. If the key data of a particular diagnosis key
-   * already exists in the database, this diagnosis key is not persisted.
+   * Persists the specified collection of {@link DiagnosisKey} instances and returns the number of inserted diagnosis
+   * keys. If the key data of a particular diagnosis key already exists in the database, this diagnosis key is not
+   * persisted.
    *
    * @param diagnosisKeys must not contain {@literal null}.
+   * @return Number of successfully inserted diagnosis keys.
    * @throws IllegalArgumentException in case the given collection contains {@literal null}.
    */
   @Timed
   @Transactional
-  public void saveDiagnosisKeys(Collection<DiagnosisKey> diagnosisKeys) {
+  public int saveDiagnosisKeys(Collection<DiagnosisKey> diagnosisKeys) {
+    int numberOfInsertedKeys = 0;
+
     for (DiagnosisKey diagnosisKey : diagnosisKeys) {
-      keyRepository.saveDoNothingOnConflict(
+      boolean keyInsertedSuccessfully = keyRepository.saveDoNothingOnConflict(
           diagnosisKey.getKeyData(), diagnosisKey.getRollingStartIntervalNumber(), diagnosisKey.getRollingPeriod(),
           diagnosisKey.getSubmissionTimestamp(), diagnosisKey.getTransmissionRiskLevel(),
           diagnosisKey.getOriginCountry(), diagnosisKey.getVisitedCountries().toArray(new String[0]),
           diagnosisKey.getReportType().name(), diagnosisKey.getDaysSinceOnsetOfSymptoms(),
           diagnosisKey.isConsentToFederation());
+
+      if (keyInsertedSuccessfully) {
+        numberOfInsertedKeys++;
+      }
     }
+
+    int conflictingKeys = diagnosisKeys.size() - numberOfInsertedKeys;
+    if (conflictingKeys > 0) {
+      logger.warn("{} out of {} diagnosis keys conflicted with existing database entries and were ignored.",
+          conflictingKeys, diagnosisKeys.size());
+    }
+
+    return numberOfInsertedKeys;
   }
 
   /**

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTest.java
@@ -155,10 +155,22 @@ class DiagnosisKeyServiceTest {
             .withReportType(ReportType.CONFIRMED_CLINICAL_DIAGNOSIS)
             .build());
 
-    diagnosisKeyService.saveDiagnosisKeys(keys);
+    int actNumberOfInsertedRows = diagnosisKeyService.saveDiagnosisKeys(keys);
     var actKeys = diagnosisKeyService.getDiagnosisKeys();
 
+    assertThat(actNumberOfInsertedRows).isEqualTo(1);
     assertThat(actKeys).hasSize(1);
     assertThat(actKeys.iterator().next().getTransmissionRiskLevel()).isEqualTo(2);
+  }
+
+  @Test
+  void testReturnedNumberOfInsertedKeysForNoConflict() {
+    var keys = list(
+        buildDiagnosisKeyForSubmissionTimestamp(1L),
+        buildDiagnosisKeyForSubmissionTimestamp(0L));
+
+    int actNumberOfInsertedRows = diagnosisKeyService.saveDiagnosisKeys(keys);
+
+    assertThat(actNumberOfInsertedRows).isEqualTo(2);
   }
 }

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
@@ -138,7 +138,7 @@ public class SubmissionController {
       if (diagnosisKey.isYoungerThanRetentionThreshold(retentionDays)) {
         diagnosisKeys.add(diagnosisKey);
       } else {
-        logger.info("Not persisting a diagnosis key, as it is outdated beyond retention threshold.");
+        logger.warn("Not persisting a diagnosis key, as it is outdated beyond retention threshold.");
       }
     }
 


### PR DESCRIPTION
Resolves #764 

- Log the number of conflicting keys during insert into the database.
- Log a warning if a submitted key is dated beyond the retention period.
- Add message for country code length constraint violation.