### PR TITLE
mitigate CVE-2020-5421 by switching to newer spring-boot-starter-parent

### DIFF
--- a/common/persistence/pom.xml
+++ b/common/persistence/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.2.RELEASE</version>
+    <version>2.3.4.RELEASE</version>
     <relativePath></relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.2.RELEASE</version>
+    <version>2.3.4.RELEASE</version>
     <relativePath></relativePath>
   </parent>
 


### PR DESCRIPTION
In Spring Framework versions 5.2.0 - 5.2.8, 5.1.0 - 5.1.17, 5.0.0 - 5.0.18, 4.3.0 - 4.3.28, and older unsupported versions, the protections against RFD attacks from CVE-2015-5211 may be bypassed depending on the browser used through the use of a jsessionid path parameter.

fix:
Upgrade to version org.springframework:spring-web:5.2.9,org.springframework:spring-web:5.1.18,org.springframework:spring-web:5.0.19,org.springframework:spring-web:4.3.29
--
https://tanzu.vmware.com/security/cve-2020-5421: Upgrade to version
