### PR TITLE
ensure usage of latest guava version 29.0-jre

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -35,6 +35,16 @@
     <sonar.projectKey>corona-warn-app_cwa-server_services</sonar.projectKey>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>29.0-jre</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
mitigate CVE-2018-10237

Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.