### PR TITLE
Enhance upload logging

### DIFF
--- a/common/federation/src/main/java/app/coronawarn/server/common/federation/client/upload/BatchUploadResponse.java
+++ b/common/federation/src/main/java/app/coronawarn/server/common/federation/client/upload/BatchUploadResponse.java
@@ -52,6 +52,18 @@ public class BatchUploadResponse {
     this.status201 = status201;
   }
 
+  @Override
+  public String toString() {
+    return "BatchUploadResponse{"
+        + "status409="
+        + status409
+        + ", status500="
+        + status500
+        + ", status201="
+        + status201
+        + '}';
+  }
+
   /**
    * Create an empty BatchUploadResponse.
    */

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyService.java
@@ -33,13 +33,11 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
 
 @Component
 public class FederationUploadKeyService {
@@ -83,6 +81,7 @@ public class FederationUploadKeyService {
         .filter(key -> sharingPoliciesChecker.canShareKeyAtTime(key, policy, LocalDateTime.now(UTC)))
         .peek(k -> keysPickedAfterSharePolicy.addAndGet(1))
         .collect(Collectors.toList());
+    logger.info("Keys selected for upload: {}", listOfKeys.size());
 
     logger.info("{} keys picked after read from upload table", keysPicked.get());
     logger.info("{} keys remaining after filtering by consent", keysPickedAfterConsent.get());
@@ -93,8 +92,8 @@ public class FederationUploadKeyService {
   }
 
   /**
-   * Updates only the batchTagId field of all given upload keys. The entities are not merged
-   * with the persisted ones, thus no other side effects are to be expected.
+   * Updates only the batchTagId field of all given upload keys. The entities are not merged with the persisted ones,
+   * thus no other side effects are to be expected.
    */
   @Transactional
   public void updateBatchTagForKeys(Collection<FederationUploadKey> originalKeys, String batchTagId) {

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyService.java
@@ -32,7 +32,11 @@ import app.coronawarn.server.common.persistence.service.common.ValidDiagnosisKey
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +47,8 @@ public class FederationUploadKeyService {
   private final FederationUploadKeyRepository keyRepository;
   private final ValidDiagnosisKeyFilter validationFilter;
   private final KeySharingPoliciesChecker sharingPoliciesChecker;
+
+  private static final Logger logger = LoggerFactory.getLogger(FederationUploadKeyService.class);
 
   /**
    * Constructs the key upload service.
@@ -63,12 +69,27 @@ public class FederationUploadKeyService {
    * <li> Key is expired conforming to the given policy
    */
   public List<FederationUploadKey> getPendingUploadKeys(ExpirationPolicy policy) {
-    return createStreamFromIterator(
-           keyRepository.findAllUploadableKeys().iterator())
-           .filter(DiagnosisKey::isConsentToFederation)
-           .filter(validationFilter::isDiagnosisKeyValid)
-           .filter(key -> sharingPoliciesChecker.canShareKeyAtTime(key, policy, LocalDateTime.now(UTC)))
-           .collect(Collectors.toList());
+    AtomicInteger keysPicked = new AtomicInteger();
+    AtomicInteger keysPickedAfterConsent = new AtomicInteger();
+    AtomicInteger keysPickedAfterValidity = new AtomicInteger();
+    AtomicInteger keysPickedAfterSharePolicy = new AtomicInteger();
+
+    var listOfKeys = createStreamFromIterator(keyRepository.findAllUploadableKeys().iterator())
+        .peek(k -> keysPicked.addAndGet(1))
+        .filter(DiagnosisKey::isConsentToFederation)
+        .peek(k -> keysPickedAfterConsent.addAndGet(1))
+        .filter(validationFilter::isDiagnosisKeyValid)
+        .peek(k -> keysPickedAfterValidity.addAndGet(1))
+        .filter(key -> sharingPoliciesChecker.canShareKeyAtTime(key, policy, LocalDateTime.now(UTC)))
+        .peek(k -> keysPickedAfterSharePolicy.addAndGet(1))
+        .collect(Collectors.toList());
+
+    logger.info("{} keys picked after read from upload table", keysPicked.get());
+    logger.info("{} keys remaining after filtering by consent", keysPickedAfterConsent.get());
+    logger.info("{} keys remaining after filtering by validity", keysPickedAfterValidity.get());
+    logger.info("{} keys remaining after filtering by share policy", keysPickedAfterSharePolicy.get());
+
+    return listOfKeys;
   }
 
   /**

--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/runner/Upload.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/runner/Upload.java
@@ -84,7 +84,15 @@ public class Upload implements ApplicationRunner {
                 ByteString.copyFrom(diagnosisKey.getKeyData()).toStringUtf8()))
             .collect(Collectors.toList()).get(index))
         .collect(Collectors.toList());
-    logger.error("Error on {} keys, marking them for retry", retryKeys.size());
+
+    if (result.getStatus409().size() > 0 || result.getStatus500().size() > 0) {
+      logger.info("Some keys were not processed correctly");
+      logger.info("{} keys marked with status 201 (Successful)", result.getStatus201().size());
+      logger.info("{} keys marked with status 409 (Conflict)", result.getStatus409().size());
+      logger.info("{} keys marked with status 500 (Retry)", result.getStatus500().size());
+    } else {
+      logger.info("All keys processed successfully");
+    }
     return retryKeys;
   }
 

--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/runner/Upload.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/runner/Upload.java
@@ -85,7 +85,7 @@ public class Upload implements ApplicationRunner {
             .collect(Collectors.toList()).get(index))
         .collect(Collectors.toList());
 
-    if (result.getStatus409().size() > 0 || result.getStatus500().size() > 0) {
+    if (!result.getStatus409().isEmpty() || !result.getStatus500().isEmpty()) {
       logger.info("Some keys were not processed correctly");
       logger.info("{} keys marked with status 201 (Successful)", result.getStatus201().size());
       logger.info("{} keys marked with status 409 (Conflict)", result.getStatus409().size());

--- a/services/upload/src/main/resources/application-dev.yaml
+++ b/services/upload/src/main/resources/application-dev.yaml
@@ -1,0 +1,14 @@
+---
+logging:
+  level:
+    org:
+      springframework:
+        web: DEBUG
+    app:
+      coronawarn: DEBUG
+
+feign:
+  client:
+    config:
+      default:
+        loggerLevel: FULL


### PR DESCRIPTION
- Logs number of keys received per status code on 207 status upload
- Adds `toString()` method to `BatchUploadResponse` to show payload content in console
- Adds breakdown of keys selected to upload based on each filter criteria 
- Adds a new profile `dev` to Upload that sets log level to DEBUG and logs feign client request 