### PR TITLE
Rework Upload TestDataGeneration

### DIFF
--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/config/UploadServiceConfig.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/config/UploadServiceConfig.java
@@ -100,14 +100,14 @@ public class UploadServiceConfig {
   }
 
   public static class TestData {
-    private int keysPerHour;
+    private int maxPendingKeys;
 
-    public int getKeysPerHour() {
-      return keysPerHour;
+    public int getMaxPendingKeys() {
+      return maxPendingKeys;
     }
 
-    public void setKeysPerHour(int keysPerHour) {
-      this.keysPerHour = keysPerHour;
+    public void setMaxPendingKeys(int maxPendingKeys) {
+      this.maxPendingKeys = maxPendingKeys;
     }
   }
 

--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/testdata/TestDataUploadRepository.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/testdata/TestDataUploadRepository.java
@@ -52,6 +52,6 @@ public interface TestDataUploadRepository
       @Param("days_since_onset_of_symptoms") int daysSinceOnsetOfSymptoms,
       @Param("consent_to_federation") boolean consentToFederation);
 
-  @Query("SELECT MAX(submission_timestamp) FROM federation_upload_key")
-  Optional<Long> getMaxSubmissionTimestamp();
+  @Query("SELECT COUNT(*) FROM federation_upload_key WHERE batch_tag IS NULL")
+  Integer countPendingKeys();
 }

--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/testdata/TestDataUploadRepository.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/testdata/TestDataUploadRepository.java
@@ -21,7 +21,6 @@
 package app.coronawarn.server.services.federation.upload.testdata;
 
 import app.coronawarn.server.common.persistence.domain.FederationUploadKey;
-import java.util.Optional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jdbc.repository.query.Modifying;
 import org.springframework.data.jdbc.repository.query.Query;

--- a/services/upload/src/main/resources/application-testdata.yaml
+++ b/services/upload/src/main/resources/application-testdata.yaml
@@ -2,4 +2,4 @@
 services:
   upload:
     test-data:
-      keys-per-hour: 350
+      max-pending-keys: 8000

--- a/services/upload/src/test/resources/application-testdata.yaml
+++ b/services/upload/src/test/resources/application-testdata.yaml
@@ -2,4 +2,4 @@
 services:
   upload:
     test-data:
-      keys-per-hour: 200
+      max-pending-keys: 8000


### PR DESCRIPTION
If the upload fails, pending keys are left with an empty batch tag in the DB. This means that after many failed upload runs, we can get a pretty high amount of fake keys in the DB. 

This PR changes the TestDataGeneration to generate fake keys only until a threshold is met (currently set to 8k). 