### PR TITLE
hotfix empty visited_countries list

### DIFF
--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/ProdDiagnosisKeyBundlerKeyRetrievalTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/ProdDiagnosisKeyBundlerKeyRetrievalTest.java
@@ -13,6 +13,7 @@ import app.coronawarn.server.services.distribution.config.DistributionServiceCon
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -74,6 +75,17 @@ class ProdDiagnosisKeyBundlerKeyRetrievalTest {
   }
 
   @Test
+  void testGetAllDiagnosisKeysWhenEmptyVisitedCountries() {
+    List<DiagnosisKey> diagnosisKeys = Stream
+        .of(buildDiagnosisKeys(6, 50L, 5, Collections.emptySet()),
+            buildDiagnosisKeys(6, 51L, 5))
+        .flatMap(List::stream)
+        .collect(Collectors.toList());
+    bundler.setDiagnosisKeys(diagnosisKeys, LocalDateTime.of(1970, 1, 5, 0, 0));
+    assertThat(bundler.getAllDiagnosisKeys("DE")).hasSize(10);
+  }
+
+  @Test
   void testGetDatesForEmptyListWithWrongCountry() {
     bundler.setDiagnosisKeys(emptySet(), LocalDateTime.of(1970, 1, 5, 0, 0));
     assertThat(bundler.getDiagnosisKeysForHour(LocalDateTime.of(1970, 1, 1, 0, 0, 0), INVALID_COUNTRY)).isEmpty();
@@ -84,6 +96,7 @@ class ProdDiagnosisKeyBundlerKeyRetrievalTest {
     bundler.setDiagnosisKeys(emptySet(), LocalDateTime.of(1970, 1, 5, 0, 0));
     assertThat(bundler.getDatesWithDistributableDiagnosisKeys("DE")).isEmpty();
   }
+
   @Test
   void testGetsDatesWithDistributableDiagnosisKeys() {
     List<DiagnosisKey> diagnosisKeys = Stream

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/common/Helpers.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/common/Helpers.java
@@ -70,6 +70,12 @@ public class Helpers {
         "DE", Set.of("DE"), ReportType.CONFIRMED_CLINICAL_DIAGNOSIS, 1);
   }
 
+  public static List<DiagnosisKey> buildDiagnosisKeys(int startIntervalNumber, long submissionTimestamp,
+      int number, Set<String> visitedCountries) {
+    return buildDiagnosisKeys(startIntervalNumber, submissionTimestamp, number,
+        "DE", visitedCountries, ReportType.CONFIRMED_CLINICAL_DIAGNOSIS, 1);
+  }
+
   public static List<DiagnosisKey> buildDiagnosisKeys(int startIntervalNumber,
       long submissionTimestamp,
       int number,


### PR DESCRIPTION
Keys added prior to 1.5 will for sure have `visited_countries` as empty on the DB, this would stop them from being distributed if they were quarantined during the upgrade.

This patch is done on assembling the `Country -> Keys` map by treating keys with empty visited countries as keys from the origin country in `application.yaml`.  