### PR TITLE
Introduce new paramter that allows to enforce downloading batches for…

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/FederationBatchInfoRepository.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/FederationBatchInfoRepository.java
@@ -42,4 +42,11 @@ public interface FederationBatchInfoRepository extends PagingAndSortingRepositor
   @Modifying
   @Query("DELETE FROM federation_batch_info WHERE date<:threshold")
   void deleteOlderThan(@Param("threshold") LocalDate date);
+
+  @Query("SELECT COUNT(*) FROM federation_batch_info WHERE date=:date")
+  int countForDate(@Param("date") LocalDate date);
+
+  @Modifying
+  @Query("DELETE FROM federation_batch_info WHERE date=:date")
+  void deleteForDate(@Param("date") LocalDate date);
 }

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/FederationBatchInfoService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/FederationBatchInfoService.java
@@ -47,6 +47,12 @@ public class FederationBatchInfoService {
     logger.info("Marked batch with status {}.", statusValue);
   }
 
+  /**
+   * Returns all batch information entries with a given status.
+   *
+   * @param federationBatchStatus the status the batch information entries should have.
+   * @return the list of batch information entries with the given status.
+   */
   public List<FederationBatchInfo> findByStatus(FederationBatchStatus federationBatchStatus) {
     return federationBatchInfoRepository.findByStatus(federationBatchStatus.name());
   }
@@ -69,5 +75,18 @@ public class FederationBatchInfoService {
     logger.info("Deleting {} batch info(s) with a date older than {} day(s) ago.",
         numberOfDeletions, daysToRetain);
     federationBatchInfoRepository.deleteOlderThan(threshold);
+  }
+
+  /**
+   * Deletes all federation batch information entries which have a specific date.
+   *
+   * @param date The date for which the batch information entries should be deleted.
+   */
+  @Transactional
+  public void deleteForDate(LocalDate date) {
+    int numberOfDeletions = federationBatchInfoRepository.countForDate(date);
+    logger.info("Deleting {} batch info(s) for date {}.",
+        numberOfDeletions, date);
+    federationBatchInfoRepository.deleteForDate(date);
   }
 }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/repository/FederationBatchInfoRepositoryTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/repository/FederationBatchInfoRepositoryTest.java
@@ -18,6 +18,7 @@ class FederationBatchInfoRepositoryTest {
 
   private static final String batchTag1 = "11111";
   private static final String batchTag2 = "22222";
+  private static final String batchTag3 = "33333";
   private static final LocalDate date1 = LocalDate.parse("2020-08-15");
   private static final LocalDate date2 = LocalDate.parse("2020-08-16");
   private static final String statusError = FederationBatchStatus.ERROR.name();
@@ -57,5 +58,25 @@ class FederationBatchInfoRepositoryTest {
   void testReturnsEmptyListIfNoUnprocessedBatch() {
     federationBatchInfoRepository.saveDoNothingOnConflict(batchTag1, date1, statusProcessed);
     assertThat(federationBatchInfoRepository.findByStatus(statusUnprocessed)).isEmpty();
+  }
+
+  @Test
+  void testCountForDate() {
+    federationBatchInfoRepository.saveDoNothingOnConflict(batchTag1, date1, statusUnprocessed);
+    federationBatchInfoRepository.saveDoNothingOnConflict(batchTag2, date2, statusUnprocessed);
+    federationBatchInfoRepository.saveDoNothingOnConflict(batchTag3, date2, statusUnprocessed);
+    assertThat(federationBatchInfoRepository.countForDate(date1)).isEqualTo(1);
+    assertThat(federationBatchInfoRepository.countForDate(date2)).isEqualTo(2);
+  }
+
+  @Test
+  void testDeleteForDate() {
+    federationBatchInfoRepository.saveDoNothingOnConflict(batchTag1, date1, statusUnprocessed);
+    federationBatchInfoRepository.saveDoNothingOnConflict(batchTag2, date2, statusUnprocessed);
+    assertThat(federationBatchInfoRepository.countForDate(date1)).isEqualTo(1);
+    assertThat(federationBatchInfoRepository.countForDate(date2)).isEqualTo(1);
+    federationBatchInfoRepository.deleteForDate(date1);
+    assertThat(federationBatchInfoRepository.countForDate(date1)).isEqualTo(0);
+    assertThat(federationBatchInfoRepository.countForDate(date2)).isEqualTo(1);
   }
 }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/FederationBatchInfoServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/FederationBatchInfoServiceTest.java
@@ -132,4 +132,15 @@ class FederationBatchInfoServiceTest {
 
     assertThat(actualBatchInfos).isEmpty();
   }
+
+  @Test
+  void testDeleteForDay() {
+    LocalDate date = LocalDate.now(ZoneOffset.UTC);
+    FederationBatchInfo expectedBatchInfo = new FederationBatchInfo(batchTag, date);
+    federationBatchInfoService.save(expectedBatchInfo);
+
+    assertThat(federationBatchInfoService.findByStatus(FederationBatchStatus.UNPROCESSED)).hasSize(1);
+    federationBatchInfoService.deleteForDate(date);
+    assertThat(federationBatchInfoService.findByStatus(FederationBatchStatus.UNPROCESSED)).isEmpty();
+  }
 }

--- a/services/download/src/main/java/app/coronawarn/server/services/download/FederationBatchProcessor.java
+++ b/services/download/src/main/java/app/coronawarn/server/services/download/FederationBatchProcessor.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.download;
 
 import static app.coronawarn.server.common.persistence.domain.FederationBatchStatus.ERROR;
@@ -19,6 +17,8 @@ import app.coronawarn.server.services.download.config.DownloadServiceConfig;
 import app.coronawarn.server.services.download.normalization.FederationKeyNormalizer;
 import app.coronawarn.server.services.download.validation.ValidFederationKeyFilter;
 import java.time.LocalDate;
+import java.time.Period;
+import java.time.ZoneOffset;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
@@ -69,12 +69,31 @@ public class FederationBatchProcessor {
    * @param date The date for which the first batch info is stored.
    */
   public void saveFirstBatchInfoForDate(LocalDate date) {
+    checkIfDownloadShouldBeForced(date);
     try {
       logger.info("Triggering download of first batch for date {}.", date);
       BatchDownloadResponse response = federationGatewayDownloadService.downloadBatch(date);
       batchInfoService.save(new FederationBatchInfo(response.getBatchTag(), date));
     } catch (Exception e) {
       logger.error("Triggering download of first batch for date {} failed.", date, e);
+    }
+  }
+
+  /**
+   * The Federation Batch Info stores information about which batches have already been processed to not download them
+   * again. The batches for the current day might change constantly when national backends upload keys, hence there is
+   * the need to download the batches for today again. Hence, the entries in federation batch info with the current day
+   * need to be removed. There is a parameter 'efgs-repeat-download-offset-days' with default 0 for
+   * that.
+   *
+   * @param date The date the download was triggered for
+   */
+  public void checkIfDownloadShouldBeForced(LocalDate date) {
+    LocalDate downloadAgainDate = LocalDate.now(ZoneOffset.UTC)
+        .minus(Period.ofDays(config.getEfgsEnforceDownloadOffsetDays()));
+    if (downloadAgainDate.equals(date)) {
+      logger.info("Preparing database to enforce download of batches for day {} again.", date);
+      batchInfoService.deleteForDate(downloadAgainDate);
     }
   }
 

--- a/services/download/src/main/java/app/coronawarn/server/services/download/config/DownloadServiceConfig.java
+++ b/services/download/src/main/java/app/coronawarn/server/services/download/config/DownloadServiceConfig.java
@@ -21,6 +21,9 @@ public class DownloadServiceConfig {
   @Max(14)
   private Integer efgsOffsetDays;
   @Min(0)
+  @Max(14)
+  private Integer efgsEnforceDownloadOffsetDays;
+  @Min(0)
   @Max(28)
   private Integer retentionDays;
   private Validation validation;
@@ -50,6 +53,14 @@ public class DownloadServiceConfig {
 
   public void setEfgsOffsetDays(Integer efgsOffsetDays) {
     this.efgsOffsetDays = efgsOffsetDays;
+  }
+
+  public Integer getEfgsEnforceDownloadOffsetDays() {
+    return efgsEnforceDownloadOffsetDays;
+  }
+
+  public void setEfgsEnforceDownloadOffsetDays(Integer efgsEnforceDownloadOffsetDays) {
+    this.efgsEnforceDownloadOffsetDays = efgsEnforceDownloadOffsetDays;
   }
 
   public Integer getRetentionDays() {

--- a/services/download/src/main/java/app/coronawarn/server/services/download/runner/Download.java
+++ b/services/download/src/main/java/app/coronawarn/server/services/download/runner/Download.java
@@ -29,8 +29,8 @@ public class Download implements ApplicationRunner {
 
   @Override
   public void run(ApplicationArguments args) {
-    LocalDate yesterday = LocalDate.now(ZoneOffset.UTC).minus(Period.ofDays(serviceConfig.getEfgsOffsetDays()));
-    batchProcessor.saveFirstBatchInfoForDate(yesterday);
+    LocalDate downloadDate = LocalDate.now(ZoneOffset.UTC).minus(Period.ofDays(serviceConfig.getEfgsOffsetDays()));
+    batchProcessor.saveFirstBatchInfoForDate(downloadDate);
     batchProcessor.processErrorFederationBatches();
     batchProcessor.processUnprocessedFederationBatches();
   }

--- a/services/download/src/main/resources/application.yaml
+++ b/services/download/src/main/resources/application.yaml
@@ -14,6 +14,9 @@ services:
     # the keys for today. If it is set to 1, the keys from yesterday will be downloaded.
     # The value must be between 0 and 14.
     efgs-offset-days: ${EFGS_OFFSET_DAYS:1}
+    # The offset in days for which the keys from the federation gateway shall be downloaded from,
+    # ignoring if a batch of this day has already been downloaded.
+    efgs-enforce-download-offset-days: ${EFGS_ENFORCE_DOWNLOAD_OFFSET_DAYS:0}
     # The number of days to retain batch information in the database.
     retention-days: 14
     validation:

--- a/services/download/src/test/java/app/coronawarn/server/services/download/DownloadEnforceDownloadAgainIntegrationTest.java
+++ b/services/download/src/test/java/app/coronawarn/server/services/download/DownloadEnforceDownloadAgainIntegrationTest.java
@@ -1,0 +1,126 @@
+package app.coronawarn.server.services.download;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+
+import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
+import app.coronawarn.server.common.persistence.repository.DiagnosisKeyRepository;
+import app.coronawarn.server.common.persistence.repository.FederationBatchInfoRepository;
+import app.coronawarn.server.common.protocols.external.exposurenotification.DiagnosisKeyBatch;
+import app.coronawarn.server.common.protocols.external.exposurenotification.ReportType;
+import app.coronawarn.server.services.download.config.DownloadServiceConfig;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
+import com.google.protobuf.ByteString;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * This integration test is responsible for testing the runners for downloading today's batches again. The Spring
+ * profile "federation-download-today-again-integration" enables the test data generation in
+ * /db/testdata-download-today-again/V99__createTestDataForDownloadTodayAgainIntegrationTest.sql via the
+ * application-federation-download-today-again-integration.yaml.
+ * <p>
+ * The sql script for the test data contains a batch info for an already downloaded successfully processed batch today.
+ * This test should verify that the download is triggered for the whole day again to incorporate changes of the batches
+ * on the EFGS that might have happened since the last download.
+ * <p>
+ * The WireMockServer will additionally return a series of two batches:
+ * <li>Batch1 is the first batch of the corresponding date..</li>
+ * <li>Batch2 is the second batch of the corresponding date which is new on the EFGS.</li>
+ * <p>
+ * Hence, after the execution of both runners, the federation_batch_info table should be the following:
+ * <li>"batch1_tag" has state "PROCESSED"</li>
+ * <li>"batch2_tag" has state "PROCESSED"</li>
+ * <p>
+ * The diagnosis_key table should contain the data that correspond to the two batches with state "PROCESSED".
+ */
+@SpringBootTest
+@ActiveProfiles("federation-enforce-download-again-integration")
+@DirtiesContext
+class DownloadEnforceDownloadAgainIntegrationTest {
+
+  private static final String BATCH1_TAG = "batch1_tag";
+  private static final String BATCH1_KEY_DATA = "0123456789ABCDEA";
+
+  private static final String BATCH2_TAG = "batch2_tag";
+  private static final String BATCH2_KEY_DATA = "0123456789ABCDEB";
+
+  private static final String EMPTY_BATCH_TAG = "null";
+
+  private static WireMockServer server;
+
+  @Autowired
+  private FederationBatchInfoRepository federationBatchInfoRepository;
+
+  @Autowired
+  private DiagnosisKeyRepository diagnosisKeyRepository;
+
+  @Autowired
+  private DownloadServiceConfig downloadServiceConfig;
+
+  @BeforeAll
+  static void setupWireMock() {
+    HttpHeaders batch1Headers = getHttpHeaders(BATCH1_TAG, BATCH2_TAG);
+    DiagnosisKeyBatch batch1 = FederationBatchTestHelper.createDiagnosisKeyBatch(BATCH1_KEY_DATA);
+
+    HttpHeaders batch2Headers = getHttpHeaders(BATCH2_TAG, EMPTY_BATCH_TAG);
+    DiagnosisKeyBatch batch2 = FederationBatchTestHelper.createDiagnosisKeyBatch(BATCH2_KEY_DATA);
+
+    server = new WireMockServer(options().port(1234));
+    server.start();
+    server.stubFor(
+        get(anyUrl())
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.OK.value())
+                    .withHeaders(batch1Headers)
+                    .withBody(batch1.toByteArray())));
+    server.stubFor(
+        get(anyUrl())
+            .withHeader("batchTag", equalTo(BATCH2_TAG))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.OK.value())
+                    .withHeaders(batch2Headers)
+                    .withBody(batch2.toByteArray())));
+  }
+
+  private static HttpHeaders getHttpHeaders(String batchTag, String nextBatchTag) {
+    return new HttpHeaders()
+        .plus(new HttpHeader(CONTENT_TYPE, "application/protobuf; version=1.0"))
+        .plus(new HttpHeader("batchTag", batchTag))
+        .plus(new HttpHeader("nextBatchTag", nextBatchTag));
+  }
+
+  @AfterAll
+  static void tearDown() {
+    server.stop();
+  }
+
+  @Test
+  void testDownloadRunSuccessfully() {
+    assertThat(federationBatchInfoRepository.findAll()).hasSize(2);
+    assertThat(federationBatchInfoRepository.findByStatus("UNPROCESSED")).isEmpty();
+    assertThat(federationBatchInfoRepository.findByStatus("PROCESSED")).hasSize(2);
+
+    Iterable<DiagnosisKey> diagnosisKeys = diagnosisKeyRepository.findAll();
+    assertThat(diagnosisKeys)
+        .hasSize(2)
+        .contains(FederationBatchTestHelper.createDiagnosisKey(BATCH1_KEY_DATA, downloadServiceConfig))
+        .contains(FederationBatchTestHelper.createDiagnosisKey(BATCH2_KEY_DATA, downloadServiceConfig));
+  }
+}

--- a/services/download/src/test/java/app/coronawarn/server/services/download/FederationBatchProcessorTest.java
+++ b/services/download/src/test/java/app/coronawarn/server/services/download/FederationBatchProcessorTest.java
@@ -33,6 +33,7 @@ import app.coronawarn.server.services.download.validation.ValidFederationKeyFilt
 import com.google.protobuf.ByteString;
 import feign.FeignException;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
@@ -108,6 +109,16 @@ class FederationBatchProcessorTest {
       batchProcessor.saveFirstBatchInfoForDate(date);
 
       Mockito.verify(batchInfoService, never()).save(any());
+    }
+
+    @Test
+    void testBatchInfoForTodayIsDeleted() {
+      LocalDate date = LocalDate.now(ZoneOffset.UTC);
+      when(federationGatewayDownloadService.downloadBatch(date)).thenReturn(null);
+
+      batchProcessor.saveFirstBatchInfoForDate(date);
+
+      Mockito.verify(batchInfoService, times(1)).deleteForDate(date);
     }
   }
 

--- a/services/download/src/test/resources/application-federation-enforce-download-again-integration.yaml
+++ b/services/download/src/test/resources/application-federation-enforce-download-again-integration.yaml
@@ -1,0 +1,10 @@
+---
+spring:
+  flyway:
+    locations: classpath:/db/migration,classpath:/db/testdata-enforce-download-again
+
+services:
+  download:
+    efgs-offset-days: 0
+    efgs-enforce-download-offset-days: 0
+

--- a/services/download/src/test/resources/application.yaml
+++ b/services/download/src/test/resources/application.yaml
@@ -22,6 +22,7 @@ logging:
 services:
   download:
     efgs-offset-days: 1
+    efgs-enforce-download-offset-days: 0
     retention-days: 14
     validation:
       allowed-report-types: CONFIRMED_TEST

--- a/services/download/src/test/resources/db/testdata-enforce-download-again/V99__createTestDataForDownloadTodayAgainIntegrationTest.sql
+++ b/services/download/src/test/resources/db/testdata-enforce-download-again/V99__createTestDataForDownloadTodayAgainIntegrationTest.sql
@@ -1,0 +1,1 @@
+INSERT INTO federation_batch_info(batch_tag, date, status) VALUES ('batch1_tag', current_timestamp, 'PROCESSED');


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

The Federation Batch Info stores information about which batches have already been processed to not download them again. The batches for the current day might change constantly when national backends upload keys, hence there is the need to download the batches for today again. Hence, the entries in federation batch info with the current day need to be removed. There is a parameter 'efgs-repeat-download-offset-days' with default 0 for that.
