### PR TITLE
Set reportType to ConfirmedTest for each downloaded key

### DIFF
--- a/services/download/src/main/java/app/coronawarn/server/services/download/FederationBatchProcessor.java
+++ b/services/download/src/main/java/app/coronawarn/server/services/download/FederationBatchProcessor.java
@@ -15,6 +15,7 @@ import app.coronawarn.server.common.persistence.domain.FederationBatchStatus;
 import app.coronawarn.server.common.persistence.service.DiagnosisKeyService;
 import app.coronawarn.server.common.persistence.service.FederationBatchInfoService;
 import app.coronawarn.server.common.protocols.external.exposurenotification.DiagnosisKeyBatch;
+import app.coronawarn.server.common.protocols.external.exposurenotification.ReportType;
 import app.coronawarn.server.services.download.config.DownloadServiceConfig;
 import app.coronawarn.server.services.download.normalization.FederationKeyNormalizer;
 import app.coronawarn.server.services.download.validation.ValidFederationKeyFilter;
@@ -158,6 +159,7 @@ public class FederationBatchProcessor {
       app.coronawarn.server.common.protocols.external.exposurenotification.DiagnosisKey diagnosisKey) {
     try {
       return Optional.of(DiagnosisKey.builder().fromFederationDiagnosisKey(diagnosisKey)
+          .withReportType(ReportType.CONFIRMED_TEST)
           .withFieldNormalization(new FederationKeyNormalizer(config))
           .build());
     } catch (Exception ex) {

--- a/services/download/src/main/resources/application.yaml
+++ b/services/download/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ services:
     # The number of days to retain batch information in the database.
     retention-days: 14
     validation:
-      allowed-report-types: ${ALLOWED_REPORT_TYPES:CONFIRMED_TEST}
+      allowed-report-types: ${ALLOWED_REPORT_TYPES:CONFIRMED_TEST,CONFIRMED_CLINICAL_DIAGNOSIS}
 
 federation-gateway:
   base-url: ${FEDERATION_GATEWAY_BASE_URL:http://localhost:8005}

--- a/services/download/src/test/java/app/coronawarn/server/services/download/DownloadIntegrationTest.java
+++ b/services/download/src/test/java/app/coronawarn/server/services/download/DownloadIntegrationTest.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.download;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -42,10 +40,11 @@ import org.springframework.test.context.ActiveProfiles;
  * accordingly.
  * <p>
  * The WireMockServer will additionally return a series of three batches:
- * <li>Batch1 is the first batch of the corresponding date. The first and fourth diagnosis keys can be processed
- * successfully.
- * The second diagnosis key is rejected due to its unsupported ReportType "Self Reported". The third diagnosis key is
- * rejected due to its invalid RollingPeriod.</li>
+ * <li>Batch1 is the first batch of the corresponding date. The first diagnosis key can be processed
+ * successfully. The second diagnosis key is rejected due to its unsupported ReportType "Self Reported". The third
+ * diagnosis key is rejected due to its invalid RollingPeriod. The fourth diagnosis key can be processed successfully,
+ * but its ReportType is CONFIRMED_CLINICAL_DIAGNOSIS which should be changed to CONFIRMED_TEST during the
+ * download.</li>
  * <li>Batch2 is returned by an explicit call to its batch tag and can be processed successfully as well.</li>
  * <li>Batch3 fails with a 404 Not Found.</li>
  * <p>
@@ -104,6 +103,7 @@ class DownloadIntegrationTest {
             FederationBatchTestHelper.createBuilderForValidFederationDiagnosisKey()
                 .setKeyData(ByteString.copyFromUtf8(BATCH1_KEY4_DATA))
                 .setTransmissionRiskLevel(Integer.MAX_VALUE)
+                .setReportType(ReportType.CONFIRMED_CLINICAL_DIAGNOSIS)
                 .build(),
             FederationBatchTestHelper
                 .createBuilderForValidFederationDiagnosisKey()

--- a/services/download/src/test/resources/application.yaml
+++ b/services/download/src/test/resources/application.yaml
@@ -24,7 +24,7 @@ services:
     efgs-offset-days: 1
     retention-days: 14
     validation:
-      allowed-report-types: CONFIRMED_TEST
+      allowed-report-types: CONFIRMED_TEST,CONFIRMED_CLINICAL_DIAGNOSIS
 
 federation-gateway:
   base-url: http://localhost:1234


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

From EFGS integration perspective we were asked to accept keys of types "CONFIRMED_TEST" and "CONFIRMED_CLINICAL_DIAGNOSIS".
But due to DPP reasons we are not allowed to distribute the real report type values to CDN. Therefore we default report type to CONFIRMED_TEST for all keys coming from EFGS.
