### PR TITLE
revert change to existing migration

### DIFF
--- a/common/persistence/src/main/resources/db/migration/V3__createAndUpdateTablesForFederation.sql
+++ b/common/persistence/src/main/resources/db/migration/V3__createAndUpdateTablesForFederation.sql
@@ -11,7 +11,7 @@ ALTER TABLE diagnosis_key
 ALTER TABLE diagnosis_key
     ADD visited_countries VARCHAR(2)[];
 ALTER TABLE diagnosis_key
-    ADD report_type VARCHAR(30) DEFAULT 'CONFIRMED_TEST';
+    ADD report_type VARCHAR(30) DEFAULT 'CONFIRMED_CLINICAL_DIAGNOSIS';
 ALTER TABLE diagnosis_key
     ADD days_since_onset_of_symptoms INTEGER;
 


### PR DESCRIPTION
PR #887 accidentally changed an existing migration, which now causes DB conflicts between `release/1.5` and `master`. 