### PR TITLE
Rollback the vault-integration-ssl feature

### DIFF
--- a/services/distribution/Dockerfile
+++ b/services/distribution/Dockerfile
@@ -30,7 +30,7 @@ RUN ${WORK_DIR}/mvnw --batch-mode -DskipTests=true --file ${WORK_DIR}/pom.xml ${
 RUN cp ${WORK_DIR}/services/distribution/target/distribution-*.jar /usr/sap/distribution-service/distribution.jar
 RUN cp ${WORK_DIR}/scripts/DpkgHelper.java /DpkgHelper.java
 
-FROM gcr.io/distroless/java-debian10:11
+FROM gcr.io/distroless/java:11
 COPY --from=build /DpkgHelper.java .
 COPY --from=build /usr/sap/distribution-service/distribution.jar .
 RUN ["java", "DpkgHelper.java"]

--- a/services/download/Dockerfile
+++ b/services/download/Dockerfile
@@ -29,7 +29,7 @@ RUN ${WORK_DIR}/mvnw --batch-mode -DskipTests=true --file ${WORK_DIR}/pom.xml ${
 RUN cp ${WORK_DIR}/services/download/target/download-*.jar /usr/sap/download-service/download.jar
 RUN cp ${WORK_DIR}/scripts/DpkgHelper.java /DpkgHelper.java
 
-FROM gcr.io/distroless/java-debian10:11
+FROM gcr.io/distroless/java:11
 COPY --from=build /DpkgHelper.java .
 COPY --from=build /usr/sap/download-service/download.jar .
 RUN ["java", "DpkgHelper.java"]

--- a/services/submission/Dockerfile
+++ b/services/submission/Dockerfile
@@ -29,7 +29,7 @@ RUN ${WORK_DIR}/mvnw --batch-mode -DskipTests=true --file ${WORK_DIR}/pom.xml ${
 RUN cp ${WORK_DIR}/services/submission/target/submission-*.jar /usr/sap/submission-service/submission.jar
 RUN cp ${WORK_DIR}/scripts/DpkgHelper.java /DpkgHelper.java
 
-FROM gcr.io/distroless/java-debian10:11
+FROM gcr.io/distroless/java:11
 COPY --from=build /DpkgHelper.java .
 COPY --from=build /usr/sap/submission-service/submission.jar .
 RUN ["java", "DpkgHelper.java"]

--- a/services/submission/src/main/resources/bootstrap-cloud.yaml
+++ b/services/submission/src/main/resources/bootstrap-cloud.yaml
@@ -4,9 +4,6 @@ spring:
     name: cwa-server
   cloud:
     vault:
-      ssl:
-        trust-store: file:${SSL_VAULT_TRUSTSTORE_PATH}
-        trust-store-password: ${SSL_VAULT_TRUSTSTORE_PASSWORD}
       enabled: true
       generic:
         enabled: false

--- a/services/upload/Dockerfile
+++ b/services/upload/Dockerfile
@@ -29,7 +29,7 @@ RUN ${WORK_DIR}/mvnw --batch-mode -DskipTests=true --file ${WORK_DIR}/pom.xml ${
 RUN cp ${WORK_DIR}/services/upload/target/upload-*.jar /usr/sap/upload-service/upload.jar
 RUN cp ${WORK_DIR}/scripts/DpkgHelper.java /DpkgHelper.java
 
-FROM gcr.io/distroless/java-debian10:11
+FROM gcr.io/distroless/java:11
 COPY --from=build /DpkgHelper.java .
 COPY --from=build /usr/sap/upload-service/upload.jar .
 RUN ["java", "DpkgHelper.java"]


### PR DESCRIPTION

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

This PR includes the rollback of the https-vault-integration feature. This rollback is needed because the feature cannot be completed for the next release.