### PR TITLE
Fix/upload testdata

### DIFF
--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilderTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilderTest.java
@@ -283,12 +283,12 @@ class DiagnosisKeyBuilderTest {
 
   @Test
   void submissionTimestampDoesNotThrowOnValid() {
-    assertThatCode(() -> buildDiagnosisKeyForSubmissionTimestamp(1L)).doesNotThrowAnyException();
-    assertThatCode(() -> buildDiagnosisKeyForSubmissionTimestamp(getCurrentHoursSinceEpoch()))
+    assertThatCode(() -> buildDiagnosisKeyForSubmissionTimestamp(1L, 144, false)).doesNotThrowAnyException();
+    assertThatCode(() -> buildDiagnosisKeyForSubmissionTimestamp(getCurrentHoursSinceEpoch(), 144, false))
         .doesNotThrowAnyException();
     assertThatCode(
         () -> buildDiagnosisKeyForSubmissionTimestamp(
-            Instant.now().minus(Duration.ofHours(2)).getEpochSecond() / SECONDS_PER_HOUR))
+            Instant.now().minus(Duration.ofHours(2)).getEpochSecond() / SECONDS_PER_HOUR, 144, false))
         .doesNotThrowAnyException();
   }
 

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilderTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilderTest.java
@@ -281,7 +281,7 @@ class DiagnosisKeyBuilderTest {
 
   @Test
   void submissionTimestampDoesNotThrowOnValid() {
-    assertThatCode(() -> buildDiagnosisKeyForSubmissionTimestamp(0L)).doesNotThrowAnyException();
+    assertThatCode(() -> buildDiagnosisKeyForSubmissionTimestamp(1L)).doesNotThrowAnyException();
     assertThatCode(() -> buildDiagnosisKeyForSubmissionTimestamp(getCurrentHoursSinceEpoch()))
         .doesNotThrowAnyException();
     assertThatCode(

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTest.java
@@ -48,7 +48,7 @@ class DiagnosisKeyServiceTest {
 
   @Test
   void testSaveAndRetrieve() {
-    var expKeys = list(buildDiagnosisKeyForSubmissionTimestamp(0L));
+    var expKeys = list(buildDiagnosisKeyForSubmissionTimestamp(1L));
 
     diagnosisKeyService.saveDiagnosisKeys(expKeys);
     var actKeys = diagnosisKeyService.getDiagnosisKeys();
@@ -59,8 +59,8 @@ class DiagnosisKeyServiceTest {
   @Test
   void testSortedRetrievalResult() {
     var expKeys = list(
-        buildDiagnosisKeyForSubmissionTimestamp(1L),
-        buildDiagnosisKeyForSubmissionTimestamp(0L));
+        buildDiagnosisKeyForSubmissionTimestamp(2L),
+        buildDiagnosisKeyForSubmissionTimestamp(1L));
 
     diagnosisKeyService.saveDiagnosisKeys(expKeys);
 
@@ -150,7 +150,7 @@ class DiagnosisKeyServiceTest {
   void testReturnedNumberOfInsertedKeysForNoConflict() {
     var keys = list(
         buildDiagnosisKeyForSubmissionTimestamp(1L),
-        buildDiagnosisKeyForSubmissionTimestamp(0L));
+        buildDiagnosisKeyForSubmissionTimestamp(2L));
 
     int actNumberOfInsertedRows = diagnosisKeyService.saveDiagnosisKeys(keys);
 

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTestHelper.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTestHelper.java
@@ -69,12 +69,17 @@ public class DiagnosisKeyServiceTestHelper {
         .build();
   }
 
+  public static int makeRollingStartIntervalFromSubmission(long submissionTimestamp) {
+    return (int)((submissionTimestamp - 24) * 6);
+  }
+
   public static DiagnosisKey buildDiagnosisKeyForSubmissionTimestamp(long submissionTimeStamp) {
     return buildDiagnosisKeyForSubmissionTimestamp(submissionTimeStamp, false);
   }
 
   public static DiagnosisKey buildDiagnosisKeyForSubmissionTimestamp(long submissionTimeStamp, boolean consentToShare) {
-    return buildDiagnosisKeyForSubmissionTimestamp(submissionTimeStamp, 600, consentToShare);
+    return buildDiagnosisKeyForSubmissionTimestamp(submissionTimeStamp,
+        makeRollingStartIntervalFromSubmission(submissionTimeStamp), consentToShare);
   }
 
   public static DiagnosisKey buildDiagnosisKeyForSubmissionTimestamp(long submissionTimeStamp,
@@ -89,7 +94,9 @@ public class DiagnosisKeyServiceTestHelper {
 
   public static DiagnosisKey buildDiagnosisKeyForDateTime(OffsetDateTime dateTime,
       String countryCode, Set<String> visitedCountries, ReportType reportType) {
-    return buildDiagnosisKeyForSubmissionTimestamp(dateTime.toEpochSecond() / 3600, 600, false, countryCode, visitedCountries, reportType);
+    var submissionTimeStamp = dateTime.toEpochSecond() / 3600;
+    return buildDiagnosisKeyForSubmissionTimestamp(submissionTimeStamp, makeRollingStartIntervalFromSubmission(submissionTimeStamp),
+        false, countryCode, visitedCountries, reportType);
   }
 
   /**

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTestHelper.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/DiagnosisKeyServiceTestHelper.java
@@ -70,7 +70,7 @@ public class DiagnosisKeyServiceTestHelper {
   }
 
   public static int makeRollingStartIntervalFromSubmission(long submissionTimestamp) {
-    return (int)((submissionTimestamp - 24) * 6);
+    return (int)((submissionTimestamp) * 6);
   }
 
   public static DiagnosisKey buildDiagnosisKeyForSubmissionTimestamp(long submissionTimeStamp) {

--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/config/UploadServiceConfig.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/config/UploadServiceConfig.java
@@ -14,9 +14,18 @@ public class UploadServiceConfig {
   private String privateKey;
   private String privateKeyPassword;
   private String certificate;
+  private Integer retentionDays;
   private Signature signature;
   private TestData testData;
   private EfgsTransmission efgsTransmission;
+
+  public Integer getRetentionDays() {
+    return retentionDays;
+  }
+
+  public void setRetentionDays(Integer retentionDays) {
+    this.retentionDays = retentionDays;
+  }
 
   public EfgsTransmission getEfgsTransmission() {
     return efgsTransmission;

--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/keys/DiagnosisKeyPersistenceLoader.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/keys/DiagnosisKeyPersistenceLoader.java
@@ -25,6 +25,8 @@ public class DiagnosisKeyPersistenceLoader implements DiagnosisKeyLoader {
   @Override
   public List<FederationUploadKey> loadDiagnosisKeys() {
     return this.uploadKeyService
-        .getPendingUploadKeys(ExpirationPolicy.of(uploadConfig.getExpiryPolicyMinutes(), ChronoUnit.MINUTES));
+        .getPendingUploadKeys(
+            ExpirationPolicy.of(uploadConfig.getExpiryPolicyMinutes(), ChronoUnit.MINUTES),
+            this.uploadConfig.getRetentionDays());
   }
 }

--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/runner/TestDataGeneration.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/runner/TestDataGeneration.java
@@ -75,7 +75,7 @@ public class TestDataGeneration implements ApplicationRunner {
         submissionTimestamp * ONE_HOUR_INTERVAL_SECONDS / TEN_MINUTES_INTERVAL_SECONDS;
     long minRollingStartIntervalNumber =
         maxRollingStartIntervalNumber
-            - TimeUnit.DAYS.toSeconds(13) / TEN_MINUTES_INTERVAL_SECONDS;
+            - TimeUnit.DAYS.toSeconds(11) / TEN_MINUTES_INTERVAL_SECONDS;
     return Math.toIntExact(getRandomBetween(minRollingStartIntervalNumber, maxRollingStartIntervalNumber));
   }
 

--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/runner/TestDataGeneration.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/runner/TestDataGeneration.java
@@ -100,6 +100,11 @@ public class TestDataGeneration implements ApplicationRunner {
    * @return List of Federation Upload Keys generated.
    */
   private List<FederationUploadKey> generateFakeKeysForPreviousDay() {
+    long timestamp = getCurrentTimestampTruncatedHour()
+        .minusDays(this.uploadServiceConfig.getRetentionDays())
+        .toEpochSecond(ZoneOffset.UTC) / 600L;
+    logger.info("Deleting test keys with rolling_start_interval_number less than {}", timestamp);
+    keyRepository.applyRetentionToTestKeys((int)timestamp);
     int pendingKeys = keyRepository.countPendingKeys();
     int maxPendingKeys = this.uploadServiceConfig.getTestData().getMaxPendingKeys();
     logger.info("Found {} pending upload keys on DB", pendingKeys);

--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/testdata/TestDataUploadRepository.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/testdata/TestDataUploadRepository.java
@@ -35,4 +35,8 @@ public interface TestDataUploadRepository
 
   @Query("SELECT COUNT(*) FROM federation_upload_key WHERE batch_tag IS NULL")
   Integer countPendingKeys();
+
+  @Modifying
+  @Query("DELETE FROM federation_upload_key WHERE rolling_start_interval_number<=:retention")
+  void applyRetentionToTestKeys(@Param("retention") int retention);
 }

--- a/services/upload/src/main/resources/application.yaml
+++ b/services/upload/src/main/resources/application.yaml
@@ -25,6 +25,8 @@ services:
     min-batch-key-count: 140
     # The maximum number of keys that an upload batch can contain
     max-batch-key-count: 4000
+    # Time window Federation Upload Keys will be loaded from DB
+    retention-days: 14
     privatekey: ${VAULT_EFGS_BATCHIGNING_SECRET}
     certificate: ${VAULT_EFGS_BATCHIGNING_CERTIFICATE}
     privatekey-password: ${VAULT_EFGS_BATCHSIGNING_PASSWORD}

--- a/services/upload/src/test/resources/application.yaml
+++ b/services/upload/src/test/resources/application.yaml
@@ -18,6 +18,7 @@ services:
     expiry-policy-minutes: 120
     min-batch-key-count: 140
     max-batch-key-count: 4000
+    retention-days: 14
     privatekey: classpath:testprivatekey.pem
     certificate: classpath:testpublickey.pem
     privatekey-password: testpass


### PR DESCRIPTION
This PR introduces two new things:
1. TestDataGeneration will clean up old keys that would only have been generated by TestDataGeneration or by manual addition to the DB (only relevant for test environments)
2. Upload will only pick up keys that have a valid rolling start interval. Based on our productive code we should never have any keys in that table that are invalid. But if for some other bug they are, Upload will avoid them. 

Internal tracking: EXPOSUREBACK-434