### PR TITLE
Define SUPPORTED_COUNTRIES docker env variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       POSTGRESQL_PASSWORD_FLYWAY: ${POSTGRES_FLYWAY_PASSWORD}
       POSTGRESQL_USER_FLYWAY: ${POSTGRES_FLYWAY_USER}
       VERIFICATION_BASE_URL: http://verification-fake:8004
+      SUPPORTED_COUNTRIES: DE,FR
   distribution:
     build:
       context: ./


### PR DESCRIPTION
We do not want to deliver default values for supported countries, as not defining them should result in an error. However, during development, we want those values to be available—especially for anybody new to the project. Solution: Define them in the docker script.

This PR solves:
submission_1         | ***************************
submission_1         | APPLICATION FAILED TO START
submission_1         | ***************************
submission_1         |
submission_1         | Description:
submission_1         |
submission_1         | Binding to target org.springframework.boot.context.properties.bind.BindException: Failed to bind properties under 'services.submission' to app.coronawarn.server.services.submission.config.SubmissionServiceConfig failed:
submission_1         |
submission_1         |     Property: services.submission.supportedCountries
submission_1         |     Value: null
submission_1         |     Reason: null
submission_1         |
submission_1         |
submission_1         | Action:
submission_1         |
submission_1         | Update your application's configuration