### PR TITLE
let's manage the codeowners via a dedicated team 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-*   @hilmarf @sorin-stefan-iovita-sap @KevponSAP @EvgeniiSkrebtcov @ioangut @kilbphilippSAP @emmetsap @EugenM-SAP @fredrb @mibrasap @JonasZeitzem-sap @FelixRottler @roesslerj
+*   @corona-warn-app/cwa-server-codeowners


### PR DESCRIPTION
instead of listing each individual

https://docs.github.com/en/enterprise-server@2.19/github/creating-cloning-and-archiving-repositories/about-code-owners 