### PR TITLE
Improve readability by using %maxLen{%m}{20} instead of %.-1000m

### DIFF
--- a/services/callback/src/main/resources/log4j2.xml
+++ b/services/callback/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%.-1000m} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{1000}} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">

--- a/services/distribution/src/main/resources/log4j2.xml
+++ b/services/distribution/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%.-1000m} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{1000}} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">

--- a/services/download/src/main/resources/log4j2.xml
+++ b/services/download/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%.-1000m} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{1000}} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">

--- a/services/submission/src/main/resources/log4j2.xml
+++ b/services/submission/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%.-1000m} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{1000}} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">


### PR DESCRIPTION
Very small change that will improve the readability of the logging config.