### PR TITLE
Rename proto cached names

### DIFF
--- a/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/internal/key_download_parameters.proto
+++ b/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/internal/key_download_parameters.proto
@@ -5,14 +5,14 @@ option java_multiple_files = true;
 
 message KeyDownloadParametersIOS {
 
-  repeated DayPackageMetadata cachedDayPackagesToUpdateOnETagMismatch = 1;
-  repeated HourPackageMetadata cachedHourPackagesToUpdateOnETagMismatch = 2;
+  repeated DayPackageMetadata revokedDayPackages = 1;
+  repeated HourPackageMetadata revokedHourPackages = 2;
 }
 
 message KeyDownloadParametersAndroid {
 
-  repeated DayPackageMetadata cachedDayPackagesToUpdateOnETagMismatch = 1;
-  repeated HourPackageMetadata cachedHourPackagesToUpdateOnETagMismatch = 2;
+  repeated DayPackageMetadata revokedDayPackages = 1;
+  repeated HourPackageMetadata revokedHourPackages = 2;
 
   int32 downloadTimeoutInSeconds = 3;
 

--- a/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/internal/v2/key_download_parameters.proto
+++ b/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/internal/v2/key_download_parameters.proto
@@ -5,14 +5,14 @@ option java_multiple_files = true;
 
 message KeyDownloadParametersIOS {
 
-  repeated DayPackageMetadata cachedDayPackagesToUpdateOnETagMismatch = 1;
-  repeated HourPackageMetadata cachedHourPackagesToUpdateOnETagMismatch = 2;
+  repeated DayPackageMetadata revokedDayPackages = 1;
+  repeated HourPackageMetadata revokedHourPackages = 2;
 }
 
 message KeyDownloadParametersAndroid {
 
-  repeated DayPackageMetadata cachedDayPackagesToUpdateOnETagMismatch = 1;
-  repeated HourPackageMetadata cachedHourPackagesToUpdateOnETagMismatch = 2;
+  repeated DayPackageMetadata revokedDayPackages = 1;
+  repeated HourPackageMetadata revokedHourPackages = 2;
 
   int32 downloadTimeoutInSeconds = 3;
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/ApplicationConfigurationPublicationConfig.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/ApplicationConfigurationPublicationConfig.java
@@ -102,9 +102,9 @@ public class ApplicationConfigurationPublicationConfig {
     return KeyDownloadParametersAndroid.newBuilder()
         .setOverallTimeoutInSeconds(androidKeyDownloadParameters.getOverallTimeoutInSeconds())
         .setDownloadTimeoutInSeconds(androidKeyDownloadParameters.getDownloadTimeoutInSeconds())
-        .addAllCachedDayPackagesToUpdateOnETagMismatch(buildCachedDayPackagesToUpdateOnETagMismatch(
+        .addAllRevokedDayPackages(buildRevokedDayPackages(
             androidKeyDownloadParameters.getRevokedDayPackages()))
-        .addAllCachedHourPackagesToUpdateOnETagMismatch(buildCachedHourPackagesToUpdateOnETagMismatch(
+        .addAllRevokedHourPackages(buildRevokedHourPackages(
             androidKeyDownloadParameters.getRevokedHourPackages()))
         .build();
   }
@@ -119,9 +119,9 @@ public class ApplicationConfigurationPublicationConfig {
     IosKeyDownloadParameters iosKeyDownloadParameters =
         distributionServiceConfig.getAppConfigParameters().getIosKeyDownloadParameters();
     return KeyDownloadParametersIOS.newBuilder()
-        .addAllCachedDayPackagesToUpdateOnETagMismatch(buildCachedDayPackagesToUpdateOnETagMismatch(
+        .addAllRevokedDayPackages(buildRevokedDayPackages(
             iosKeyDownloadParameters.getRevokedDayPackages()))
-        .addAllCachedHourPackagesToUpdateOnETagMismatch(buildCachedHourPackagesToUpdateOnETagMismatch(
+        .addAllRevokedHourPackages(buildRevokedHourPackages(
             iosKeyDownloadParameters.getRevokedHourPackages()))
         .build();
   }
@@ -175,7 +175,7 @@ public class ApplicationConfigurationPublicationConfig {
     return Integer.valueOf(items[position]);
   }
 
-  private List<DayPackageMetadata> buildCachedDayPackagesToUpdateOnETagMismatch(
+  private List<DayPackageMetadata> buildRevokedDayPackages(
       List<DeserializedDayPackageMetadata> deserializedDayPackage) {
     return deserializedDayPackage.stream().map(deserializedConfig ->
         DayPackageMetadata.newBuilder()
@@ -186,7 +186,7 @@ public class ApplicationConfigurationPublicationConfig {
     ).collect(Collectors.toList());
   }
 
-  private List<HourPackageMetadata> buildCachedHourPackagesToUpdateOnETagMismatch(
+  private List<HourPackageMetadata> buildRevokedHourPackages(
       List<DeserializedHourPackageMetadata> deserializedHourPackage) {
     return deserializedHourPackage.stream().map(deserializedHourConfig ->
         HourPackageMetadata.newBuilder()

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/ApplicationConfigurationPublicationConfig.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/ApplicationConfigurationPublicationConfig.java
@@ -103,9 +103,9 @@ public class ApplicationConfigurationPublicationConfig {
         .setOverallTimeoutInSeconds(androidKeyDownloadParameters.getOverallTimeoutInSeconds())
         .setDownloadTimeoutInSeconds(androidKeyDownloadParameters.getDownloadTimeoutInSeconds())
         .addAllCachedDayPackagesToUpdateOnETagMismatch(buildCachedDayPackagesToUpdateOnETagMismatch(
-            androidKeyDownloadParameters.getCachedDayPackagesToUpdateOnETagMismatch()))
+            androidKeyDownloadParameters.getRevokedDayPackages()))
         .addAllCachedHourPackagesToUpdateOnETagMismatch(buildCachedHourPackagesToUpdateOnETagMismatch(
-            androidKeyDownloadParameters.getCachedHourPackagesToUpdateOnETagMismatch()))
+            androidKeyDownloadParameters.getRevokedHourPackages()))
         .build();
   }
 
@@ -120,9 +120,9 @@ public class ApplicationConfigurationPublicationConfig {
         distributionServiceConfig.getAppConfigParameters().getIosKeyDownloadParameters();
     return KeyDownloadParametersIOS.newBuilder()
         .addAllCachedDayPackagesToUpdateOnETagMismatch(buildCachedDayPackagesToUpdateOnETagMismatch(
-            iosKeyDownloadParameters.getCachedDayPackagesToUpdateOnETagMismatch()))
+            iosKeyDownloadParameters.getRevokedDayPackages()))
         .addAllCachedHourPackagesToUpdateOnETagMismatch(buildCachedHourPackagesToUpdateOnETagMismatch(
-            iosKeyDownloadParameters.getCachedHourPackagesToUpdateOnETagMismatch()))
+            iosKeyDownloadParameters.getRevokedHourPackages()))
         .build();
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/ApplicationConfigurationV2PublicationConfig.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/ApplicationConfigurationV2PublicationConfig.java
@@ -117,9 +117,9 @@ public class ApplicationConfigurationV2PublicationConfig {
         .setOverallTimeoutInSeconds(androidKeyDownloadParameters.getOverallTimeoutInSeconds())
         .setDownloadTimeoutInSeconds(androidKeyDownloadParameters.getDownloadTimeoutInSeconds())
         .addAllCachedDayPackagesToUpdateOnETagMismatch(buildCachedDayPackagesToUpdateOnETagMismatch(
-            androidKeyDownloadParameters.getCachedDayPackagesToUpdateOnETagMismatch()))
+            androidKeyDownloadParameters.getRevokedDayPackages()))
         .addAllCachedHourPackagesToUpdateOnETagMismatch(buildCachedHourPackagesToUpdateOnETagMismatch(
-            androidKeyDownloadParameters.getCachedHourPackagesToUpdateOnETagMismatch()))
+            androidKeyDownloadParameters.getRevokedHourPackages()))
         .build();
   }
 
@@ -129,9 +129,9 @@ public class ApplicationConfigurationV2PublicationConfig {
         distributionServiceConfig.getAppConfigParameters().getIosKeyDownloadParameters();
     return KeyDownloadParametersIOS.newBuilder()
         .addAllCachedDayPackagesToUpdateOnETagMismatch(buildCachedDayPackagesToUpdateOnETagMismatch(
-            iosKeyDownloadParameters.getCachedDayPackagesToUpdateOnETagMismatch()))
+            iosKeyDownloadParameters.getRevokedDayPackages()))
         .addAllCachedHourPackagesToUpdateOnETagMismatch(buildCachedHourPackagesToUpdateOnETagMismatch(
-            iosKeyDownloadParameters.getCachedHourPackagesToUpdateOnETagMismatch()))
+            iosKeyDownloadParameters.getRevokedHourPackages()))
         .build();
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/ApplicationConfigurationV2PublicationConfig.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/ApplicationConfigurationV2PublicationConfig.java
@@ -116,9 +116,9 @@ public class ApplicationConfigurationV2PublicationConfig {
     return KeyDownloadParametersAndroid.newBuilder()
         .setOverallTimeoutInSeconds(androidKeyDownloadParameters.getOverallTimeoutInSeconds())
         .setDownloadTimeoutInSeconds(androidKeyDownloadParameters.getDownloadTimeoutInSeconds())
-        .addAllCachedDayPackagesToUpdateOnETagMismatch(buildCachedDayPackagesToUpdateOnETagMismatch(
+        .addAllRevokedDayPackages(buildRevokedDayPackages(
             androidKeyDownloadParameters.getRevokedDayPackages()))
-        .addAllCachedHourPackagesToUpdateOnETagMismatch(buildCachedHourPackagesToUpdateOnETagMismatch(
+        .addAllRevokedHourPackages(buildRevokedHourPackages(
             androidKeyDownloadParameters.getRevokedHourPackages()))
         .build();
   }
@@ -128,9 +128,9 @@ public class ApplicationConfigurationV2PublicationConfig {
     IosKeyDownloadParameters iosKeyDownloadParameters =
         distributionServiceConfig.getAppConfigParameters().getIosKeyDownloadParameters();
     return KeyDownloadParametersIOS.newBuilder()
-        .addAllCachedDayPackagesToUpdateOnETagMismatch(buildCachedDayPackagesToUpdateOnETagMismatch(
+        .addAllRevokedDayPackages(buildRevokedDayPackages(
             iosKeyDownloadParameters.getRevokedDayPackages()))
-        .addAllCachedHourPackagesToUpdateOnETagMismatch(buildCachedHourPackagesToUpdateOnETagMismatch(
+        .addAllRevokedHourPackages(buildRevokedHourPackages(
             iosKeyDownloadParameters.getRevokedHourPackages()))
         .build();
   }
@@ -217,7 +217,7 @@ public class ApplicationConfigurationV2PublicationConfig {
   }
 
 
-  private List<DayPackageMetadata> buildCachedDayPackagesToUpdateOnETagMismatch(
+  private List<DayPackageMetadata> buildRevokedDayPackages(
       List<DeserializedDayPackageMetadata> deserializedDayPackage) {
     return deserializedDayPackage.stream().map(deserializedConfig ->
         DayPackageMetadata.newBuilder()
@@ -228,7 +228,7 @@ public class ApplicationConfigurationV2PublicationConfig {
     ).collect(Collectors.toList());
   }
 
-  private List<HourPackageMetadata> buildCachedHourPackagesToUpdateOnETagMismatch(
+  private List<HourPackageMetadata> buildRevokedHourPackages(
       List<DeserializedHourPackageMetadata> deserializedHourPackage) {
     return deserializedHourPackage.stream().map(deserializedHourConfig ->
         HourPackageMetadata.newBuilder()

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/config/DistributionServiceConfig.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/config/DistributionServiceConfig.java
@@ -813,26 +813,26 @@ public class DistributionServiceConfig {
 
     private abstract static class CommonKeyDownloadParameters {
 
-      private String cachedDayPackagesToUpdateOnETagMismatch;
-      private String cachedHourPackagesToUpdateOnETagMismatch;
+      private String revokedDayPackages;
+      private String revokedHourPackages;
 
-      public List<DeserializedDayPackageMetadata> getCachedDayPackagesToUpdateOnETagMismatch() {
-        return SerializationUtils.deserializeJson(cachedDayPackagesToUpdateOnETagMismatch,
+      public List<DeserializedDayPackageMetadata> getRevokedDayPackages() {
+        return SerializationUtils.deserializeJson(revokedDayPackages,
             typeFactory -> typeFactory.constructCollectionType(List.class, DeserializedDayPackageMetadata.class));
       }
 
-      public void setCachedDayPackagesToUpdateOnETagMismatch(String cachedDayPackagesToUpdateOnETagMismatch) {
-        this.cachedDayPackagesToUpdateOnETagMismatch = cachedDayPackagesToUpdateOnETagMismatch;
+      public void setRevokedDayPackages(String revokedDayPackages) {
+        this.revokedDayPackages = revokedDayPackages;
       }
 
-      public List<DeserializedHourPackageMetadata> getCachedHourPackagesToUpdateOnETagMismatch() {
-        return SerializationUtils.deserializeJson(cachedHourPackagesToUpdateOnETagMismatch,
+      public List<DeserializedHourPackageMetadata> getRevokedHourPackages() {
+        return SerializationUtils.deserializeJson(revokedHourPackages,
             typeFactory -> typeFactory
                 .constructCollectionType(List.class, DeserializedHourPackageMetadata.class));
       }
 
-      public void setCachedHourPackagesToUpdateOnETagMismatch(String cachedHourPackagesToUpdateOnETagMismatch) {
-        this.cachedHourPackagesToUpdateOnETagMismatch = cachedHourPackagesToUpdateOnETagMismatch;
+      public void setRevokedHourPackages(String revokedHourPackages) {
+        this.revokedHourPackages = revokedHourPackages;
       }
     }
 

--- a/services/distribution/src/main/resources/application.yaml
+++ b/services/distribution/src/main/resources/application.yaml
@@ -102,11 +102,11 @@ services:
       latest-android-version-code: ${ANDROID_LATEST_VERSION_CODE:31}
     app-config-parameters:
       ios-key-download-parameters:
-        cached-day-packages-to-update-on-etag-mismatch: ${KEY_DOWNLOAD_INVALIDATED_DAY_PACKAGES:[]}
-        cached-hour-packages-to-update-on-etag-mismatch: ${KEY_DOWNLOAD_INVALIDATED_HOUR_PACKAGES:[]}
+        revoked-day-packages: ${KEY_DOWNLOAD_REVOKED_DAY_PACKAGES:[]}
+        revoked-hour-packages: ${KEY_DOWNLOAD_REVOKED_HOUR_PACKAGES:[]}
       android-key-download-parameters:
-        cached-day-packages-to-update-on-etag-mismatch: ${KEY_DOWNLOAD_INVALIDATED_DAY_PACKAGES:[]}
-        cached-hour-packages-to-update-on-etag-mismatch: ${KEY_DOWNLOAD_INVALIDATED_HOUR_PACKAGES:[]}
+        revoked-day-packages: ${KEY_DOWNLOAD_REVOKED_DAY_PACKAGES:[]}
+        revoked-hour-packages: ${KEY_DOWNLOAD_REVOKED_HOUR_PACKAGES:[]}
         download-timeout-in-seconds: ${ANDROID_KEY_DOWNLOAD_DOWNLOAD_TIMEOUT_IN_SECONDS:450}
         overall-timeout-in-seconds: ${ANDROID_KEY_DOWNLOAD_OVERALL_TIMEOUT_IN_SECONDS:480}
       ios-exposure-detection-parameters:

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ApplicationVersionConfigurationValidatorTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ApplicationVersionConfigurationValidatorTest.java
@@ -172,16 +172,16 @@ class ApplicationVersionConfigurationValidatorTest {
       KeyDownloadParametersAndroid keyDownloadParametersAndroid =
           applicationConfigurationPublicationConfig.buildKeyDownloadParametersAndroid(distributionServiceConfig);
 
-      assertThat(keyDownloadParametersAndroid.getCachedDayPackagesToUpdateOnETagMismatch(0).toString())
+      assertThat(keyDownloadParametersAndroid.getRevokedDayPackages(0).toString())
           .hasToString("region: \"EUR\"\ndate: \"2020-10-28\"\netag:"
               + " \"\\\"7d595060d664c4040ff3f65b532f6a57\\\"\"\n");
-      assertThat(keyDownloadParametersAndroid.getCachedDayPackagesToUpdateOnETagMismatch(1).toString())
+      assertThat(keyDownloadParametersAndroid.getRevokedDayPackages(1).toString())
           .hasToString("region: \"DE\"\ndate: \"2020-10-29\"\netag:"
               + " \"\\\"7d595060d664c4040ff3f65b532f6a58\\\"\"\n");
-      assertThat(keyDownloadParametersAndroid.getCachedHourPackagesToUpdateOnETagMismatch(0).toString())
+      assertThat(keyDownloadParametersAndroid.getRevokedHourPackages(0).toString())
           .hasToString("region: \"EUR\"\ndate: \"2020-10-28\"\nhour: 3\netag:"
               + " \"\\\"7d595060d664c4040ff3f65b532f6a57\\\"\"\n");
-      assertThat(keyDownloadParametersAndroid.getCachedHourPackagesToUpdateOnETagMismatch(1).toString())
+      assertThat(keyDownloadParametersAndroid.getRevokedHourPackages(1).toString())
           .hasToString("region: \"EUR\"\ndate: \"2020-10-29\"\nhour: 5\netag:"
               + " \"\\\"7d595060d664c4040ff3f65b532f6a57\\\"\"\n");
     }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ApplicationVersionConfigurationValidatorTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ApplicationVersionConfigurationValidatorTest.java
@@ -160,12 +160,12 @@ class ApplicationVersionConfigurationValidatorTest {
     @Test
     void testCachedDayAndHourPackagesForKeyDownloadParameters() {
       distributionServiceConfig.getAppConfigParameters().getAndroidKeyDownloadParameters().
-          setCachedDayPackagesToUpdateOnETagMismatch("[\n{ \"region\":\"EUR\", \"date\":\"2020-10-28\", \"etag\":"
+          setRevokedDayPackages("[\n{ \"region\":\"EUR\", \"date\":\"2020-10-28\", \"etag\":"
               + "\"\\\"7d595060d664c4040ff3f65b532f6a57\\\"\" },\n"
               + "{ \"region\":\"DE\", \"date\":\"2020-10-29\", \"etag\":"
               + "\"\\\"7d595060d664c4040ff3f65b532f6a58\\\"\" }]");
       distributionServiceConfig.getAppConfigParameters().getAndroidKeyDownloadParameters()
-          .setCachedHourPackagesToUpdateOnETagMismatch("[\n{ \"region\":\"EUR\", \"date\":\"2020-10-28\", \"hour\":3, "
+          .setRevokedHourPackages("[\n{ \"region\":\"EUR\", \"date\":\"2020-10-28\", \"hour\":3, "
               + "\"etag\":\"\\\"7d595060d664c4040ff3f65b532f6a57\\\"\" },\n"
               + "{ \"region\":\"EUR\", \"date\":\"2020-10-29\", \"hour\":5, "
               + "\"etag\":\"\\\"7d595060d664c4040ff3f65b532f6a57\\\"\" }]");

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/config/DistributionServiceConfigTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/config/DistributionServiceConfigTest.java
@@ -157,20 +157,20 @@ class DistributionServiceConfigTest {
     void testIosKeyDownloadParameters() {
       assertEquals(emptyList(),
           distributionServiceConfig.getAppConfigParameters().getIosKeyDownloadParameters()
-              .getCachedDayPackagesToUpdateOnETagMismatch());
+              .getRevokedDayPackages());
       assertEquals(emptyList(),
           distributionServiceConfig.getAppConfigParameters().getIosKeyDownloadParameters()
-              .getCachedHourPackagesToUpdateOnETagMismatch());
+              .getRevokedHourPackages());
     }
 
     @Test
     void testAndroidKeyDownloadParameters() {
       assertEquals(emptyList(),
           distributionServiceConfig.getAppConfigParameters().getAndroidKeyDownloadParameters()
-              .getCachedDayPackagesToUpdateOnETagMismatch());
+              .getRevokedDayPackages());
       assertEquals(emptyList(),
           distributionServiceConfig.getAppConfigParameters().getAndroidKeyDownloadParameters()
-              .getCachedHourPackagesToUpdateOnETagMismatch());
+              .getRevokedHourPackages());
       assertEquals(30,
           distributionServiceConfig.getAppConfigParameters().getAndroidKeyDownloadParameters()
               .getDownloadTimeoutInSeconds());

--- a/services/distribution/src/test/resources/application.yaml
+++ b/services/distribution/src/test/resources/application.yaml
@@ -71,11 +71,11 @@ services:
       latest-android-version-code: ${ANDROID_LATEST_VERSION_CODE:31}
     app-config-parameters:
       ios-key-download-parameters:
-        cached-day-packages-to-update-on-etag-mismatch: "[]"
-        cached-hour-packages-to-update-on-etag-mismatch: "[]"
+        revoked-day-packages: "[]"
+        revoked-hour-packages: "[]"
       android-key-download-parameters:
-        cached-day-packages-to-update-on-etag-mismatch: "[]"
-        cached-hour-packages-to-update-on-etag-mismatch: "[]"
+        revoked-day-packages: "[]"
+        revoked-hour-packages: "[]"
         download-timeout-in-seconds: 30
         overall-timeout-in-seconds: 480
       ios-exposure-detection-parameters:


### PR DESCRIPTION

## Description

In this PR is a refactoring one where the attributes name for the protobuf configuration has been changed. 
It contains the adjusting names PR from the cwa-protocol-buffers.