### PR TITLE
chore: change default value for android config

### DIFF
--- a/services/distribution/src/main/resources/application.yaml
+++ b/services/distribution/src/main/resources/application.yaml
@@ -107,7 +107,7 @@ services:
       android-key-download-parameters:
         revoked-day-packages: ${KEY_DOWNLOAD_REVOKED_DAY_PACKAGES:[]}
         revoked-hour-packages: ${KEY_DOWNLOAD_REVOKED_HOUR_PACKAGES:[]}
-        download-timeout-in-seconds: ${ANDROID_KEY_DOWNLOAD_DOWNLOAD_TIMEOUT_IN_SECONDS:450}
+        download-timeout-in-seconds: ${ANDROID_KEY_DOWNLOAD_DOWNLOAD_TIMEOUT_IN_SECONDS:60}
         overall-timeout-in-seconds: ${ANDROID_KEY_DOWNLOAD_OVERALL_TIMEOUT_IN_SECONDS:480}
       ios-exposure-detection-parameters:
         max-exposure-detections-per-interval: ${IOS_EXPOSURE_DETECTION_MAX_ED_PER_INTERVAL:6}


### PR DESCRIPTION
The `downloadTimeoutInSeconds` parameter is set to `60` after reviewing the the implementation on Android side. It's the timeout for an individual download instead of all downloads.

<!-- 
Thank you for supporting us with your Pull Request! 🙌 ❤️ 

Before submitting, please take the time to check the points below and provide some descriptive information.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a meaningful title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unncessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

-->

## Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] Make sure `mvn install` runs for the whole project and, if you touched any code in the respective service, submission and distribution service can be run with `spring-boot:run`

## Description

<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
