### PR TITLE
add testThisClassDeclaration

### DIFF
--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/validation/ValidSubmissionPayloadTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/validation/ValidSubmissionPayloadTest.java
@@ -62,8 +62,8 @@ public class ValidSubmissionPayloadTest {
   @Test
   void testOriginCountryConstraintViolationInterpolationIsTurnedOff() {
     SubmissionPayload payload = SubmissionPayloadMockData
-        .buildPayloadWithOriginCountry("java.lang.Runtime.getRuntime().exec(\'%s\');//${" + "\'\'.getClass().forName(\'"
-            + ValidSubmissionPayloadTest.class.getName() + "\')" + ".newInstance().showInterpolationEffect()}");
+        .buildPayloadWithOriginCountry("java.lang.Runtime.getRuntime().exec(\'%s\');//${\'\'.getClass().forName(\'"
+            + ValidSubmissionPayloadTest.class.getName() + "\').newInstance().showInterpolationEffect()}");
 
     ResponseEntity<Void> response = requestExecutor.executePost(payload);
     assertThat(response.getStatusCode()).isEqualTo(BAD_REQUEST);
@@ -87,8 +87,8 @@ public class ValidSubmissionPayloadTest {
   @Test
   void testVisitedCountryConstraintViolationInterpolationIsTurnedOff() {
     SubmissionPayload payload = SubmissionPayloadMockData.buildPayloadWithVisitedCountries(
-        List.of("java.lang.Runtime.getRuntime().exec(\'%s\');//${" + "\'\'.getClass().forName(\'"
-            + ValidSubmissionPayloadTest.class.getName() + "\')" + ".newInstance().showInterpolationEffect()}"));
+        List.of("java.lang.Runtime.getRuntime().exec(\'%s\');//${\'\'.getClass().forName(\'"
+            + ValidSubmissionPayloadTest.class.getName() + "\').newInstance().showInterpolationEffect()}"));
 
     ResponseEntity<Void> response = requestExecutor.executePost(payload);
     assertThat(response.getStatusCode()).isEqualTo(BAD_REQUEST);


### PR DESCRIPTION
with that we can ensure, that we have failing tests in place as soon as someone is refactoring the class/test

if the class isn't public, the 'remote code execution' won't be detected!
