### PR TITLE
Change default for Android report-type-when-missing

### DIFF
--- a/services/distribution/src/main/resources/master-config/v2/diagnosis-keys-data-mapping.yaml
+++ b/services/distribution/src/main/resources/master-config/v2/diagnosis-keys-data-mapping.yaml
@@ -11,4 +11,4 @@ days-since-onset-to-infectiousness:
   2: 2
   
 infectiousness-when-days-since-onset-missing: 0
-report-type-when-missing: 0
+report-type-when-missing: 1

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/parsing/v2/DeserializedDiagnosisKeysDataMappingTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/parsing/v2/DeserializedDiagnosisKeysDataMappingTest.java
@@ -18,7 +18,7 @@ class DeserializedDiagnosisKeysDataMappingTest {
         ANDROID_V2_DATA_MAPPING_FILE, DeserializedDiagnosisKeysDataMapping.class);
 
     assertThat(dataMapping.getDaysSinceOnsetToInfectiousness()).containsAllEntriesOf(Map.of(1,1,2,2));
-    assertThat(dataMapping.getInfectiousnessWhenDaysSinceOnsetMissing()).isEqualTo(0);
-    assertThat(dataMapping.getReportTypeWhenMissing()).isEqualTo(0);
+    assertThat(dataMapping.getInfectiousnessWhenDaysSinceOnsetMissing()).isZero();
+    assertThat(dataMapping.getReportTypeWhenMissing()).isEqualTo(1);
   }
 }


### PR DESCRIPTION
The previous default value `0` is not accepted by the client, see https://github.com/corona-warn-app/cwa-app-tech-spec/pull/6/commits/8d783a7e6a4eb12c216c6264b6696879f56a8800.