### PR TITLE
fix config for minutesAtAttenuationFilters

### DIFF
--- a/services/distribution/src/main/resources/master-config/v2/risk-calculation-parameters.yaml
+++ b/services/distribution/src/main/resources/master-config/v2/risk-calculation-parameters.yaml
@@ -13,7 +13,6 @@ minutes-at-attenuation-filters:
       min: 0
       max: 73
       max-exclusive: true
-  -
     drop-if-minutes-in-range:
       min: 0
       max: 10


### PR DESCRIPTION
The data structure for elements in minutesAtAttenuationFilters has two range objects.

Note that we do not need this PR for 1.7 but for 1.8 ASAP

This is the fix for https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3911