### PR TITLE
Adopt TRL encoding to ENF restrictions (EXPOSUREAPP-4039)

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,4 +1,4 @@
--Drevision=1.7.0
+-Drevision=1.7.1
 -Dlicense.projectName=Corona-Warn-App
 -Dlicense.inceptionYear=2020
 -Dlicense.licenseName=apache_v2

--- a/services/distribution/src/main/resources/master-config/transmission-risk-encoding.yaml
+++ b/services/distribution/src/main/resources/master-config/transmission-risk-encoding.yaml
@@ -11,19 +11,19 @@ transmission-risk-encoding:
 # published to CDNs for client consumption.
   transmissionRisk-to-daysSinceSymptoms:
     1: 1
-    2: 1
-    3: 1
-    4: 1
-    5: 2
-    6: 2
-    7: 2
-    8: 2
-  transmissionRisk-to-reportType:
-    1: 1
     2: 2
-    3: 3
-    4: 4
+    3: 1
+    4: 2
     5: 1
     6: 2
-    7: 3
-    8: 4
+    7: 1
+    8: 2
+  transmissionRisk-to-reportType:
+    1: 4
+    2: 4
+    3: 3
+    4: 3
+    5: 2
+    6: 2
+    7: 1
+    8: 1

--- a/services/distribution/src/main/resources/master-config/v2/risk-calculation-parameters.yaml
+++ b/services/distribution/src/main/resources/master-config/v2/risk-calculation-parameters.yaml
@@ -68,9 +68,9 @@ normalized-time-per-day-to-risk-level-mapping:
 transmission-risk-level-multiplier: 0.2
 
 trlEncoding:
-  infectiousnessOffsetStandard: 0
-  infectiousnessOffsetHigh: 4
-  reportTypeOffsetRecursive: 4
-  reportTypeOffsetSelfReport: 3
-  reportTypeOffsetConfirmedClinicalDiagnosis: 2
-  reportTypeOffsetConfirmedTest: 1
+  infectiousnessOffsetStandard: 1
+  infectiousnessOffsetHigh: 2
+  reportTypeOffsetRecursive: 0
+  reportTypeOffsetSelfReport: 2
+  reportTypeOffsetConfirmedClinicalDiagnosis: 4
+  reportTypeOffsetConfirmedTest: 6

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/transformation/EnfParameterAdapterComponentTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/transformation/EnfParameterAdapterComponentTest.java
@@ -45,13 +45,13 @@ class EnfParameterAdapterComponentTest {
   private static Stream<Arguments> createTestExpectations() {
     return Stream.of(
         /* First argument is TRL, followed by expected DSOS, expected Report Type */
-        Arguments.of(1, 1, ReportType.CONFIRMED_TEST),
-        Arguments.of(2, 1, ReportType.CONFIRMED_CLINICAL_DIAGNOSIS),
+        Arguments.of(1, 1, ReportType.RECURSIVE),
+        Arguments.of(2, 2, ReportType.RECURSIVE),
         Arguments.of(3, 1, ReportType.SELF_REPORT),
-        Arguments.of(4, 1, ReportType.RECURSIVE),
-        Arguments.of(5, 2, ReportType.CONFIRMED_TEST),
+        Arguments.of(4, 2, ReportType.SELF_REPORT),
+        Arguments.of(5, 1, ReportType.CONFIRMED_CLINICAL_DIAGNOSIS),
         Arguments.of(6, 2, ReportType.CONFIRMED_CLINICAL_DIAGNOSIS),
-        Arguments.of(7, 2, ReportType.SELF_REPORT),
-        Arguments.of(8, 2, ReportType.RECURSIVE));
+        Arguments.of(7, 1, ReportType.CONFIRMED_TEST),
+        Arguments.of(8, 2, ReportType.CONFIRMED_TEST));
   }
 }


### PR DESCRIPTION
keys with report type RECURSIVE are dropped by Android in Exposure
Window mode. The new encoding uses RECUSRIVE only with TRL 1 and 2
which are dropped anyway.

https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4039