### PR TITLE
Do not automatically disable ssl on server when certificate authentic…

### DIFF
--- a/services/callback/src/main/resources/application-disable-certificate-authentication.yaml
+++ b/services/callback/src/main/resources/application-disable-certificate-authentication.yaml
@@ -1,4 +1,0 @@
----
-server:
-  ssl:
-    enabled: false


### PR DESCRIPTION
Do not automatically disable ssl on server when certificate authentication is disabled.
When testing on INT, we would like to test the SSL connection without certificate authentication enabled. For local testing, the profile 'disable-ssl-server' can be used as usual.