### PR TITLE
Do not enforce client-auth for disable-certificate-authentication pro…

### DIFF
--- a/services/callback/src/main/resources/application-disable-certificate-authentication.yaml
+++ b/services/callback/src/main/resources/application-disable-certificate-authentication.yaml
@@ -1,0 +1,3 @@
+server:
+  ssl:
+    client-auth: none


### PR DESCRIPTION
Do not enforce client-auth for disable-certificate-authentication profile. When not setting it this way, it will only allow authenticated requests as long as ssl is enabled