### PR TITLE
Feature/new app config content type

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/publish/LocalFile.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/publish/LocalFile.java
@@ -76,7 +76,7 @@ public abstract class LocalFile {
    *         <a href="https://www.iana.org/assignments/media-types/application/json">json</a>.
    */
   public String getContentType() {
-    if (s3Key.endsWith("app_config")) {
+    if (s3Key.endsWith("app_config") || s3Key.endsWith("app_config_ios") || s3Key.endsWith("app_config_android")) {
       return "application/zip";
     }
     if (isKeyFile()) {

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/publish/LocalFileTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/publish/LocalFileTest.java
@@ -12,11 +12,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class LocalFileTest {
   @ParameterizedTest
-  @ValueSource(strings = { 
-      "version", 
-      "version/v1/configuration/country", 
+  @ValueSource(strings = {
+      "version",
+      "version/v1/configuration/country",
       "version/v1/diagnosis-keys/country",
-      "version/v1/diagnosis-keys/country/DE/date", 
+      "version/v1/diagnosis-keys/country/DE/date",
       "version/v1/diagnosis-keys/country/DE/date/2020-06-11/hour" })
   void testGetContentTypeJson(String path) {
     LocalFile test = new LocalIndexFile(Path.of("/root", path, "/index"), Path.of("/root"));
@@ -24,9 +24,11 @@ class LocalFileTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = { 
-      "version/v1/configuration/country/DE/app_config", 
-      "version/v1/diagnosis-keys/country/DE/date/2020-06-11", 
+  @ValueSource(strings = {
+      "version/v1/app_config_ios",
+      "version/v1/app_config_android",
+      "version/v1/configuration/country/DE/app_config",
+      "version/v1/diagnosis-keys/country/DE/date/2020-06-11",
       "version/v1/diagnosis-keys/country/DE/date/2020-06-11/hour/13" })
   void testGetContentTypeZip(String path) {
     LocalFile test = new LocalIndexFile(Path.of("/root", path, "/index"), Path.of("/root"));
@@ -34,7 +36,7 @@ class LocalFileTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = { 
+  @ValueSource(strings = {
       "version/v1/diagnosis-keys/country/DE/date/2020-06-11",
       "version/v1/diagnosis-keys/country/DE/date/2020-06-11/hour/13" })
   void testIsKeyFile(String path) {
@@ -43,12 +45,12 @@ class LocalFileTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = { 
+  @ValueSource(strings = {
       "version",
       "version/v1/configuration/country",
-      "version/v1/configuration/country/DE/app_config", 
+      "version/v1/configuration/country/DE/app_config",
       "version/v1/diagnosis-keys/country",
-      "version/v1/diagnosis-keys/country/DE/date", 
+      "version/v1/diagnosis-keys/country/DE/date",
       "version/v1/diagnosis-keys/country/DE/date/2020-06-11/hour" })
   void testIsNotKeyFile(String path) {
     LocalFile test = new LocalIndexFile(Path.of("/root", path, "/index"), Path.of("/root"));


### PR DESCRIPTION

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn -P integration-tests clean verify` runs for the whole project and, if you touched any code in the respective [service](services), ensure it can be run with `spring-boot:run`

## Description

This PR fixes the wrong content-type  set on the ENV2.0 configuration file(app_config_ios, app_config_android). The content-type has been changed from application/json to application/zip.