### PR TITLE
don't print stack trace on client side errors

### DIFF
--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/ApiExceptionHandler.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/ApiExceptionHandler.java
@@ -30,14 +30,14 @@ public class ApiExceptionHandler {
       InvalidProtocolBufferException.class})
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public void bindingExceptions(Exception ex, WebRequest wr) {
-    logger.error("Binding failed {}", getFormattedDescription(wr), ex);
+    logger.error("Binding failed {} {}", getFormattedDescription(wr), ex.getMessage());
   }
 
   @ExceptionHandler({
       InvalidDiagnosisKeyException.class, ConstraintViolationException.class, IllegalArgumentException.class})
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public void diagnosisKeyExceptions(Exception ex, WebRequest wr) {
-    logger.error("Erroneous Submission Payload {}", getFormattedDescription(wr), ex);
+    logger.error("Erroneous Submission Payload {} {}", getFormattedDescription(wr), ex.getMessage());
   }
 
   private String getFormattedDescription(WebRequest wr) {


### PR DESCRIPTION
Submission logs are flooded with stack trace lines if many invalid requests are received. As a solution we decided to only log the exception message in case there is a client side error. The stack trace does not provide useful information in this scenarios.

Here's an example how it should look like now:
```
2020-12-15T11:27:00+0100 ERROR http-nio-8000-exec-1 a.c.s.s.s.c.ApiExceptionHandler[43607]: Erroneous Submission Payload uri=/version/v1/diagnosis-keys submitDiagnosisKey.exposureKeys: [FR]: Visited country is not part of the supported countries list 
```

---
Internal tracking: EXPOSUREBACK-682