### PR TITLE
WIP update spring-web-starter version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
 
     <!-- https://spring.io/projects/spring-boot -->
     <spring-boot.version>2.3.6.RELEASE</spring-boot.version>
+    <spring-boot-web-starter.version>2.4.1</spring-boot-web-starter.version>
     <!-- https://spring.io/projects/spring-cloud#release-trains -->
     <spring-cloud.version>2.2.6.RELEASE</spring-cloud.version>
     <spring-retry.version>1.3.0</spring-retry.version>
@@ -109,7 +110,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-web</artifactId>
-        <version>${spring-boot.version}</version>
+        <version>${spring-boot-web-starter.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.tomcat.embed</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,7 @@
     <sonar.projectKey>${sonar.organization}_cwa-${project.artifactId}</sonar.projectKey>
 
     <!-- https://spring.io/projects/spring-boot -->
-    <spring-boot.version>2.3.6.RELEASE</spring-boot.version>
-    <spring-boot-web-starter.version>2.4.1</spring-boot-web-starter.version>
+    <spring-boot.version>2.3.7.RELEASE</spring-boot.version>
     <!-- https://spring.io/projects/spring-cloud#release-trains -->
     <spring-cloud.version>2.2.6.RELEASE</spring-cloud.version>
     <spring-retry.version>1.3.0</spring-retry.version>
@@ -67,7 +66,7 @@
     <wiremock.version>2.27.2</wiremock.version>
     <httpclient.version>4.5.13</httpclient.version>
     <junit.version>4.13.1</junit.version>
-    <tomcat-embed-core.version>9.0.40</tomcat-embed-core.version>
+    <tomcat-embed-core.version>9.0.41</tomcat-embed-core.version>
     <findify-s3mock.version>0.2.6</findify-s3mock.version>
   </properties>
 
@@ -110,7 +109,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-web</artifactId>
-        <version>${spring-boot-web-starter.version}</version>
+        <version>${spring-boot.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.tomcat.embed</groupId>


### PR DESCRIPTION
## Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn -P integration-tests clean verify` runs for the whole project and, if you touched any code in the respective [service](services), ensure it can be run with `spring-boot:run`

## Description

Since changing the version of all spring-boot dependancies to 2.4.1 causes build failures, this PR focuses on bumping only the version of spring-boot-web-starter.
