### PR TITLE
Reference Apple and Google documentation for rate-limiting

### DIFF
--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -14,7 +14,7 @@ Each interval generates a `.zip` file for each applicable country where keys are
 The file structure definition can be found [here](https://github.com/google/exposure-notifications-server/blob/HEAD/internal/pb/export/export.proto).
 
 The distribution service is triggered by a CRON scheduler, currently set to 1 hour. However, this
-will change, since the Exposure Notification APIs have a rate-limiting in place (Apple: 15 files/day, Google 20 API calls/day).
+will change, since the Exposure Notification APIs have a rate-limiting in place (cf. details for [Apple](https://developer.apple.com/documentation/exposurenotification/enmanager/3586331-detectexposures) and [Google](https://developers.google.com/android/exposure-notifications/exposure-notifications-api#providediagnosiskeys)).
 
 In case there is an insufficient number of diagnosis keys for the target interval available, the
 creation of the file will be skipped in order to prevent attackers from being potentially able to


### PR DESCRIPTION
Reference Apple and Google documentation for rate-limiting to avoid mentioning outdated information