### PR TITLE
Use correct properties in statistic and add date to warning message

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonStringObject.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonStringObject.java
@@ -70,7 +70,7 @@ public class StatisticsJsonStringObject {
   @JsonProperty("seven_day_r_value_published_growthrate")
   private Double sevenDayRvaluepublishedGrowthrate;
   @JsonProperty("seven_day_r_value_published_trend_1percent")
-  private Integer sevenDayRvaluePublishedTrend5percent;
+  private Integer sevenDayRvaluePublishedTrend1percent;
   @JsonProperty("tests_total_daily")
   private Integer testsTotalDaily;
   @JsonProperty("update_timestamp")
@@ -188,7 +188,7 @@ public class StatisticsJsonStringObject {
     return sevenDayRvalue1stReportedTrend1percent;
   }
 
-  public Double getSevenDayRvaluepublishedDaily() {
+  public Double getSevenDayRvaluePublishedDaily() {
     return sevenDayRvaluepublishedDaily;
   }
 
@@ -196,8 +196,8 @@ public class StatisticsJsonStringObject {
     return sevenDayRvaluepublishedGrowthrate;
   }
 
-  public Integer getSevenDayRvaluePublishedTrend5percent() {
-    return sevenDayRvaluePublishedTrend5percent;
+  public Integer getSevenDayRvaluePublishedTrend1percent() {
+    return sevenDayRvaluePublishedTrend1percent;
   }
 
   public Integer getTestsTotalDaily() {
@@ -328,8 +328,8 @@ public class StatisticsJsonStringObject {
     this.sevenDayRvaluepublishedGrowthrate = sevenDayRvaluepublishedGrowthrate;
   }
 
-  public void setSevenDayRvaluePublishedTrend5percent(Integer sevenDayRvaluePublishedTrend5percent) {
-    this.sevenDayRvaluePublishedTrend5percent = sevenDayRvaluePublishedTrend5percent;
+  public void setSevenDayRvaluePublishedTrend1percent(Integer sevenDayRvaluePublishedTrend1percent) {
+    this.sevenDayRvaluePublishedTrend1percent = sevenDayRvaluePublishedTrend1percent;
   }
 
   public void setTestsTotalDaily(Integer testsTotalDaily) {

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsToProtobufMapping.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsToProtobufMapping.java
@@ -118,7 +118,7 @@ public class StatisticsToProtobufMapping {
             card = keyFigureCardFactory.createKeyFigureCard(stat, id);
             figureCardMap.put(id, Optional.of(card));
           } catch (MissingPropertyException ex) {
-            logger.warn(ex.getMessage());
+            logger.warn("[{}] {}", stat.getEffectiveDate(), ex.getMessage());
           }
         }
       });

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/keyfigurecard/factory/ReproductionNumberCardFactory.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/keyfigurecard/factory/ReproductionNumberCardFactory.java
@@ -24,10 +24,10 @@ public class ReproductionNumberCardFactory extends HeaderCardFactory {
   }
 
   private KeyFigure getSevenDayRValueKeyFigure(StatisticsJsonStringObject stats) {
-    var trend = ValueTrendCalculator.from(stats.getSevenDayRvalue1stReportedTrend1percent());
+    var trend = ValueTrendCalculator.from(stats.getSevenDayRvaluePublishedTrend1percent());
     var semantic = ValueTrendCalculator.getNegativeTrendGrowth(trend);
     return KeyFigure.newBuilder()
-        .setValue(stats.getSevenDayRvalue1stReportedDaily())
+        .setValue(stats.getSevenDayRvaluePublishedDaily())
         .setRank(Rank.PRIMARY)
         .setDecimals(2)
         .setTrend(trend)
@@ -38,8 +38,8 @@ public class ReproductionNumberCardFactory extends HeaderCardFactory {
   @Override
   protected List<Optional<Object>> getRequiredFieldValues(StatisticsJsonStringObject stats) {
     return List.of(
-        Optional.ofNullable(stats.getSevenDayRvalue1stReportedTrend1percent()),
-        Optional.ofNullable(stats.getSevenDayRvalue1stReportedDaily())
+        Optional.ofNullable(stats.getSevenDayRvaluePublishedTrend1percent()),
+        Optional.ofNullable(stats.getSevenDayRvaluePublishedDaily())
     );
   }
 }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/KeyFigureCardFactoryTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/KeyFigureCardFactoryTest.java
@@ -53,8 +53,8 @@ class KeyFigureCardFactoryTest {
     statisticsJsonStringObject.setPersonsWhoSharedKeysCumulated(4321);
     statisticsJsonStringObject.setPersonsWhoSharedKeys7daysTrend5percent(1);
 
-    statisticsJsonStringObject.setSevenDayRvalue1stReportedDaily(100.63);
-    statisticsJsonStringObject.setSevenDayRvalue1stReportedTrend1percent(1);
+    statisticsJsonStringObject.setSevenDayRvaluepublishedDaily(100.63);
+    statisticsJsonStringObject.setSevenDayRvaluePublishedTrend1percent(1);
   }
 
   @Nested

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonProcessingTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonProcessingTest.java
@@ -76,7 +76,7 @@ class StatisticsJsonProcessingTest {
         .containsExactly(REPRODUCTION_NUMBER_CARD, dateToTimestamp(LocalDate.of(2020, 11, 5)));
     assertThat(result.getKeyFigureCards(3).getKeyFigures(0))
         .extracting(KeyFigure::getValue, KeyFigure::getTrend, KeyFigure::getTrendSemantic)
-        .containsExactly(0.63, Trend.DECREASING, TrendSemantic.POSITIVE);
+        .containsExactly(1.67, Trend.INCREASING, TrendSemantic.NEGATIVE);
   }
 
 }


### PR DESCRIPTION
- Change properties used for reproduction number card
- Add date to warning message when required fields are not found, e.g.:
```
2021-01-18T12:22:26+0100 WARN  main a.c.s.s.d.s.StatisticsToProtobufMapping[20318]: [2021-01-18] Some required properties are missing in JSON file for card with ID 4 
2021-01-18T12:22:26+0100 WARN  main a.c.s.s.d.s.StatisticsToProtobufMapping[20318]: [2021-01-17] Some required properties are missing in JSON file for card with ID 4 
2021-01-18T12:22:26+0100 WARN  main a.c.s.s.d.s.StatisticsToProtobufMapping[20318]: [2021-01-16] Some required properties are missing in JSON file for card with ID 4 
2021-01-18T12:22:26+0100 WARN  main a.c.s.s.d.s.StatisticsToProtobufMapping[20318]: [2021-01-15] Some required properties are missing in JSON file for card with ID 4 
2021-01-18T12:22:26+0100 WARN  main a.c.s.s.d.s.StatisticsToProtobufMapping[20318]: [2021-01-14] Some required properties are missing in JSON file for card with ID 4 
2021-01-18T12:22:26+0100 WARN  main a.c.s.s.d.s.StatisticsToProtobufMapping[20318]: [2021-01-13] Some required properties are missing in JSON file for card with ID 4 
```
 