### PR TITLE
add extra tests to JSON validation on statistic module

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsToProtobufMapping.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsToProtobufMapping.java
@@ -74,8 +74,8 @@ public class StatisticsToProtobufMapping {
           .addAllKeyFigureCards(buildAllKeyFigureCards(jsonStringObjects))
           .build();
     } catch (BucketNotFoundException | ConnectionException | FilePathNotFoundException ex) {
-      logger.warn(ex.getMessage());
-      logger.warn("Statistics file will not be generated due to previous errors!");
+      logger.error(ex.getMessage());
+      logger.error("Statistics file will not be generated due to previous errors!");
       return Statistics.newBuilder().build();
     }
   }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsToProtobufMapping.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsToProtobufMapping.java
@@ -74,8 +74,7 @@ public class StatisticsToProtobufMapping {
           .addAllKeyFigureCards(buildAllKeyFigureCards(jsonStringObjects))
           .build();
     } catch (BucketNotFoundException | ConnectionException | FilePathNotFoundException ex) {
-      logger.error(ex.getMessage());
-      logger.error("Statistics file will not be generated due to previous errors!");
+      logger.error("Statistics file not generated!", ex);
       return Statistics.newBuilder().build();
     }
   }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonProcessingTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonProcessingTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @EnableConfigurationProperties(value = DistributionServiceConfig.class)
 @ExtendWith(SpringExtension.class)
-@ActiveProfiles({"local-json-stats", "processing-test"})
+@ActiveProfiles({"local-json-stats", "processing-test", "debug"})
 @ContextConfiguration(classes = {StatisticsJsonToProtobufTest.class,
     StatisticsToProtobufMapping.class, KeyFigureCardFactory.class,
     LocalStatisticJsonFileLoader.class

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/validation/StatisticsJsonValidatorTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/validation/StatisticsJsonValidatorTest.java
@@ -1,0 +1,65 @@
+package app.coronawarn.server.services.distribution.statistics.validation;
+
+import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
+import app.coronawarn.server.services.distribution.statistics.StatisticsJsonStringObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@EnableConfigurationProperties(value = DistributionServiceConfig.class)
+@ContextConfiguration(classes = {StatisticsJsonValidator.class},
+    initializers = ConfigFileApplicationContextInitializer.class)
+class StatisticsJsonValidatorTest {
+
+  @Autowired
+  StatisticsJsonValidator validator;
+
+  StatisticsJsonStringObject jsonWithDate(String date) {
+    var obj = new StatisticsJsonStringObject();
+    obj.setEffectiveDate(date);
+    return obj;
+  }
+
+  StatisticsJsonStringObject jsonWithoutDate() {
+    return new StatisticsJsonStringObject();
+  }
+
+  @Test
+  void shouldSelectAllPropertiesWithEffectiveDate() {
+    var result = validator.validate(asList(
+        jsonWithDate("2021-01-01"),
+        jsonWithDate("2021-01-02"),
+        jsonWithDate("2021-01-03")
+    ));
+    assertThat(result).hasSize(3);
+  }
+
+  @Test
+  void shouldFilterOutObjectsWithoutEffectiveDate() {
+    var result = validator.validate(asList(
+        jsonWithDate("2021-01-01"),
+        jsonWithDate("2021-01-02"),
+        jsonWithoutDate()
+    ));
+    assertThat(result).hasSize(2);
+  }
+
+  @Test
+  void shouldFilterOutObjectWithWrongEffectiveDate() {
+    var result = validator.validate(asList(
+        jsonWithDate("2021-01-01"),
+        jsonWithDate("back in the day"),
+        jsonWithoutDate()
+    ));
+    assertThat(result).hasSize(1);
+  }
+
+}

--- a/services/distribution/src/test/resources/application-wrong-json.yaml
+++ b/services/distribution/src/test/resources/application-wrong-json.yaml
@@ -1,0 +1,5 @@
+---
+services:
+  distribution:
+    statistics:
+      statistic-path: stats/statistic_data_wrong.json

--- a/services/distribution/src/test/resources/stats/statistic_data_wrong.json
+++ b/services/distribution/src/test/resources/stats/statistic_data_wrong.json
@@ -1,0 +1,9 @@
+[
+  {
+    "effective_date": "2020-06-24"
+  },
+  {},
+  {
+    "some_random_property": "abc"
+  }
+]


### PR DESCRIPTION
Adds extra test automation to how Statistics Module handles the external JSON:
- If JSON has objects that don't mean anything: shouldn't crash, generates empty cards
- Parsing should filter out based on effective date 
- Log level should be `error` if statistic fails