### PR TITLE
dump circleci memory usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,9 @@ jobs:
           path: ~/test-results
       - store_artifacts:
           path: ~/test-results/junit
+      - run:
+          command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+          when: always
 
 workflows:
   circleci:


### PR DESCRIPTION
to get more insights on, why sometimes circleci fails, let's keep track of it's memory usage