### PR TITLE
Adjust parsing double json attributes

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,4 +1,4 @@
--Drevision=1.11.0
+-Drevision=1.11.1
 -Dlicense.projectName=Corona-Warn-App
 -Dlicense.inceptionYear=2020
 -Dlicense.licenseName=apache_v2

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonStringObject.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonStringObject.java
@@ -24,7 +24,7 @@ public class StatisticsJsonStringObject {
   @JsonProperty("effective_date")
   private String effectiveDate;
   @JsonProperty("infections_effective_7days_avg")
-  private Integer infectionsReported7daysAvg;
+  private Double infectionsReported7daysAvg;
   @JsonProperty("infections_effective_7days_avg_growthrate")
   private Double infectionsReported7daysGrowthrate;
   @JsonProperty("infections_effective_7days_avg_trend_5percent")
@@ -48,7 +48,7 @@ public class StatisticsJsonStringObject {
   @JsonProperty("persons_who_shared_keys_daily")
   private Integer personsWhoSharedKeysDaily;
   @JsonProperty("persons_who_shared_keys_7days_avg")
-  private Integer personWhoSharedKeys7daysAvg;
+  private Double personWhoSharedKeys7daysAvg;
   @JsonProperty("positive_tests_not_used_to_share_keys_daily")
   private Integer positiveTestsNotUsedToShareKeysDaily;
   @JsonProperty("positive_tests_used_to_share_keys_daily")
@@ -104,7 +104,7 @@ public class StatisticsJsonStringObject {
     return effectiveDate;
   }
 
-  public Integer getInfectionsReported7daysAvg() {
+  public Double getInfectionsReported7daysAvg() {
     return infectionsReported7daysAvg;
   }
 
@@ -152,7 +152,7 @@ public class StatisticsJsonStringObject {
     return personsWhoSharedKeysDaily;
   }
 
-  public Integer getPersonWhoSharedKeys7daysAvg() {
+  public Double getPersonWhoSharedKeys7daysAvg() {
     return personWhoSharedKeys7daysAvg;
   }
 
@@ -236,7 +236,7 @@ public class StatisticsJsonStringObject {
     this.effectiveDate = effectiveDate;
   }
 
-  public void setInfectionsReported7daysAvg(Integer infectionsReported7daysAvg) {
+  public void setInfectionsReported7daysAvg(Double infectionsReported7daysAvg) {
     this.infectionsReported7daysAvg = infectionsReported7daysAvg;
   }
 
@@ -284,7 +284,7 @@ public class StatisticsJsonStringObject {
     this.personsWhoSharedKeysDaily = personsWhoSharedKeysDaily;
   }
 
-  public void setPersonWhoSharedKeys7daysAvg(Integer personWhoSharedKeys7daysAvg) {
+  public void setPersonWhoSharedKeys7daysAvg(Double personWhoSharedKeys7daysAvg) {
     this.personWhoSharedKeys7daysAvg = personWhoSharedKeys7daysAvg;
   }
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/KeyFigureCardFactoryTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/KeyFigureCardFactoryTest.java
@@ -39,7 +39,7 @@ class KeyFigureCardFactoryTest {
     statisticsJsonStringObject.setEffectiveDate("2020-11-05");
 
     statisticsJsonStringObject.setInfectionsReportedDaily(70200);
-    statisticsJsonStringObject.setInfectionsReported7daysAvg(1234);
+    statisticsJsonStringObject.setInfectionsReported7daysAvg(1234.0);
     statisticsJsonStringObject.setInfectionsReported7daysGrowthrate(1.15);
     statisticsJsonStringObject.setInfectionsReportedCumulated(123456);
     statisticsJsonStringObject.setInfectionsReported7daysTrend5percent(1);
@@ -48,7 +48,7 @@ class KeyFigureCardFactoryTest {
     statisticsJsonStringObject.setSevenDayIncidenceTrend1percent(1);
 
     statisticsJsonStringObject.setPersonsWhoSharedKeysDaily(2717);
-    statisticsJsonStringObject.setPersonWhoSharedKeys7daysAvg(123);
+    statisticsJsonStringObject.setPersonWhoSharedKeys7daysAvg(123.0);
     statisticsJsonStringObject.setPersonsWhoSharedKeys7daysGrowthrate(1.05);
     statisticsJsonStringObject.setPersonsWhoSharedKeysCumulated(4321);
     statisticsJsonStringObject.setPersonsWhoSharedKeys7daysTrend5percent(1);

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonProcessingTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonProcessingTest.java
@@ -68,7 +68,7 @@ class StatisticsJsonProcessingTest {
         .containsExactly(KEY_SUBMISSION_CARD_ID, dateToTimestamp(LocalDate.of(2020, 11, 6)));
     assertThat(result.getKeyFigureCards(2).getKeyFigures(1))
         .extracting(KeyFigure::getValue, KeyFigure::getTrend, KeyFigure::getTrendSemantic)
-        .containsExactly(11.0, Trend.STABLE, TrendSemantic.NEUTRAL);
+        .containsExactly(11.428571428571429, Trend.STABLE, TrendSemantic.NEUTRAL);
 
     // Assert Reproduction Number Card
     assertThat(result.getKeyFigureCards(3).getHeader())

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonToProtobufTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonToProtobufTest.java
@@ -128,6 +128,7 @@ class StatisticsJsonToProtobufTest {
       StatisticsToProtobufMapping.class, KeyFigureCardFactory.class,
       LocalStatisticJsonFileLoader.class
   }, initializers = ConfigFileApplicationContextInitializer.class)
+
   class StatisticsJsonProcessingTest {
 
     @Autowired
@@ -175,7 +176,7 @@ class StatisticsJsonToProtobufTest {
           .containsExactly(KEY_SUBMISSION_CARD_ID, dateToTimestamp(LocalDate.of(2020, 11, 6)));
       assertThat(keySubmission.getKeyFigures(1))
           .extracting(KeyFigure::getValue, KeyFigure::getTrend, KeyFigure::getTrendSemantic)
-          .containsExactly(11.0, Trend.STABLE, TrendSemantic.NEUTRAL);
+          .containsExactly(11.428571428571429, Trend.STABLE, TrendSemantic.NEUTRAL);
     }
 
   }


### PR DESCRIPTION

## Description

Change two property from the json file that were being parsed as Integer, but they should be Double.
 - infections_effective_7days_avg
 - persons_who_shared_keys_7days_avg
