### PR TITLE
Consider ETag when downloading Statistics JSON File

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/StatisticsDownload.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/StatisticsDownload.java
@@ -11,6 +11,12 @@ public class StatisticsDownload {
 
   private final String etag;
 
+  /**
+   * Statistic JSON Download record POJO.
+   * @param counter file counter/version. Incremented via a postgres sequence.
+   * @param downloadedTimestamp timestamp in seconds when this record was downloaded.
+   * @param etag etag value of the JSON file at the downloaded time.
+   */
   public StatisticsDownload(Integer counter, long downloadedTimestamp, String etag) {
     this.counter = counter;
     this.downloadedTimestamp = downloadedTimestamp;

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/StatisticsDownload.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/StatisticsDownload.java
@@ -1,0 +1,31 @@
+package app.coronawarn.server.common.persistence.domain;
+
+import org.springframework.data.annotation.Id;
+
+public class StatisticsDownload {
+
+  @Id
+  private final Integer counter;
+
+  private final long downloadedTimestamp;
+
+  private final String etag;
+
+  public StatisticsDownload(Integer counter, long downloadedTimestamp, String etag) {
+    this.counter = counter;
+    this.downloadedTimestamp = downloadedTimestamp;
+    this.etag = etag;
+  }
+
+  public Integer getCounter() {
+    return counter;
+  }
+
+  public long getDownloadedTimestamp() {
+    return downloadedTimestamp;
+  }
+
+  public String getEtag() {
+    return etag;
+  }
+}

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/StatisticsDownloadRepository.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/StatisticsDownloadRepository.java
@@ -1,12 +1,12 @@
 package app.coronawarn.server.common.persistence.repository;
 
 import app.coronawarn.server.common.persistence.domain.StatisticsDownload;
+import java.util.List;
 import org.springframework.data.jdbc.repository.query.Modifying;
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import java.util.List;
 
 @Repository
 public interface StatisticsDownloadRepository extends CrudRepository<StatisticsDownload, Integer> {

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/StatisticsDownloadRepository.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/StatisticsDownloadRepository.java
@@ -1,7 +1,6 @@
 package app.coronawarn.server.common.persistence.repository;
 
 import app.coronawarn.server.common.persistence.domain.StatisticsDownload;
-import java.util.List;
 import org.springframework.data.jdbc.repository.query.Modifying;
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -11,11 +10,18 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface StatisticsDownloadRepository extends CrudRepository<StatisticsDownload, Integer> {
 
-  @Query("SELECT * FROM statistics_downloaded ORDER BY counter DESC")
-  List<StatisticsDownload> getWithLatestETag();
+  @Query("SELECT * FROM statistics_downloaded ORDER BY counter DESC fetch first 1 rows only")
+  StatisticsDownload getWithLatestETag();
 
   @Modifying
   @Query("INSERT INTO statistics_downloaded (downloaded_timestamp, etag) VALUES (:timestamp, :etag)")
   void insertWithAutoIncrement(@Param("timestamp") long timestamp, @Param("etag") String etag);
+
+  @Modifying
+  @Query("DELETE FROM statistics_downloaded WHERE downloaded_timestamp <= :cutoff")
+  void deleteDownloadEntriesOlderThan(@Param("cutoff") long timestamp);
+
+  @Query("SELECT COUNT(*) FROM statistics_downloaded WHERE downloaded_timestamp <= :cutoff")
+  int countDownloadEntriesOlderThan(@Param("cutoff") long timestamp);
 
 }

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/StatisticsDownloadRepository.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/StatisticsDownloadRepository.java
@@ -1,0 +1,21 @@
+package app.coronawarn.server.common.persistence.repository;
+
+import app.coronawarn.server.common.persistence.domain.StatisticsDownload;
+import org.springframework.data.jdbc.repository.query.Modifying;
+import org.springframework.data.jdbc.repository.query.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface StatisticsDownloadRepository extends CrudRepository<StatisticsDownload, Integer> {
+
+  @Query("SELECT * FROM statistics_downloaded ORDER BY counter DESC")
+  List<StatisticsDownload> getWithLatestETag();
+
+  @Modifying
+  @Query("INSERT INTO statistics_downloaded (downloaded_timestamp, etag) VALUES (:timestamp, :etag)")
+  void insertWithAutoIncrement(@Param("timestamp") long timestamp, @Param("etag") String etag);
+
+}

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/StatisticsDownloadService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/StatisticsDownloadService.java
@@ -1,7 +1,11 @@
 package app.coronawarn.server.common.persistence.service;
 
+import static java.time.ZoneOffset.UTC;
+
 import app.coronawarn.server.common.persistence.domain.StatisticsDownload;
 import app.coronawarn.server.common.persistence.repository.StatisticsDownloadRepository;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class StatisticsDownloadService {
 
-  private StatisticsDownloadRepository repository;
+  private final StatisticsDownloadRepository repository;
   private static final Logger logger = LoggerFactory.getLogger(StatisticsDownloadService.class);
 
   public StatisticsDownloadService(StatisticsDownloadRepository repository) {
@@ -21,8 +25,9 @@ public class StatisticsDownloadService {
   /**
    * Stores an entry in the Database with {@param timestamp} as seconds and {@param eTag}. The counter is an incremental
    * value automatically determined by a postgres sequence.
+   *
    * @param timestamp in seconds.
-   * @param etag value to be stored.
+   * @param etag      value to be stored.
    * @return boolean determining if store was successful or not.s
    */
   @Transactional
@@ -39,14 +44,29 @@ public class StatisticsDownloadService {
   /**
    * Retrieves the latest {@link StatisticsDownload} stored. The order is determined by the counter field, which is
    * automatically incremented by the Database.
+   *
    * @return {@link StatisticsDownload} returns Optional.empty if no download entries are stored.
    */
   public Optional<StatisticsDownload> getMostRecentDownload() {
-    var downloads = this.repository.getWithLatestETag();
-    if (downloads.size() > 0) {
-      return Optional.of(downloads.get(0));
-    } else {
-      return Optional.empty();
+    return Optional.ofNullable(repository.getWithLatestETag());
+  }
+
+  /**
+   * Delete all downloaded entries for JSON statistics older than `today - {@param retentionDays}`.
+   *
+   * @param retentionDays number of days to retain the data.
+   */
+  public void applyRetentionPolicy(Integer retentionDays) {
+    if (retentionDays < 0) {
+      throw new IllegalArgumentException("Number of days to retain must be greater or equal to 0.");
     }
+    long threshold = LocalDateTime
+        .ofInstant(Instant.now(), UTC)
+        .minusDays(retentionDays)
+        .toEpochSecond(UTC);
+    int numberOfDeletions = this.repository.countDownloadEntriesOlderThan(threshold);
+    logger.info("Deleting {} Statistics JSON record(s) with a downloaded timestamp older than {} day(s) ago.",
+        numberOfDeletions, retentionDays);
+    this.repository.deleteDownloadEntriesOlderThan(threshold);
   }
 }

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/StatisticsDownloadService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/StatisticsDownloadService.java
@@ -1,0 +1,53 @@
+package app.coronawarn.server.common.persistence.service;
+
+import app.coronawarn.server.common.persistence.domain.StatisticsDownload;
+import app.coronawarn.server.common.persistence.repository.StatisticsDownloadRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Optional;
+
+@Component
+public class StatisticsDownloadService {
+
+  private StatisticsDownloadRepository repository;
+  private static final Logger logger = LoggerFactory.getLogger(StatisticsDownloadService.class);
+
+  public StatisticsDownloadService(StatisticsDownloadRepository repository) {
+    this.repository = repository;
+  }
+
+  @Transactional
+  public boolean save(StatisticsDownload download) {
+    try {
+      this.repository.save(download);
+      return true;
+    } catch (Exception e) {
+      logger.error("Failed to store Statistics Download entry", e);
+      return false;
+    }
+  }
+
+  @Transactional
+  public boolean store(long timestamp, String eTag) {
+    try {
+      this.repository.insertWithAutoIncrement(timestamp, eTag);
+      return true;
+    } catch (Exception e) {
+      logger.error("Failed to store Statistics Download entry", e);
+      return false;
+    }
+  }
+
+  public Optional<StatisticsDownload> getMostRecentDownload() {
+    var downloads = this.repository.getWithLatestETag();
+    if (downloads.size() > 0) {
+      return Optional.of(downloads.get(0));
+    } else {
+      return Optional.empty();
+    }
+//    this.repository.getWithLatestETag().get(0);
+//    return Optional.ofNullable(this.repository.getWithLatestETag().get(0));
+  }
+}

--- a/common/persistence/src/main/resources/db/specific/postgresql/V7__statistics.sql
+++ b/common/persistence/src/main/resources/db/specific/postgresql/V7__statistics.sql
@@ -4,4 +4,5 @@ CREATE TABLE statistics_downloaded (
     etag varchar(256) NOT NULL
 );
 
-GRANT ALL ON TABLE statistics_downloaded TO "cwa_distribution"
+GRANT ALL ON TABLE statistics_downloaded TO "cwa_distribution";
+GRANT USAGE, SELECT ON SEQUENCE statistics_downloaded_counter_seq TO "cwa_distribution";

--- a/common/persistence/src/main/resources/db/specific/postgresql/V7__statistics.sql
+++ b/common/persistence/src/main/resources/db/specific/postgresql/V7__statistics.sql
@@ -1,0 +1,7 @@
+CREATE TABLE statistics_downloaded (
+    counter SERIAL PRIMARY KEY,
+    downloaded_timestamp bigint NOT NULL UNIQUE,
+    etag varchar(256) NOT NULL
+);
+
+GRANT ALL ON TABLE statistics_downloaded TO "cwa_distribution"

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/TestApplication.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/TestApplication.java
@@ -7,9 +7,11 @@ import app.coronawarn.server.common.persistence.domain.config.YamlPropertySource
 import app.coronawarn.server.common.persistence.repository.DiagnosisKeyRepository;
 import app.coronawarn.server.common.persistence.repository.FederationBatchInfoRepository;
 import app.coronawarn.server.common.persistence.repository.FederationUploadKeyRepository;
+import app.coronawarn.server.common.persistence.repository.StatisticsDownloadRepository;
 import app.coronawarn.server.common.persistence.service.DiagnosisKeyService;
 import app.coronawarn.server.common.persistence.service.FederationBatchInfoService;
 import app.coronawarn.server.common.persistence.service.FederationUploadKeyService;
+import app.coronawarn.server.common.persistence.service.StatisticsDownloadService;
 import app.coronawarn.server.common.persistence.service.common.KeySharingPoliciesChecker;
 import app.coronawarn.server.common.persistence.service.common.ValidDiagnosisKeyFilter;
 import java.util.Map;
@@ -44,6 +46,11 @@ public class TestApplication {
   @Bean
   FederationBatchInfoService createFederationBatchInfoService(FederationBatchInfoRepository federationBatchInfoRepository) {
     return new FederationBatchInfoService(federationBatchInfoRepository);
+  }
+
+  @Bean
+  StatisticsDownloadService createStatisticsDownloadService(StatisticsDownloadRepository repository) {
+    return new StatisticsDownloadService(repository);
   }
 
   @Bean

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyServiceTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/StatisticsDownloadServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/StatisticsDownloadServiceTest.java
@@ -1,0 +1,58 @@
+package app.coronawarn.server.common.persistence.service;
+
+import app.coronawarn.server.common.persistence.domain.StatisticsDownload;
+import app.coronawarn.server.common.persistence.repository.StatisticsDownloadRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@DataJdbcTest
+public class StatisticsDownloadServiceTest {
+
+  @Autowired
+  private StatisticsDownloadService statisticsDownloadService;
+
+  @MockBean
+  private StatisticsDownloadRepository statisticsDownloadRepository;
+
+  @Test
+  void shouldReturnOptionalEmptyWhenNoRecordsFound() {
+    when(statisticsDownloadRepository.getWithLatestETag()).thenReturn(null);
+    assertThat(statisticsDownloadService.getMostRecentDownload()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnDownloadRecordIfStored() {
+    when(statisticsDownloadRepository.getWithLatestETag()).thenReturn(new StatisticsDownload(1, 1, "a"));
+    assertThat(statisticsDownloadService.getMostRecentDownload()).isNotEmpty();
+  }
+
+  @Test
+  void shouldReturnTrueWhenStoredSuccessfully() {
+    assertThat(statisticsDownloadService.store(123, "etag")).isTrue();
+  }
+
+  @Test
+  void shouldReturnFalseWhenFailedToStore() {
+    doThrow(new RuntimeException())
+        .when(statisticsDownloadRepository)
+        .insertWithAutoIncrement(anyLong(), anyString());
+    assertThat(statisticsDownloadService.store(123, "etag")).isFalse();
+  }
+
+  @Test
+  void shouldApplyRetentionPolicyEvenWhenNoRecordsAreFound() {
+    when(statisticsDownloadRepository.countDownloadEntriesOlderThan(anyLong()))
+        .thenReturn(0);
+    statisticsDownloadService.applyRetentionPolicy(14);
+    verify(statisticsDownloadRepository, times(1))
+        .deleteDownloadEntriesOlderThan(anyLong());
+  }
+
+}

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClient.java
@@ -2,6 +2,8 @@
 
 package app.coronawarn.server.services.distribution.objectstore.client;
 
+import app.coronawarn.server.services.distribution.statistics.exceptions.NotModifiedException;
+import app.coronawarn.server.services.distribution.statistics.file.JsonFile;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -21,7 +23,9 @@ public interface ObjectStoreClient {
    */
   List<S3Object> getObjects(String bucket, String prefix);
 
-  String getSingleObjectContent(String bucket, String key);
+  JsonFile getSingleObjectContent(String bucket, String key);
+
+  JsonFile getSingleObjectContent(String bucket, String key, String ifNotETag) throws NotModifiedException;
 
   /**
    * Uploads data from the specified file to an object with the specified name.

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
@@ -3,6 +3,8 @@ package app.coronawarn.server.services.distribution.objectstore.client;
 import static java.lang.Boolean.TRUE;
 import static java.util.stream.Collectors.toList;
 
+import app.coronawarn.server.services.distribution.statistics.exceptions.NotModifiedException;
+import app.coronawarn.server.services.distribution.statistics.file.JsonFile;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
@@ -13,8 +15,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import app.coronawarn.server.services.distribution.statistics.exceptions.NotModifiedException;
-import app.coronawarn.server.services.distribution.statistics.file.JsonFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.retry.annotation.Backoff;

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
@@ -13,12 +13,15 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import app.coronawarn.server.services.distribution.statistics.exceptions.NotModifiedException;
+import app.coronawarn.server.services.distribution.statistics.file.JsonFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.retry.support.RetrySynchronizationManager;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -26,12 +29,14 @@ import software.amazon.awssdk.services.s3.model.Delete;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 /**
  * Implementation of {@link ObjectStoreClient} that encapsulates an {@link S3Client}.
@@ -61,24 +66,51 @@ public class S3ClientWrapper implements ObjectStoreClient {
     }
   }
 
+  private JsonFile fromResponse(ResponseInputStream<GetObjectResponse> response) {
+    StringBuilder builder = new StringBuilder();
+    BufferedReader reader = new BufferedReader(new InputStreamReader(response));
+    reader.lines()
+        .map(String::strip)
+        .forEach(builder::append);
+    return new JsonFile(builder.toString(), response.response().eTag());
+  }
+
   @Override
   @Retryable(
       value = SdkException.class,
       maxAttemptsExpression = "${services.distribution.objectstore.retry-attempts}",
       backoff = @Backoff(delayExpression = "${services.distribution.objectstore.retry-backoff}"))
-  public String getSingleObjectContent(String bucket, String key) {
+  public JsonFile getSingleObjectContent(String bucket, String key) {
     GetObjectRequest request = GetObjectRequest.builder()
         .bucket(bucket)
         .key(key)
         .build();
-
     var object = s3Client.getObject(request);
-    StringBuilder builder = new StringBuilder();
-    BufferedReader reader = new BufferedReader(new InputStreamReader(object));
-    reader.lines()
-        .map(String::strip)
-        .forEach(builder::append);
-    return builder.toString();
+    return fromResponse(object);
+  }
+
+  @Override
+  @Retryable(
+      value = SdkException.class,
+      exclude = NotModifiedException.class,
+      maxAttemptsExpression = "${services.distribution.objectstore.retry-attempts}",
+      backoff = @Backoff(delayExpression = "${services.distribution.objectstore.retry-backoff}"))
+  public JsonFile getSingleObjectContent(String bucket, String key, String ifNotETag) throws NotModifiedException {
+    try {
+      GetObjectRequest request = GetObjectRequest.builder()
+          .bucket(bucket)
+          .key(key)
+          .ifNoneMatch(ifNotETag)
+          .build();
+      var object = s3Client.getObject(request);
+      return fromResponse(object);
+    } catch (S3Exception ex) {
+      if (ex.statusCode() == 304) {
+        throw new NotModifiedException(key, ifNotETag);
+      } else {
+        throw ex;
+      }
+    }
   }
 
   @Override

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/RetentionPolicy.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/runner/RetentionPolicy.java
@@ -1,6 +1,7 @@
 package app.coronawarn.server.services.distribution.runner;
 
 import app.coronawarn.server.common.persistence.service.DiagnosisKeyService;
+import app.coronawarn.server.common.persistence.service.StatisticsDownloadService;
 import app.coronawarn.server.services.distribution.Application;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.objectstore.S3RetentionPolicy;
@@ -32,6 +33,8 @@ public class RetentionPolicy implements ApplicationRunner {
 
   private final Integer hourFileRetentionDays;
 
+  private final StatisticsDownloadService statisticsDownloadService;
+
 
   /**
    * Creates a new RetentionPolicy.
@@ -39,12 +42,14 @@ public class RetentionPolicy implements ApplicationRunner {
   public RetentionPolicy(DiagnosisKeyService diagnosisKeyService,
       ApplicationContext applicationContext,
       DistributionServiceConfig distributionServiceConfig,
-      S3RetentionPolicy s3RetentionPolicy) {
+      S3RetentionPolicy s3RetentionPolicy,
+      StatisticsDownloadService statisticsDownloadService) {
     this.diagnosisKeyService = diagnosisKeyService;
     this.applicationContext = applicationContext;
     this.retentionDays = distributionServiceConfig.getRetentionDays();
     this.hourFileRetentionDays = distributionServiceConfig.getObjectStore().getHourFileRetentionDays();
     this.s3RetentionPolicy = s3RetentionPolicy;
+    this.statisticsDownloadService = statisticsDownloadService;
   }
 
   @Override
@@ -53,6 +58,7 @@ public class RetentionPolicy implements ApplicationRunner {
       diagnosisKeyService.applyRetentionPolicy(retentionDays);
       s3RetentionPolicy.applyRetentionPolicy(retentionDays);
       s3RetentionPolicy.applyHourFileRetentionPolicy(hourFileRetentionDays);
+      statisticsDownloadService.applyRetentionPolicy(retentionDays);
     } catch (Exception e) {
       logger.error("Application of retention policy failed.", e);
       Application.killApplication(applicationContext);

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsToProtobufMapping.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsToProtobufMapping.java
@@ -44,7 +44,7 @@ public class StatisticsToProtobufMapping {
 
   /**
    * Process the JSON file provided by TSI and map the it to Statistics protobuf object.
-   *  @param distributionServiceConfig The config properties
+   * @param distributionServiceConfig The config properties
    * @param keyFigureCardFactory      KeyFigureCard structure provider
    * @param jsonFileLoader            Loader of the file from the system
    * @param statisticsDownloadService Statistics Download Service for keeping track of ETags

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsToProtobufMapping.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsToProtobufMapping.java
@@ -2,18 +2,22 @@ package app.coronawarn.server.services.distribution.statistics;
 
 import static app.coronawarn.server.services.distribution.statistics.keyfigurecard.KeyFigureCardSequenceConstants.*;
 
+import app.coronawarn.server.common.persistence.service.StatisticsDownloadService;
 import app.coronawarn.server.common.protocols.internal.stats.KeyFigureCard;
 import app.coronawarn.server.common.protocols.internal.stats.Statistics;
+import app.coronawarn.server.services.distribution.assembly.structure.util.TimeUtils;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.statistics.exceptions.BucketNotFoundException;
 import app.coronawarn.server.services.distribution.statistics.exceptions.ConnectionException;
 import app.coronawarn.server.services.distribution.statistics.exceptions.FilePathNotFoundException;
+import app.coronawarn.server.services.distribution.statistics.file.JsonFile;
 import app.coronawarn.server.services.distribution.statistics.file.JsonFileLoader;
 import app.coronawarn.server.services.distribution.statistics.keyfigurecard.KeyFigureCardFactory;
 import app.coronawarn.server.services.distribution.statistics.keyfigurecard.factory.MissingPropertyException;
 import app.coronawarn.server.services.distribution.statistics.validation.StatisticsJsonValidator;
 import app.coronawarn.server.services.distribution.utils.SerializationUtils;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,22 +40,38 @@ public class StatisticsToProtobufMapping {
   private final DistributionServiceConfig distributionServiceConfig;
   private final KeyFigureCardFactory keyFigureCardFactory;
   private final JsonFileLoader jsonFileLoader;
+  private final StatisticsDownloadService statisticsDownloadService;
 
   /**
    * Process the JSON file provided by TSI and map the it to Statistics protobuf object.
-   *
-   * @param distributionServiceConfig The config properties
+   *  @param distributionServiceConfig The config properties
    * @param keyFigureCardFactory      KeyFigureCard structure provider
    * @param jsonFileLoader            Loader of the file from the system
+   * @param statisticsDownloadService Statistics Download Service for keeping track of ETags
    */
   public StatisticsToProtobufMapping(DistributionServiceConfig distributionServiceConfig,
       KeyFigureCardFactory keyFigureCardFactory,
-      JsonFileLoader jsonFileLoader) {
+      JsonFileLoader jsonFileLoader,
+      StatisticsDownloadService statisticsDownloadService) {
     this.distributionServiceConfig = distributionServiceConfig;
     this.keyFigureCardFactory = keyFigureCardFactory;
     this.jsonFileLoader = jsonFileLoader;
+    this.statisticsDownloadService = statisticsDownloadService;
   }
 
+  private Optional<JsonFile> getFile() {
+    var mostRecent = this.statisticsDownloadService.getMostRecentDownload();
+    if (mostRecent.isPresent()) {
+      return this.jsonFileLoader.getFileIfUpdated(mostRecent.get().getEtag());
+    } else {
+      return Optional.of(this.jsonFileLoader.getFile());
+    }
+  }
+
+  private void updateETag(String newETag) {
+    var currentTimestamp = TimeUtils.getCurrentUtcHour().toEpochSecond(ZoneOffset.UTC);
+    this.statisticsDownloadService.store(currentTimestamp, newETag);
+  }
 
   /**
    * Create protobuf statistic object from raw JSON statistics.
@@ -61,18 +81,24 @@ public class StatisticsToProtobufMapping {
   @Bean
   public Statistics constructProtobufStatistics() {
     try {
-      String content = this.jsonFileLoader.getContent();
-      List<StatisticsJsonStringObject> jsonStringObjects = SerializationUtils
-          .deserializeJson(content, typeFactory -> typeFactory
-              .constructCollectionType(List.class, StatisticsJsonStringObject.class));
+      Optional<JsonFile> file = this.getFile();
+      if (file.isEmpty()) {
+        logger.warn("Stats file is already updated to the latest version. Skipping generation.");
+        return Statistics.newBuilder().build();
+      } else {
+        List<StatisticsJsonStringObject> jsonStringObjects = SerializationUtils
+            .deserializeJson(file.get().getContent(), typeFactory -> typeFactory
+                .constructCollectionType(List.class, StatisticsJsonStringObject.class));
 
-      StatisticsJsonValidator validator = new StatisticsJsonValidator();
-      jsonStringObjects = new ArrayList<>(validator.validate(jsonStringObjects));
+        StatisticsJsonValidator validator = new StatisticsJsonValidator();
+        jsonStringObjects = new ArrayList<>(validator.validate(jsonStringObjects));
 
-      return Statistics.newBuilder()
-          .addAllCardIdSequence(getAllCardIdSequence())
-          .addAllKeyFigureCards(buildAllKeyFigureCards(jsonStringObjects))
-          .build();
+        this.updateETag(file.get().getETag());
+        return Statistics.newBuilder()
+            .addAllCardIdSequence(getAllCardIdSequence())
+            .addAllKeyFigureCards(buildAllKeyFigureCards(jsonStringObjects))
+            .build();
+      }
     } catch (BucketNotFoundException | ConnectionException | FilePathNotFoundException ex) {
       logger.error("Statistics file not generated!", ex);
       return Statistics.newBuilder().build();

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/exceptions/BucketNotFoundException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/exceptions/BucketNotFoundException.java
@@ -1,9 +1,8 @@
 package app.coronawarn.server.services.distribution.statistics.exceptions;
 
+@SuppressWarnings("serial")
 public class BucketNotFoundException extends RuntimeException {
-
-  public BucketNotFoundException(String bucketName) {
-    super(String.format("Bucket not found: %s", bucketName));
+  public BucketNotFoundException(final String bucketName, final Throwable cause) {
+    super(String.format("Bucket not found: %s", bucketName), cause);
   }
-
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/exceptions/ConnectionException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/exceptions/ConnectionException.java
@@ -1,7 +1,8 @@
 package app.coronawarn.server.services.distribution.statistics.exceptions;
 
+@SuppressWarnings("serial")
 public class ConnectionException extends RuntimeException {
-  public ConnectionException() {
-    super("Failed to retrieve statistics file from Object Store");
+  public ConnectionException(final Throwable cause) {
+    super("Failed to retrieve statistics file from Object Store", cause);
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/exceptions/FilePathNotFoundException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/exceptions/FilePathNotFoundException.java
@@ -1,9 +1,8 @@
 package app.coronawarn.server.services.distribution.statistics.exceptions;
 
+@SuppressWarnings("serial")
 public class FilePathNotFoundException extends RuntimeException {
-
-  public FilePathNotFoundException(String path) {
-    super(String.format("Failed to load file at path: %s", path));
+  public FilePathNotFoundException(final String path, final Throwable cause) {
+    super(String.format("Failed to load file at path: %s", path), cause);
   }
-
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/exceptions/NotModifiedException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/exceptions/NotModifiedException.java
@@ -1,7 +1,7 @@
 package app.coronawarn.server.services.distribution.statistics.exceptions;
 
 public class NotModifiedException extends Exception {
-  public NotModifiedException(String path, String eTag) {
-    super(String.format("File %s not modified since last checked. ETag: %s", path, eTag));
+  public NotModifiedException(String path, String etag) {
+    super(String.format("File %s not modified since last checked. ETag: %s", path, etag));
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/exceptions/NotModifiedException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/exceptions/NotModifiedException.java
@@ -1,0 +1,7 @@
+package app.coronawarn.server.services.distribution.statistics.exceptions;
+
+public class NotModifiedException extends Exception {
+  public NotModifiedException(String path, String eTag) {
+    super(String.format("File %s not modified since last checked. ETag: %s", path, eTag));
+  }
+}

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/JsonFile.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/JsonFile.java
@@ -2,11 +2,11 @@ package app.coronawarn.server.services.distribution.statistics.file;
 
 public class JsonFile {
   private String content;
-  private String eTag;
+  private String etag;
 
-  public JsonFile(String content, String eTag) {
+  public JsonFile(String content, String etag) {
     this.content = content;
-    this.eTag = eTag;
+    this.etag = etag;
   }
 
   public String getContent() {
@@ -18,10 +18,10 @@ public class JsonFile {
   }
 
   public String getETag() {
-    return eTag;
+    return etag;
   }
 
-  public void setETag(String eTag) {
-    this.eTag = eTag;
+  public void setETag(String etag) {
+    this.etag = etag;
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/JsonFile.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/JsonFile.java
@@ -1,0 +1,27 @@
+package app.coronawarn.server.services.distribution.statistics.file;
+
+public class JsonFile {
+  private String content;
+  private String eTag;
+
+  public JsonFile(String content, String eTag) {
+    this.content = content;
+    this.eTag = eTag;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public void setContent(String content) {
+    this.content = content;
+  }
+
+  public String getETag() {
+    return eTag;
+  }
+
+  public void setETag(String eTag) {
+    this.eTag = eTag;
+  }
+}

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/JsonFileLoader.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/JsonFileLoader.java
@@ -11,9 +11,9 @@ public interface JsonFileLoader {
   JsonFile getFile();
 
   /**
-   * Returns the content of the file only if eTag was updated.
+   * Returns the content of the file only if etag was updated. Otherwise returns Optional.empty.
    * @return String encoded JSON content
    */
-  Optional<JsonFile> getFileIfUpdated(String eTag);
+  Optional<JsonFile> getFileIfUpdated(String etag);
 
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/JsonFileLoader.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/JsonFileLoader.java
@@ -1,11 +1,19 @@
 package app.coronawarn.server.services.distribution.statistics.file;
 
+import java.util.Optional;
+
 public interface JsonFileLoader {
 
   /**
    * Returns the content of the file. Can be loaded from the local filesystem or a remote storage.
    * @return String encoded JSON content
    */
-  String getContent();
+  JsonFile getFile();
+
+  /**
+   * Returns the content of the file only if eTag was updated.
+   * @return String encoded JSON content
+   */
+  Optional<JsonFile> getFileIfUpdated(String eTag);
 
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/LocalStatisticJsonFileLoader.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/LocalStatisticJsonFileLoader.java
@@ -3,6 +3,7 @@ package app.coronawarn.server.services.distribution.statistics.file;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import org.apache.commons.io.FileUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
@@ -24,15 +25,21 @@ public class LocalStatisticJsonFileLoader implements JsonFileLoader {
    *
    * @return String content of file
    */
-  public String getContent() {
+  public JsonFile getFile() {
     var resource = resourceLoader.getResource(
         String.format("classpath:%s", serviceConfig.getStatistics().getStatisticPath()));
     try {
-      return FileUtils.readFileToString(resource.getFile(), StandardCharsets.UTF_8);
+      String content = FileUtils.readFileToString(resource.getFile(), StandardCharsets.UTF_8);
+      return new JsonFile(content, "local");
     } catch (IOException e) {
       throw new RuntimeException(String.format("Failed to load Local JSON from path %s",
           serviceConfig.getStatistics().getStatisticPath()));
     }
+  }
+
+  @Override
+  public Optional<JsonFile> getFileIfUpdated(String eTag) {
+    return Optional.of(this.getFile());
   }
 
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/LocalStatisticJsonFileLoader.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/LocalStatisticJsonFileLoader.java
@@ -33,7 +33,7 @@ public class LocalStatisticJsonFileLoader implements JsonFileLoader {
       return new JsonFile(content, "local");
     } catch (IOException e) {
       throw new RuntimeException(String.format("Failed to load Local JSON from path %s",
-          serviceConfig.getStatistics().getStatisticPath()));
+          serviceConfig.getStatistics().getStatisticPath()), e);
     }
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/LocalStatisticJsonFileLoader.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/LocalStatisticJsonFileLoader.java
@@ -38,7 +38,7 @@ public class LocalStatisticJsonFileLoader implements JsonFileLoader {
   }
 
   @Override
-  public Optional<JsonFile> getFileIfUpdated(String eTag) {
+  public Optional<JsonFile> getFileIfUpdated(String etag) {
     return Optional.of(this.getFile());
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/RemoteStatisticJsonFileLoader.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/RemoteStatisticJsonFileLoader.java
@@ -5,19 +5,23 @@ import app.coronawarn.server.services.distribution.objectstore.client.ObjectStor
 import app.coronawarn.server.services.distribution.statistics.exceptions.BucketNotFoundException;
 import app.coronawarn.server.services.distribution.statistics.exceptions.ConnectionException;
 import app.coronawarn.server.services.distribution.statistics.exceptions.FilePathNotFoundException;
+import app.coronawarn.server.services.distribution.statistics.exceptions.NotModifiedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.retry.ExhaustedRetryException;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import java.util.Optional;
 
 @Component
 @Profile("!local-json-stats")
 public class RemoteStatisticJsonFileLoader implements JsonFileLoader {
 
+  private static final Logger logger = LoggerFactory.getLogger(RemoteStatisticJsonFileLoader.class);
   ObjectStoreClient s3Stats;
-
   DistributionServiceConfig config;
 
 
@@ -27,21 +31,56 @@ public class RemoteStatisticJsonFileLoader implements JsonFileLoader {
   }
 
   /**
+   * Map parent retryable exception {@link ExhaustedRetryException} to cwa owned exceptions.
+   * The inner exception will be an S3 AwsException.
+   *
+   * @param ex {@link software.amazon.awssdk.core.exception.SdkException} wrapped in a {@link ExhaustedRetryException}.
+   * @return cwa owned RuntimeException.
+   */
+  private RuntimeException mapException(ExhaustedRetryException ex) {
+    if (ex.getCause() instanceof NoSuchBucketException) {
+      return new BucketNotFoundException(config.getStatistics().getBucket());
+    } else if (ex.getCause() instanceof S3Exception) {
+      return new FilePathNotFoundException(config.getStatistics().getStatisticPath());
+    } else {
+      return new ConnectionException();
+    }
+  }
+
+  /**
    * Connects to remote storage to load file.
    *
-   * @return String content of file
+   * @return String content of file.
+   * @throws RuntimeException if errors found using AWS SDK.
    */
-  public String getContent() {
+  @Override
+  public JsonFile getFile() {
     try {
       return s3Stats.getSingleObjectContent(config.getStatistics().getBucket(),
           config.getStatistics().getStatisticPath());
     } catch (ExhaustedRetryException ex) {
-      if (ex.getCause() instanceof NoSuchBucketException) {
-        throw new BucketNotFoundException(config.getStatistics().getBucket());
-      } else if (ex.getCause() instanceof S3Exception) {
-        throw new FilePathNotFoundException(config.getStatistics().getStatisticPath());
+      throw mapException(ex);
+    }
+  }
+
+  /**
+   * Connects to remote storage to load file if not modified compared to {@param eTag}.
+   *
+   * @param eTag only loads file if remote eTag is different from {@param eTag}.
+   * @return String content of file.
+   * @throws RuntimeException if errors found using AWS SDK.
+   */
+  @Override
+  public Optional<JsonFile> getFileIfUpdated(String eTag) {
+    try {
+      var result = s3Stats.getSingleObjectContent(config.getStatistics().getBucket(),
+          config.getStatistics().getStatisticPath(), eTag);
+      return Optional.of(result);
+    } catch (ExhaustedRetryException | NotModifiedException ex) {
+      if (ex.getCause() instanceof NotModifiedException || ex instanceof NotModifiedException) {
+        return Optional.empty();
       } else {
-        throw new ConnectionException();
+        throw mapException((ExhaustedRetryException) ex);
       }
     }
   }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/RemoteStatisticJsonFileLoader.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/RemoteStatisticJsonFileLoader.java
@@ -7,8 +7,6 @@ import app.coronawarn.server.services.distribution.statistics.exceptions.Connect
 import app.coronawarn.server.services.distribution.statistics.exceptions.FilePathNotFoundException;
 import app.coronawarn.server.services.distribution.statistics.exceptions.NotModifiedException;
 import java.util.Optional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.retry.ExhaustedRetryException;
@@ -20,10 +18,8 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 @Profile("!local-json-stats")
 public class RemoteStatisticJsonFileLoader implements JsonFileLoader {
 
-  private static final Logger logger = LoggerFactory.getLogger(RemoteStatisticJsonFileLoader.class);
   ObjectStoreClient s3Stats;
   DistributionServiceConfig config;
-
 
   RemoteStatisticJsonFileLoader(@Qualifier("stats-s3") ObjectStoreClient s3Stats, DistributionServiceConfig config) {
     this.s3Stats = s3Stats;
@@ -39,11 +35,11 @@ public class RemoteStatisticJsonFileLoader implements JsonFileLoader {
    */
   private RuntimeException mapException(ExhaustedRetryException ex) {
     if (ex.getCause() instanceof NoSuchBucketException) {
-      return new BucketNotFoundException(config.getStatistics().getBucket());
+      return new BucketNotFoundException(config.getStatistics().getBucket(), ex);
     } else if (ex.getCause() instanceof S3Exception) {
-      return new FilePathNotFoundException(config.getStatistics().getStatisticPath());
+      return new FilePathNotFoundException(config.getStatistics().getStatisticPath(), ex);
     } else {
-      return new ConnectionException();
+      return new ConnectionException(ex);
     }
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/RemoteStatisticJsonFileLoader.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/RemoteStatisticJsonFileLoader.java
@@ -6,6 +6,7 @@ import app.coronawarn.server.services.distribution.statistics.exceptions.BucketN
 import app.coronawarn.server.services.distribution.statistics.exceptions.ConnectionException;
 import app.coronawarn.server.services.distribution.statistics.exceptions.FilePathNotFoundException;
 import app.coronawarn.server.services.distribution.statistics.exceptions.NotModifiedException;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -14,7 +15,6 @@ import org.springframework.retry.ExhaustedRetryException;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.S3Exception;
-import java.util.Optional;
 
 @Component
 @Profile("!local-json-stats")
@@ -31,8 +31,8 @@ public class RemoteStatisticJsonFileLoader implements JsonFileLoader {
   }
 
   /**
-   * Map parent retryable exception {@link ExhaustedRetryException} to cwa owned exceptions.
-   * The inner exception will be an S3 AwsException.
+   * Map parent retryable exception {@link ExhaustedRetryException} to cwa owned exceptions. The inner exception will be
+   * an S3 AwsException.
    *
    * @param ex {@link software.amazon.awssdk.core.exception.SdkException} wrapped in a {@link ExhaustedRetryException}.
    * @return cwa owned RuntimeException.
@@ -66,15 +66,15 @@ public class RemoteStatisticJsonFileLoader implements JsonFileLoader {
   /**
    * Connects to remote storage to load file if not modified compared to {@param eTag}.
    *
-   * @param eTag only loads file if remote eTag is different from {@param eTag}.
+   * @param etag only loads file if remote eTag is different from {@param eTag}.
    * @return String content of file.
    * @throws RuntimeException if errors found using AWS SDK.
    */
   @Override
-  public Optional<JsonFile> getFileIfUpdated(String eTag) {
+  public Optional<JsonFile> getFileIfUpdated(String etag) {
     try {
       var result = s3Stats.getSingleObjectContent(config.getStatistics().getBucket(),
-          config.getStatistics().getStatisticPath(), eTag);
+          config.getStatistics().getStatisticPath(), etag);
       return Optional.of(result);
     } catch (ExhaustedRetryException | NotModifiedException ex) {
       if (ex.getCause() instanceof NotModifiedException || ex instanceof NotModifiedException) {

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
@@ -17,10 +17,12 @@ import static org.mockito.Mockito.when;
 
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreClient.HeaderKey;
+import java.io.ByteArrayInputStream;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import app.coronawarn.server.services.distribution.statistics.exceptions.NotModifiedException;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,14 +43,17 @@ import org.springframework.retry.ExhaustedRetryException;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.Delete;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
@@ -296,5 +301,72 @@ class S3ClientWrapperTest {
         .isThrownBy(() -> s3ClientWrapper.removeObjects(VALID_BUCKET_NAME, targetObjects));
 
     verify(s3Client, times(configuredNumberOfRetries)).deleteObjects(any(DeleteObjectsRequest.class));
+  }
+
+  private <T> ResponseInputStream<T> makeGetObjectStreamedResponse(T response, String body) {
+    var stream = new ByteArrayInputStream(body.getBytes());
+    return new ResponseInputStream<T>(response, AbortableInputStream.create(stream));
+  }
+
+  @Test
+  void getSingleObjectContent() {
+    GetObjectResponse response = GetObjectResponse.builder()
+        .eTag("abc")
+        .build();
+    var httpResponse = makeGetObjectStreamedResponse(response, "[]");
+    when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(httpResponse);
+    var jsonFile = s3ClientWrapper.getSingleObjectContent("example", "key1");
+    assertThat(jsonFile.getETag()).isEqualTo("abc");
+    assertThat(jsonFile.getContent()).isEqualTo("[]");
+  }
+
+  @Test
+  void jsonFileEtagIsNullWhenNotReceived() {
+    GetObjectResponse response = GetObjectResponse.builder()
+        .build();
+    var httpResponse = makeGetObjectStreamedResponse(response, "[]");
+    when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(httpResponse);
+    var jsonFile = s3ClientWrapper.getSingleObjectContent("example", "key1");
+    assertThat(jsonFile.getETag()).isNull();
+    assertThat(jsonFile.getContent()).isEqualTo("[]");
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {NoSuchBucketException.class, S3Exception.class, SdkClientException.class, SdkException.class})
+  void shouldThrowSameExceptionAsAwsClient(Class<Exception> cause) {
+    when(s3Client.getObject(any(GetObjectRequest.class))).thenThrow(cause);
+    assertThatExceptionOfType(ExhaustedRetryException.class)
+        .isThrownBy(() -> s3ClientWrapper.getSingleObjectContent("", ""))
+        .withCauseExactlyInstanceOf(cause);
+  }
+
+  @Test
+  void shouldReturnNewObjectIfEtagDoesntMatch() throws NotModifiedException {
+    GetObjectResponse response = GetObjectResponse.builder()
+        .eTag("abc")
+        .build();
+    var httpResponse = makeGetObjectStreamedResponse(response, "[]");
+    when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(httpResponse);
+    var jsonFile = s3ClientWrapper.getSingleObjectContent("example", "key1", "cba");
+    assertThat(jsonFile.getETag()).isEqualTo("abc");
+    assertThat(jsonFile.getContent()).isEqualTo("[]");
+  }
+
+  @Test
+  void shouldThrowNotModifiedExceptionWhenStatusCodeIs304() {
+    when(s3Client.getObject(any(GetObjectRequest.class)))
+        .thenThrow(S3Exception.builder().statusCode(304).build());
+    assertThatExceptionOfType(ExhaustedRetryException.class)
+        .isThrownBy(() -> s3ClientWrapper.getSingleObjectContent("abc", "key1", "abc"))
+        .withCauseExactlyInstanceOf(NotModifiedException.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {NoSuchBucketException.class, S3Exception.class, SdkClientException.class, SdkException.class})
+  void shouldThrowSameExceptionAsAwsClientIfNot304(Class<Exception> cause) {
+    when(s3Client.getObject(any(GetObjectRequest.class))).thenThrow(cause);
+    assertThatExceptionOfType(ExhaustedRetryException.class)
+        .isThrownBy(() -> s3ClientWrapper.getSingleObjectContent("", "", "etag"))
+        .withCauseExactlyInstanceOf(cause);
   }
 }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/integration/ObjectStoreFilePreservationIT.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/integration/ObjectStoreFilePreservationIT.java
@@ -161,7 +161,7 @@ class ObjectStoreFilePreservationIT extends BaseS3IntegrationTest {
     mockDistributionConfig.setRetentionDays(numberOfDaysSince(fromDate));
     mockDistributionConfig.setObjectStore(distributionServiceConfig.getObjectStore());
     new RetentionPolicy(diagnosisKeyService, applicationContext, mockDistributionConfig,
-        s3RetentionPolicy).run(null);
+        s3RetentionPolicy, statisticsDownloadService).run(null);
   }
 
   private Integer numberOfDaysSince(LocalDate testStartDate) {

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/integration/ObjectStoreFilePreservationIT.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/integration/ObjectStoreFilePreservationIT.java
@@ -3,6 +3,7 @@
 package app.coronawarn.server.services.distribution.objectstore.integration;
 
 import app.coronawarn.server.common.persistence.service.DiagnosisKeyService;
+import app.coronawarn.server.common.persistence.service.StatisticsDownloadService;
 import app.coronawarn.server.services.distribution.Application;
 import app.coronawarn.server.services.distribution.assembly.component.OutputDirectoryProvider;
 import app.coronawarn.server.services.distribution.assembly.structure.directory.DirectoryOnDisk;
@@ -58,6 +59,8 @@ class ObjectStoreFilePreservationIT extends BaseS3IntegrationTest {
   private ObjectStoreAccess objectStoreAccess;
   @Autowired
   private DistributionServiceConfig distributionServiceConfig;
+  @Autowired
+  private StatisticsDownloadService statisticsDownloadService;
 
   @MockBean
   private OutputDirectoryProvider distributionDirectoryProvider;

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/runner/RetentionPolicyRunnerTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/runner/RetentionPolicyRunnerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import app.coronawarn.server.common.persistence.service.DiagnosisKeyService;
+import app.coronawarn.server.common.persistence.service.StatisticsDownloadService;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.objectstore.S3RetentionPolicy;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,9 @@ class RetentionPolicyRunnerTest {
   @MockBean
   S3RetentionPolicy s3RetentionPolicy;
 
+  @MockBean
+  StatisticsDownloadService statisticsDownloadService;
+
   @Autowired
   DistributionServiceConfig distributionServiceConfig;
 
@@ -38,6 +42,7 @@ class RetentionPolicyRunnerTest {
   void shouldCallDatabaseAndS3RetentionRunner() {
     retentionPolicy.run(null);
 
+    verify(statisticsDownloadService, times(1)).applyRetentionPolicy(distributionServiceConfig.getRetentionDays());
     verify(diagnosisKeyService, times(1)).applyRetentionPolicy(distributionServiceConfig.getRetentionDays());
     verify(s3RetentionPolicy, times(1)).applyRetentionPolicy(distributionServiceConfig.getRetentionDays());
     verify(s3RetentionPolicy, times(1))

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonProcessingTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonProcessingTest.java
@@ -1,5 +1,6 @@
 package app.coronawarn.server.services.distribution.statistics;
 
+import app.coronawarn.server.common.persistence.service.StatisticsDownloadService;
 import app.coronawarn.server.common.protocols.internal.stats.CardHeader;
 import app.coronawarn.server.common.protocols.internal.stats.KeyFigure;
 import app.coronawarn.server.common.protocols.internal.stats.KeyFigure.Trend;
@@ -12,12 +13,14 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Optional;
 import app.coronawarn.server.services.distribution.statistics.keyfigurecard.KeyFigureCardSequenceConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -25,6 +28,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static app.coronawarn.server.services.distribution.statistics.keyfigurecard.KeyFigureCardSequenceConstants.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
 @EnableConfigurationProperties(value = DistributionServiceConfig.class)
 @ExtendWith(SpringExtension.class)
@@ -38,6 +42,9 @@ class StatisticsJsonProcessingTest {
   @Autowired
   StatisticsToProtobufMapping mapping;
 
+  @MockBean
+  StatisticsDownloadService service;
+
   private long dateToTimestamp(LocalDate date) {
     return date.atStartOfDay(ZoneOffset.UTC).toEpochSecond();
   }
@@ -45,6 +52,7 @@ class StatisticsJsonProcessingTest {
   @Test
   void shouldRunParsing() throws IOException {
     var result = mapping.constructProtobufStatistics();
+    when(service.getMostRecentDownload()).thenReturn(Optional.empty());
 
     // Assert Infections card
     assertThat(result.getKeyFigureCards(0).getHeader())

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonToProtobufTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonToProtobufTest.java
@@ -4,7 +4,11 @@ import static app.coronawarn.server.services.distribution.statistics.keyfigureca
 import static app.coronawarn.server.services.distribution.statistics.keyfigurecard.KeyFigureCardSequenceConstants.INFECTIONS_CARD_ID;
 import static app.coronawarn.server.services.distribution.statistics.keyfigurecard.KeyFigureCardSequenceConstants.KEY_SUBMISSION_CARD_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
+import app.coronawarn.server.common.persistence.domain.StatisticsDownload;
+import app.coronawarn.server.common.persistence.service.StatisticsDownloadService;
 import app.coronawarn.server.common.protocols.internal.stats.CardHeader;
 import app.coronawarn.server.common.protocols.internal.stats.KeyFigure;
 import app.coronawarn.server.common.protocols.internal.stats.KeyFigure.Trend;
@@ -13,7 +17,9 @@ import app.coronawarn.server.common.protocols.internal.stats.KeyFigureCard;
 import app.coronawarn.server.common.protocols.internal.stats.Statistics;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.statistics.file.JsonFile;
+import app.coronawarn.server.services.distribution.statistics.file.JsonFileLoader;
 import app.coronawarn.server.services.distribution.statistics.file.LocalStatisticJsonFileLoader;
+import app.coronawarn.server.services.distribution.statistics.file.RemoteStatisticJsonFileLoader;
 import app.coronawarn.server.services.distribution.statistics.keyfigurecard.KeyFigureCardFactory;
 import app.coronawarn.server.services.distribution.statistics.keyfigurecard.KeyFigureCardSequenceConstants;
 import app.coronawarn.server.services.distribution.statistics.validation.StatisticsJsonValidator;
@@ -25,102 +31,149 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
 
-@EnableConfigurationProperties(value = DistributionServiceConfig.class)
-@ExtendWith(SpringExtension.class)
-@ActiveProfiles({"local-json-stats"})
-@ContextConfiguration(classes = {StatisticsJsonToProtobufTest.class,
-    StatisticsToProtobufMapping.class, KeyFigureCardFactory.class,
-    LocalStatisticJsonFileLoader.class
-}, initializers = ConfigFileApplicationContextInitializer.class)
 class StatisticsJsonToProtobufTest {
 
-  @Autowired
-  StatisticsToProtobufMapping statisticsToProtobufMapping;
+  @EnableConfigurationProperties(value = DistributionServiceConfig.class)
+  @ExtendWith(SpringExtension.class)
+  @Nested
+  @DisplayName("Mocked Loader")
+  @ContextConfiguration(classes = {StatisticsJsonToProtobufTest.class, KeyFigureCardFactory.class
+  }, initializers = ConfigFileApplicationContextInitializer.class)
+  class StatisticsJsonMockLoaderTest {
+    @MockBean
+    StatisticsDownloadService service;
 
-  @Test
-  void convertFromJsonToObjectTest() throws IOException {
-    String content = FileUtils.readFileToString(
-        new File("./src/test/resources/stats/statistic_data.json"), StandardCharsets.UTF_8);
-    List<StatisticsJsonStringObject> statsDTO = SerializationUtils.deserializeJson(content, typeFactory -> typeFactory
-        .constructCollectionType(List.class, StatisticsJsonStringObject.class));
+    @MockBean
+    JsonFileLoader mockLoader;
 
-    assertThat(statisticsObjectContainsFields(statsDTO, "2020-12-04T11:13:22,588")).isTrue();
+    @Autowired
+    DistributionServiceConfig serviceConfig;
+
+    @Autowired
+    KeyFigureCardFactory factory;
+
+    @Test
+    void shouldNotGenerateStatisticsIfEtagNotUpdated() {
+      when(service.getMostRecentDownload()).thenReturn(Optional.of(new StatisticsDownload(1, 1234, "latest-etag")));
+      when(mockLoader.getFileIfUpdated(eq("latest-etag"))).thenReturn(Optional.empty());
+      var statisticsToProtobufMapping = new StatisticsToProtobufMapping(serviceConfig, factory, mockLoader, service);
+      var statistics = statisticsToProtobufMapping.constructProtobufStatistics();
+      assertThat(statistics.getKeyFigureCardsList().isEmpty()).isTrue();
+      verify(mockLoader, times(1)).getFileIfUpdated(eq("latest-etag"));
+    }
   }
 
-  private boolean statisticsObjectContainsFields(List<StatisticsJsonStringObject> statsDTO, String timestamp) {
-    return statsDTO.stream().anyMatch(stat -> stat.getUpdateTimestamp().compareTo(timestamp) == 0);
+  @EnableConfigurationProperties(value = DistributionServiceConfig.class)
+  @ExtendWith(SpringExtension.class)
+  @ActiveProfiles({"local-json-stats"})
+  @Nested
+  @DisplayName("General Tests")
+  @ContextConfiguration(classes = {StatisticsJsonToProtobufTest.class,
+      StatisticsToProtobufMapping.class, KeyFigureCardFactory.class,
+      LocalStatisticJsonFileLoader.class
+  }, initializers = ConfigFileApplicationContextInitializer.class)
+  class StatisticsJsonParsingTest {
+    @MockBean
+    StatisticsDownloadService service;
+
+    @Autowired
+    StatisticsToProtobufMapping statisticsToProtobufMapping;
+
+    @Test
+    void convertFromJsonToObjectTest() throws IOException {
+      String content = FileUtils.readFileToString(
+          new File("./src/test/resources/stats/statistic_data.json"), StandardCharsets.UTF_8);
+      List<StatisticsJsonStringObject> statsDTO = SerializationUtils.deserializeJson(content, typeFactory -> typeFactory
+          .constructCollectionType(List.class, StatisticsJsonStringObject.class));
+
+      assertThat(statisticsObjectContainsFields(statsDTO, "2020-12-04T11:13:22,588")).isTrue();
+    }
+
+    private boolean statisticsObjectContainsFields(List<StatisticsJsonStringObject> statsDTO, String timestamp) {
+      return statsDTO.stream().anyMatch(stat -> stat.getUpdateTimestamp().compareTo(timestamp) == 0);
+    }
+
+    @Test
+    void testGetCardIdSequenceFromConfig() throws IOException {
+      Statistics stats = statisticsToProtobufMapping.constructProtobufStatistics();
+
+      assertThat(stats.getCardIdSequenceList().size()).isEqualTo(4);
+    }
+
+
+    @Test
+    void testKeyFigureCardContainsHeader() throws IOException {
+      Statistics stats = statisticsToProtobufMapping.constructProtobufStatistics();
+
+      assertThat(stats.getKeyFigureCardsCount()).isEqualTo(4);
+      stats.getKeyFigureCardsList().forEach(keyFigureCard -> {
+            assertThat(keyFigureCard.getHeader()).isNotNull();
+            assertThat(keyFigureCard.getHeader().getUpdatedAt()).isPositive();
+          }
+      );
+    }
+
+    @Test
+    void testKeyFigureCardBasedOnHeaderCardId() throws IOException {
+      Statistics stats = statisticsToProtobufMapping.constructProtobufStatistics();
+
+      KeyFigureCard infectionsCard = getKeyFigureCardForId(stats, 1);
+      KeyFigureCard incidenceCard = getKeyFigureCardForId(stats, 2);
+      KeyFigureCard keySubmissionsCard = getKeyFigureCardForId(stats, 3);
+
+      assertThat(infectionsCard.getKeyFiguresCount()).isEqualTo(3);
+      assertThat(incidenceCard.getKeyFiguresCount()).isEqualTo(1);
+      assertThat(keySubmissionsCard.getKeyFiguresCount()).isEqualTo(3);
+    }
+
+    @Test
+    void testEffectiveDateValidation() throws IOException {
+      StatisticsJsonValidator statisticsJsonValidator = new StatisticsJsonValidator();
+
+      String content = FileUtils.readFileToString(
+          new File("./src/test/resources/stats/statistic_data.json"), StandardCharsets.UTF_8);
+      List<StatisticsJsonStringObject> statsDTO = SerializationUtils.deserializeJson(content, typeFactory -> typeFactory
+          .constructCollectionType(List.class, StatisticsJsonStringObject.class));
+      statsDTO = new ArrayList<>(statisticsJsonValidator.validate(statsDTO));
+
+      assertThat(statisticsObjectContainsFields(statsDTO, "2020-12-04T11:13:22,588")).isTrue();
+      //The json object that has the effective_date set on null should not be anymore present after the validation
+      assertThat(statisticsObjectContainsFields(statsDTO, "2020-12-04T00:00:00,000")).isFalse();
+      //The json object that has the effective_date set on invalid format date should not be anymore present after the validation
+      assertThat(statisticsObjectContainsFields(statsDTO, "2020-12-05T00:01:00,000")).isFalse();
+    }
+
+    private KeyFigureCard getKeyFigureCardForId(Statistics stats, Integer id) {
+      return stats.getKeyFigureCardsList()
+          .stream()
+          .filter(keyFigureCard -> keyFigureCard.getHeader().getCardId() == id)
+          .findFirst().get();
+    }
   }
 
-  @Test
-  void testGetCardIdSequenceFromConfig() throws IOException {
-    Statistics stats = statisticsToProtobufMapping.constructProtobufStatistics();
 
-    assertThat(stats.getCardIdSequenceList().size()).isEqualTo(4);
-  }
-
-
-  @Test
-  void testKeyFigureCardContainsHeader() throws IOException {
-    Statistics stats = statisticsToProtobufMapping.constructProtobufStatistics();
-
-    assertThat(stats.getKeyFigureCardsCount()).isEqualTo(4);
-    stats.getKeyFigureCardsList().forEach(keyFigureCard -> {
-          assertThat(keyFigureCard.getHeader()).isNotNull();
-          assertThat(keyFigureCard.getHeader().getUpdatedAt()).isPositive();
-        }
-    );
-  }
-
-  @Test
-  void testKeyFigureCardBasedOnHeaderCardId() throws IOException {
-    Statistics stats = statisticsToProtobufMapping.constructProtobufStatistics();
-
-    KeyFigureCard infectionsCard = getKeyFigureCardForId(stats, 1);
-    KeyFigureCard incidenceCard = getKeyFigureCardForId(stats, 2);
-    KeyFigureCard keySubmissionsCard = getKeyFigureCardForId(stats, 3);
-
-    assertThat(infectionsCard.getKeyFiguresCount()).isEqualTo(3);
-    assertThat(incidenceCard.getKeyFiguresCount()).isEqualTo(1);
-    assertThat(keySubmissionsCard.getKeyFiguresCount()).isEqualTo(3);
-  }
-
-  @Test
-  void testEffectiveDateValidation() throws IOException {
-    StatisticsJsonValidator statisticsJsonValidator = new StatisticsJsonValidator();
-
-    String content = FileUtils.readFileToString(
-        new File("./src/test/resources/stats/statistic_data.json"), StandardCharsets.UTF_8);
-    List<StatisticsJsonStringObject> statsDTO = SerializationUtils.deserializeJson(content, typeFactory -> typeFactory
-        .constructCollectionType(List.class, StatisticsJsonStringObject.class));
-    statsDTO = new ArrayList<>(statisticsJsonValidator.validate(statsDTO));
-
-    assertThat(statisticsObjectContainsFields(statsDTO, "2020-12-04T11:13:22,588")).isTrue();
-    //The json object that has the effective_date set on null should not be anymore present after the validation
-    assertThat(statisticsObjectContainsFields(statsDTO, "2020-12-04T00:00:00,000")).isFalse();
-    //The json object that has the effective_date set on invalid format date should not be anymore present after the validation
-    assertThat(statisticsObjectContainsFields(statsDTO, "2020-12-05T00:01:00,000")).isFalse();
-  }
-
-  private KeyFigureCard getKeyFigureCardForId(Statistics stats, Integer id) {
-    return stats.getKeyFigureCardsList()
-        .stream()
-        .filter(keyFigureCard -> keyFigureCard.getHeader().getCardId() == id)
-        .findFirst().get();
-  }
 
   @EnableConfigurationProperties(value = DistributionServiceConfig.class)
   @ExtendWith(SpringExtension.class)
@@ -133,12 +186,16 @@ class StatisticsJsonToProtobufTest {
   }, initializers = ConfigFileApplicationContextInitializer.class)
   class StatisticsWrongJsonTest {
 
+    @MockBean
+    StatisticsDownloadService service;
+
     @Autowired
-    StatisticsToProtobufMapping mapping;
+    StatisticsToProtobufMapping statisticsToProtobufMapping;
 
     @Test
     void testGenerateStatsWithWrongJSON() throws IOException {
-      var statsObject = mapping.constructProtobufStatistics();
+      when(service.getMostRecentDownload()).thenReturn(Optional.empty());
+      var statsObject = statisticsToProtobufMapping.constructProtobufStatistics();
       var allEmpty = statsObject.getKeyFigureCardsList().stream()
           .allMatch(c -> c.getHeader().getCardId() == KeyFigureCardSequenceConstants.EMPTY_CARD);
       Assert.assertTrue("All key figure cards are empty: no properties in JSON to create cards", allEmpty);
@@ -157,15 +214,18 @@ class StatisticsJsonToProtobufTest {
   }, initializers = ConfigFileApplicationContextInitializer.class)
   class StatisticsJsonProcessingTest {
 
+    @MockBean
+    StatisticsDownloadService service;
+
     @Autowired
-    StatisticsToProtobufMapping mapping;
+    StatisticsToProtobufMapping statisticsToProtobufMapping;
 
     Statistics result;
     KeyFigureCard infections, incidence, keySubmission;
 
     @BeforeEach
     void setup() throws IOException {
-      result = mapping.constructProtobufStatistics();
+      result = statisticsToProtobufMapping.constructProtobufStatistics();
       infections = result.getKeyFigureCards(0);
       incidence = result.getKeyFigureCards(1);
       keySubmission = result.getKeyFigureCards(2);

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonToProtobufTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsJsonToProtobufTest.java
@@ -12,6 +12,7 @@ import app.coronawarn.server.common.protocols.internal.stats.KeyFigure.TrendSema
 import app.coronawarn.server.common.protocols.internal.stats.KeyFigureCard;
 import app.coronawarn.server.common.protocols.internal.stats.Statistics;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
+import app.coronawarn.server.services.distribution.statistics.file.JsonFile;
 import app.coronawarn.server.services.distribution.statistics.file.LocalStatisticJsonFileLoader;
 import app.coronawarn.server.services.distribution.statistics.keyfigurecard.KeyFigureCardFactory;
 import app.coronawarn.server.services.distribution.statistics.keyfigurecard.KeyFigureCardSequenceConstants;

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsLoadExceptionTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/StatisticsLoadExceptionTest.java
@@ -3,6 +3,7 @@ package app.coronawarn.server.services.distribution.statistics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import app.coronawarn.server.common.persistence.service.StatisticsDownloadService;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.statistics.exceptions.BucketNotFoundException;
 import app.coronawarn.server.services.distribution.statistics.exceptions.ConnectionException;
@@ -16,10 +17,12 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import java.util.Optional;
 
 @EnableConfigurationProperties(value = {DistributionServiceConfig.class})
 @ExtendWith(SpringExtension.class)
@@ -39,6 +42,9 @@ class StatisticsLoadExceptionTest {
   @Autowired
   KeyFigureCardFactory keyFigureCardFactory;
 
+  @MockBean
+  StatisticsDownloadService statisticsDownloadService;
+
   @ParameterizedTest
   @ValueSource(classes = {
       BucketNotFoundException.class,
@@ -46,8 +52,9 @@ class StatisticsLoadExceptionTest {
       ConnectionException.class
   })
   void shouldNotGenerateProtobufFileIfException(Class<RuntimeException> exception) {
-    when(loader.getContent()).thenThrow(exception);
-    var statisticsToProtobufMapping = new StatisticsToProtobufMapping(serviceConfig, keyFigureCardFactory, loader);
+    when(loader.getFile()).thenThrow(exception);
+    when(statisticsDownloadService.getMostRecentDownload()).thenReturn(Optional.empty());
+    var statisticsToProtobufMapping = new StatisticsToProtobufMapping(serviceConfig, keyFigureCardFactory, loader, statisticsDownloadService);
     assertThat(statisticsToProtobufMapping.constructProtobufStatistics().getKeyFigureCardsCount())
         .isZero();
   }


### PR DESCRIPTION
Makes Distribution service aware of the eTag when downloading JSON Statistics files. Every time a new file is downloaded, its eTag and timestamp are stored in a new Database Table `statistics_downloaded`. The latest eTag is used in the AWS resource request to check if the file was updated since last download. 

**Summary of changes:**
- Adds new Entity, Repository and Service to reflect the new `statistics_downloaded` table.
- JsonLoader interface can return `Optional<JsonFile>` when called with eTag.
- New exception `NotModified` thrown by S3Wrapper in case AWS SDK returns 304 (NotModified) from Get Resource Request.
- Retention Policy Runner step now also deletes content from `statistics_downloaded` based on the same retention days as diagnosis keys.

--- 

Internal tracking: EXPOSUREBACK-648