### PR TITLE
Feature/callback registration

### DIFF
--- a/common/federation/src/main/java/app/coronawarn/server/common/federation/client/FederationGatewayClient.java
+++ b/common/federation/src/main/java/app/coronawarn/server/common/federation/client/FederationGatewayClient.java
@@ -1,14 +1,15 @@
-
-
 package app.coronawarn.server.common.federation.client;
 
+import app.coronawarn.server.common.federation.client.callback.RegistrationResponse;
 import app.coronawarn.server.common.federation.client.upload.BatchUploadResponse;
 import app.coronawarn.server.common.protocols.external.exposurenotification.DiagnosisKeyBatch;
+import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 /**
@@ -24,6 +25,19 @@ import org.springframework.web.bind.annotation.RequestHeader;
  */
 @FeignClient(name = "federation-server", url = "${federation-gateway.base-url}")
 public interface FederationGatewayClient {
+
+  @GetMapping(value = "/diagnosiskeys/callback",
+      headers = {"Accept=application/json; version=1.0",
+          "X-SSL-Client-SHA256=${federation-gateway.ssl.certificate-sha}",
+          "X-SSL-Client-DN=${federation-gateway.ssl.certificate-dn}"})
+  ResponseEntity<List<RegistrationResponse>> getCallbackRegistrations();
+
+  @PutMapping(value = "/diagnosiskeys/callback/{id}?url={url}",
+      headers = {"Accept=application/json; version=1.0",
+          "X-SSL-Client-SHA256=${federation-gateway.ssl.certificate-sha}",
+          "X-SSL-Client-DN=${federation-gateway.ssl.certificate-dn}"})
+  ResponseEntity<RegistrationResponse> putCallbackRegistration(@PathVariable("id") String id,
+      @PathVariable("url") String url);
 
   @GetMapping(value = "/diagnosiskeys/download/{date}",
       headers = {"Accept=application/protobuf; version=1.0",

--- a/common/federation/src/main/java/app/coronawarn/server/common/federation/client/callback/RegistrationResponse.java
+++ b/common/federation/src/main/java/app/coronawarn/server/common/federation/client/callback/RegistrationResponse.java
@@ -1,0 +1,36 @@
+package app.coronawarn.server.common.federation.client.callback;
+
+/**
+ * Callback Registration response is returned from the EFGS and contains information about endpoints registered in its
+ * callback API.
+ */
+public class RegistrationResponse {
+
+  private String id;
+  private String url;
+
+  public RegistrationResponse() {
+    // empty constructor
+  }
+
+  public RegistrationResponse(String id, String url) {
+    this.id = id;
+    this.url = url;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+}

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/CallbackUtils.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/CallbackUtils.java
@@ -1,0 +1,22 @@
+package app.coronawarn.server.services.callback;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.bouncycastle.util.encoders.Hex;
+
+public class CallbackUtils {
+
+  public static String computeSha256Hash(String subject) {
+    MessageDigest digest = null;
+    try {
+      digest = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException("Hash algorithm not found.");
+    }
+    byte[] hash = digest.digest(
+        subject.getBytes(StandardCharsets.UTF_8));
+    return new String(Hex.encode(hash));
+  }
+
+}

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/CallbackUtils.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/CallbackUtils.java
@@ -7,6 +7,12 @@ import org.bouncycastle.util.encoders.Hex;
 
 public class CallbackUtils {
 
+  public static final String HASHING_ALGORITHM = "SHA-256";
+
+  private CallbackUtils() {
+    throw new IllegalStateException("Utility class");
+  }
+
   /**
    * Computes the SHA-256 hash of the provided string.
    *
@@ -16,9 +22,9 @@ public class CallbackUtils {
   public static String computeSha256Hash(String subject) {
     MessageDigest digest = null;
     try {
-      digest = MessageDigest.getInstance("SHA-256");
+      digest = MessageDigest.getInstance(HASHING_ALGORITHM);
     } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException("Hash algorithm not found.");
+      throw new HashAlgorithmNotFoundException("Hashing algorithm '" + HASHING_ALGORITHM + "' not found.");
     }
     byte[] hash = digest.digest(
         subject.getBytes(StandardCharsets.UTF_8));

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/CallbackUtils.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/CallbackUtils.java
@@ -7,6 +7,12 @@ import org.bouncycastle.util.encoders.Hex;
 
 public class CallbackUtils {
 
+  /**
+   * Computes the SHA-256 hash of the provided string.
+   *
+   * @param subject the string to compute the hash
+   * @return the SHA-256 hash of the string.
+   */
   public static String computeSha256Hash(String subject) {
     MessageDigest digest = null;
     try {

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/HashAlgorithmNotFoundException.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/HashAlgorithmNotFoundException.java
@@ -2,7 +2,7 @@ package app.coronawarn.server.services.callback;
 
 public class HashAlgorithmNotFoundException extends RuntimeException {
 
-  public HashAlgorithmNotFoundException(String msg) {
-    super(msg);
+  public HashAlgorithmNotFoundException(String msg, Throwable rootCause) {
+    super(msg, rootCause);
   }
 }

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/HashAlgorithmNotFoundException.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/HashAlgorithmNotFoundException.java
@@ -1,0 +1,8 @@
+package app.coronawarn.server.services.callback;
+
+public class HashAlgorithmNotFoundException extends RuntimeException {
+
+  public HashAlgorithmNotFoundException(String msg) {
+    super(msg);
+  }
+}

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/HashingUtils.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/HashingUtils.java
@@ -24,7 +24,7 @@ public class HashingUtils {
     try {
       digest = MessageDigest.getInstance(HASHING_ALGORITHM);
     } catch (NoSuchAlgorithmException e) {
-      throw new HashAlgorithmNotFoundException("Hashing algorithm '" + HASHING_ALGORITHM + "' not found.");
+      throw new HashAlgorithmNotFoundException("Hashing algorithm '" + HASHING_ALGORITHM + "' not found.", e);
     }
     byte[] hash = digest.digest(
         subject.getBytes(StandardCharsets.UTF_8));

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/HashingUtils.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/HashingUtils.java
@@ -5,11 +5,11 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.bouncycastle.util.encoders.Hex;
 
-public class CallbackUtils {
+public class HashingUtils {
 
   public static final String HASHING_ALGORITHM = "SHA-256";
 
-  private CallbackUtils() {
+  private HashingUtils() {
     throw new IllegalStateException("Utility class");
   }
 

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/ServerApplication.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/ServerApplication.java
@@ -22,8 +22,8 @@ import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 @SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
 @EnableJdbcRepositories(basePackages = "app.coronawarn.server.common.persistence")
 @EntityScan(basePackages = "app.coronawarn.server.common.persistence")
-@ComponentScan({ "app.coronawarn.server.common.persistence", "app.coronawarn.server.common.federation.client.hostname", 
-    "app.coronawarn.server.services.callback" })
+@ComponentScan({"app.coronawarn.server.common.persistence", "app.coronawarn.server.common.federation.client.hostname",
+    "app.coronawarn.server.services.callback", "app.coronawarn.server.common.federation.client"})
 @EnableConfigurationProperties
 public class ServerApplication implements EnvironmentAware, DisposableBean {
 

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/config/CallbackServiceConfig.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/config/CallbackServiceConfig.java
@@ -11,11 +11,31 @@ public class CallbackServiceConfig {
 
   private String efgsCertCn;
 
+  private boolean registerOnStartup;
+
+  private String endpointUrl;
+
   public String getEfgsCertCn() {
     return efgsCertCn;
   }
 
   public void setEfgsCertCn(String efgsCertCn) {
     this.efgsCertCn = efgsCertCn;
+  }
+
+  public boolean isRegisterOnStartup() {
+    return registerOnStartup;
+  }
+
+  public void setRegisterOnStartup(boolean registerOnStartup) {
+    this.registerOnStartup = registerOnStartup;
+  }
+
+  public String getEndpointUrl() {
+    return endpointUrl;
+  }
+
+  public void setEndpointUrl(String endpointUrl) {
+    this.endpointUrl = endpointUrl;
   }
 }

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/registration/RegistrationRunner.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/registration/RegistrationRunner.java
@@ -1,12 +1,10 @@
 package app.coronawarn.server.services.callback.registration;
 
+import static app.coronawarn.server.services.callback.CallbackUtils.computeSha256Hash;
+
 import app.coronawarn.server.common.federation.client.FederationGatewayClient;
 import app.coronawarn.server.services.callback.config.CallbackServiceConfig;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import org.apache.commons.lang3.StringUtils;
-import org.bouncycastle.util.encoders.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
@@ -43,23 +41,11 @@ public class RegistrationRunner implements ApplicationRunner {
     boolean callbackUrlIsAlreadyRegistered = federationGatewayClient.getCallbackRegistrations().getBody().stream()
         .anyMatch(registrationResponse -> StringUtils.equals(registrationId, registrationResponse.getId()));
     if (callbackUrlIsAlreadyRegistered) {
-      logger.info("Callback for id '" + registrationId + "' and URL '" + endpointUrl + "' was already registered.");
+      logger.info("Callback for id '" + registrationId + "' (URL: '" + endpointUrl + "') was already registered.");
       return;
     }
 
     federationGatewayClient.putCallbackRegistration(registrationId, endpointUrl);
     logger.info("Callback for id '" + registrationId + "' and URL '" + endpointUrl + "' registered successfully.");
-  }
-
-  private String computeSha256Hash(String subject) {
-    MessageDigest digest = null;
-    try {
-      digest = MessageDigest.getInstance("SHA-256");
-    } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException("Hash algorithm not found.");
-    }
-    byte[] hash = digest.digest(
-        subject.getBytes(StandardCharsets.UTF_8));
-    return new String(Hex.encode(hash));
   }
 }

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/registration/RegistrationRunner.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/registration/RegistrationRunner.java
@@ -31,7 +31,7 @@ public class RegistrationRunner implements ApplicationRunner {
   @Override
   public void run(ApplicationArguments args) {
     if (!serviceConfig.isRegisterOnStartup()) {
-      logger.info("Callback registration on startup was disabled.");
+      logger.info("Callback registration on startup is disabled. See 'CALLBACK_REGISTER_ON_STARTUP'");
       return;
     }
 

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/registration/RegistrationRunner.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/registration/RegistrationRunner.java
@@ -37,15 +37,16 @@ public class RegistrationRunner implements ApplicationRunner {
 
     String endpointUrl = serviceConfig.getEndpointUrl();
     String registrationId = computeSha256Hash(endpointUrl);
+    logger.info("Starting callback registration for URL '" + endpointUrl + "'.");
 
     boolean callbackUrlIsAlreadyRegistered = federationGatewayClient.getCallbackRegistrations().getBody().stream()
         .anyMatch(registrationResponse -> StringUtils.equals(registrationId, registrationResponse.getId()));
     if (callbackUrlIsAlreadyRegistered) {
-      logger.info("Callback for id '" + registrationId + "' (URL: '" + endpointUrl + "') was already registered.");
+      logger.info("Callback with id '" + registrationId + "' (URL: '" + endpointUrl + "') was already registered.");
       return;
     }
 
     federationGatewayClient.putCallbackRegistration(registrationId, endpointUrl);
-    logger.info("Callback for id '" + registrationId + "' and URL '" + endpointUrl + "' registered successfully.");
+    logger.info("Callback with id '" + registrationId + "' and URL '" + endpointUrl + "' registered successfully.");
   }
 }

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/registration/RegistrationRunner.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/registration/RegistrationRunner.java
@@ -1,0 +1,59 @@
+package app.coronawarn.server.services.callback.registration;
+
+import app.coronawarn.server.common.federation.client.FederationGatewayClient;
+import app.coronawarn.server.services.callback.config.CallbackServiceConfig;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.util.encoders.Hex;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * This runner registers the callback service at the EFGS.
+ */
+@Component
+@Order(1)
+public class RegistrationRunner implements ApplicationRunner {
+
+  private CallbackServiceConfig serviceConfig;
+  private FederationGatewayClient federationGatewayClient;
+
+  public RegistrationRunner(CallbackServiceConfig serviceConfig, FederationGatewayClient federationGatewayClient) {
+    this.serviceConfig = serviceConfig;
+    this.federationGatewayClient = federationGatewayClient;
+  }
+
+  @Override
+  public void run(ApplicationArguments args) {
+    if (!serviceConfig.isRegisterOnStartup()) {
+      return;
+    }
+
+    String endpointUrl = serviceConfig.getEndpointUrl();
+    String id = computeSha256Hash(endpointUrl);
+
+    boolean callbackUrlIsRegistered = federationGatewayClient.getCallbackRegistrations().getBody().stream()
+        .anyMatch(registrationResponse -> StringUtils.equals(id, registrationResponse.getId()));
+    if (callbackUrlIsRegistered) {
+      return;
+    }
+
+    federationGatewayClient.putCallbackRegistration(id, endpointUrl);
+  }
+
+  private String computeSha256Hash(String subject) {
+    MessageDigest digest = null;
+    try {
+      digest = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException("Hash algorithm not found.");
+    }
+    byte[] hash = digest.digest(
+        subject.getBytes(StandardCharsets.UTF_8));
+    return new String(Hex.encode(hash));
+  }
+}

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/registration/RegistrationRunner.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/registration/RegistrationRunner.java
@@ -1,6 +1,6 @@
 package app.coronawarn.server.services.callback.registration;
 
-import static app.coronawarn.server.services.callback.CallbackUtils.computeSha256Hash;
+import static app.coronawarn.server.services.callback.HashingUtils.computeSha256Hash;
 
 import app.coronawarn.server.common.federation.client.FederationGatewayClient;
 import app.coronawarn.server.services.callback.config.CallbackServiceConfig;

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/registration/RegistrationRunner.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/registration/RegistrationRunner.java
@@ -37,16 +37,16 @@ public class RegistrationRunner implements ApplicationRunner {
 
     String endpointUrl = serviceConfig.getEndpointUrl();
     String registrationId = computeSha256Hash(endpointUrl);
-    logger.info("Starting callback registration for URL '" + endpointUrl + "'.");
+    logger.info("Starting callback registration for ID '{}' URL '{}'.", registrationId, endpointUrl);
 
     boolean callbackUrlIsAlreadyRegistered = federationGatewayClient.getCallbackRegistrations().getBody().stream()
         .anyMatch(registrationResponse -> StringUtils.equals(registrationId, registrationResponse.getId()));
     if (callbackUrlIsAlreadyRegistered) {
-      logger.info("Callback with id '" + registrationId + "' (URL: '" + endpointUrl + "') was already registered.");
+      logger.info("Callback with id '{}' was already registered.", registrationId);
       return;
     }
 
     federationGatewayClient.putCallbackRegistration(registrationId, endpointUrl);
-    logger.info("Callback with id '" + registrationId + "' and URL '" + endpointUrl + "' registered successfully.");
+    logger.info("Callback with id '{}' and URL '{}' registered successfully.", registrationId, endpointUrl);
   }
 }

--- a/services/callback/src/main/resources/application.yaml
+++ b/services/callback/src/main/resources/application.yaml
@@ -10,8 +10,17 @@ logging:
 services:
   callback:
     efgs-cert-cn: ${EFGS_CERT_CN}
-    register-on-startup: ${CALLBACK_REGISTER_ON_STARTUP:true}
+    register-on-startup: ${CALLBACK_REGISTER_ON_STARTUP:false}
     endpoint-url: ${CALLBACK_ENDPOINT_URL}
+
+federation-gateway:
+  base-url: ${FEDERATION_GATEWAY_BASE_URL:http://localhost:8005}
+  connection-pool-size: 200
+  ssl:
+    key-store: ${FEDERATION_GATEWAY_KEYSTORE_PATH}
+    key-store-password: ${FEDERATION_GATEWAY_KEYSTORE_PASS}
+    trust-store: ${SSL_FEDERATION_TRUSTSTORE_PATH}
+    trust-store-password: ${SSL_FEDERATION_TRUSTSTORE_PASSWORD}
 
 spring:
   lifecycle:

--- a/services/callback/src/main/resources/application.yaml
+++ b/services/callback/src/main/resources/application.yaml
@@ -10,6 +10,8 @@ logging:
 services:
   callback:
     efgs-cert-cn: ${EFGS_CERT_CN}
+    register-on-startup: ${CALLBACK_REGISTER_ON_STARTUP:true}
+    endpoint-url: ${CALLBACK_ENDPOINT_URL}
 
 spring:
   lifecycle:

--- a/services/callback/src/main/resources/application.yaml
+++ b/services/callback/src/main/resources/application.yaml
@@ -10,7 +10,7 @@ logging:
 services:
   callback:
     efgs-cert-cn: ${EFGS_CERT_CN}
-    register-on-startup: ${CALLBACK_REGISTER_ON_STARTUP:false}
+    register-on-startup: ${CALLBACK_REGISTER_ON_STARTUP:true}
     endpoint-url: ${CALLBACK_ENDPOINT_URL}
 
 federation-gateway:

--- a/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerIntegrationTest.java
+++ b/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerIntegrationTest.java
@@ -1,0 +1,91 @@
+package app.coronawarn.server.services.callback.controller;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+
+import app.coronawarn.server.common.federation.client.callback.RegistrationResponse;
+import app.coronawarn.server.services.callback.config.CallbackServiceConfig;
+import app.coronawarn.server.services.callback.registration.RegistrationRunner;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"download-date-based-integration-test"})
+@DirtiesContext
+class CallbackRegistrationRunnerIntegrationTest {
+
+  private static WireMockServer server;
+
+  @Autowired
+  private RegistrationRunner registrationRunner;
+
+  @Autowired
+  private CallbackServiceConfig callbackServiceConfig;
+
+  @BeforeAll
+  static void setupWireMock() {
+    //HttpHeaders batch1Headers = getHttpHeaders(BATCH1_TAG, BATCH2_TAG);
+
+    RegistrationResponse registrationResponse1 = new RegistrationResponse("id1", "url1");
+    RegistrationResponse registrationResponse2 = new RegistrationResponse("id2", "url2");
+    List<RegistrationResponse> responses = List.of(registrationResponse1, registrationResponse2);
+
+    server = new WireMockServer(options().port(1234));
+    server.start();
+    server.stubFor(
+        get(anyUrl())
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.OK.value())
+                    .withHeaders(getHttpHeaders())
+                    .withBody(asJsonString(responses))));
+
+    server.stubFor(
+        put(anyUrl())
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.OK.value())
+                    .withHeaders(getHttpHeaders())
+                    .withBody(asJsonString(registrationResponse1))));
+  }
+
+  @AfterAll
+  static void tearDown() {
+    server.stop();
+  }
+
+  private static HttpHeaders getHttpHeaders() {
+    return new HttpHeaders()
+        .plus(new HttpHeader(CONTENT_TYPE, "application/json; version=1.0"));
+  }
+
+  public static String asJsonString(final Object obj) {
+    try {
+      return new ObjectMapper().writeValueAsString(obj);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void testDownloadRunSuccessfully() {
+    assertThat(true).isTrue();
+  }
+}

--- a/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerIntegrationTest.java
+++ b/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerIntegrationTest.java
@@ -41,8 +41,6 @@ class CallbackRegistrationRunnerIntegrationTest {
 
   @BeforeAll
   static void setupWireMock() {
-    //HttpHeaders batch1Headers = getHttpHeaders(BATCH1_TAG, BATCH2_TAG);
-
     RegistrationResponse registrationResponse1 = new RegistrationResponse("id1", "url1");
     RegistrationResponse registrationResponse2 = new RegistrationResponse("id2", "url2");
     List<RegistrationResponse> responses = List.of(registrationResponse1, registrationResponse2);

--- a/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerIntegrationTest.java
+++ b/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerIntegrationTest.java
@@ -27,7 +27,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@ActiveProfiles({"download-date-based-integration-test"})
+@ActiveProfiles({"callback-registration"})
 @DirtiesContext
 class CallbackRegistrationRunnerIntegrationTest {
 

--- a/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerIntegrationTest.java
+++ b/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerIntegrationTest.java
@@ -1,6 +1,6 @@
 package app.coronawarn.server.services.callback.controller;
 
-import static app.coronawarn.server.services.callback.CallbackUtils.computeSha256Hash;
+import static app.coronawarn.server.services.callback.HashingUtils.computeSha256Hash;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;

--- a/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerTest.java
+++ b/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerTest.java
@@ -1,0 +1,85 @@
+package app.coronawarn.server.services.callback.controller;
+
+import static app.coronawarn.server.services.callback.CallbackUtils.computeSha256Hash;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import app.coronawarn.server.common.federation.client.FederationGatewayClient;
+import app.coronawarn.server.common.federation.client.callback.RegistrationResponse;
+import app.coronawarn.server.services.callback.config.CallbackServiceConfig;
+import app.coronawarn.server.services.callback.registration.RegistrationRunner;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+class CallbackRegistrationRunnerTest {
+
+  @Test
+  void testCallbackRegistrationDisabled() {
+    CallbackServiceConfig callbackServiceConfig = mock(CallbackServiceConfig.class);
+    when(callbackServiceConfig.isRegisterOnStartup()).thenReturn(false);
+
+    FederationGatewayClient federationGatewayClient = mock(FederationGatewayClient.class);
+
+    RegistrationRunner registrationRunner = new RegistrationRunner(callbackServiceConfig, federationGatewayClient);
+    registrationRunner.run(null);
+
+    verify(callbackServiceConfig, times(1)).isRegisterOnStartup();
+    verify(callbackServiceConfig, times(0)).getEndpointUrl();
+    verify(federationGatewayClient, times(0)).getCallbackRegistrations();
+    verify(federationGatewayClient, times(0)).putCallbackRegistration(any(), any());
+  }
+
+  @Test
+  void testCallbackRegistrationAlreadyDone() {
+    String endpointUrl = "url";
+
+    CallbackServiceConfig callbackServiceConfig = mock(CallbackServiceConfig.class);
+    when(callbackServiceConfig.isRegisterOnStartup()).thenReturn(true);
+    when(callbackServiceConfig.getEndpointUrl()).thenReturn(endpointUrl);
+
+    FederationGatewayClient federationGatewayClient = mock(FederationGatewayClient.class);
+    when(federationGatewayClient.getCallbackRegistrations())
+        .thenReturn(
+            new ResponseEntity<>(List.of(new RegistrationResponse(computeSha256Hash(endpointUrl), endpointUrl)),
+                HttpStatus.OK));
+
+    RegistrationRunner registrationRunner = new RegistrationRunner(callbackServiceConfig, federationGatewayClient);
+    registrationRunner.run(null);
+
+    verify(callbackServiceConfig, times(1)).isRegisterOnStartup();
+    verify(callbackServiceConfig, times(1)).getEndpointUrl();
+    verify(federationGatewayClient, times(1)).getCallbackRegistrations();
+    verify(federationGatewayClient, times(0)).putCallbackRegistration(any(), any());
+  }
+
+  @Test
+  void testCallbackRegistrationSuccessful() {
+    String endpointUrl = "url";
+
+    CallbackServiceConfig callbackServiceConfig = mock(CallbackServiceConfig.class);
+    when(callbackServiceConfig.isRegisterOnStartup()).thenReturn(true);
+    when(callbackServiceConfig.getEndpointUrl()).thenReturn(endpointUrl);
+
+    FederationGatewayClient federationGatewayClient = mock(FederationGatewayClient.class);
+    when(federationGatewayClient.getCallbackRegistrations())
+        .thenReturn(
+            new ResponseEntity<>(List.of(new RegistrationResponse(computeSha256Hash("id"), "other-url")),
+                HttpStatus.OK));
+
+    RegistrationRunner registrationRunner = new RegistrationRunner(callbackServiceConfig, federationGatewayClient);
+    registrationRunner.run(null);
+
+    verify(callbackServiceConfig, times(1)).isRegisterOnStartup();
+    verify(callbackServiceConfig, times(1)).getEndpointUrl();
+    verify(federationGatewayClient, times(1)).getCallbackRegistrations();
+    verify(federationGatewayClient, times(1))
+        .putCallbackRegistration(eq(computeSha256Hash(endpointUrl)), eq(endpointUrl));
+  }
+
+}

--- a/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerTest.java
+++ b/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerTest.java
@@ -1,6 +1,6 @@
 package app.coronawarn.server.services.callback.controller;
 
-import static app.coronawarn.server.services.callback.CallbackUtils.computeSha256Hash;
+import static app.coronawarn.server.services.callback.HashingUtils.computeSha256Hash;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerTest.java
+++ b/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackRegistrationRunnerTest.java
@@ -2,7 +2,6 @@ package app.coronawarn.server.services.callback.controller;
 
 import static app.coronawarn.server.services.callback.CallbackUtils.computeSha256Hash;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -79,7 +78,7 @@ class CallbackRegistrationRunnerTest {
     verify(callbackServiceConfig, times(1)).getEndpointUrl();
     verify(federationGatewayClient, times(1)).getCallbackRegistrations();
     verify(federationGatewayClient, times(1))
-        .putCallbackRegistration(eq(computeSha256Hash(endpointUrl)), eq(endpointUrl));
+        .putCallbackRegistration(computeSha256Hash(endpointUrl), endpointUrl);
   }
 
 }

--- a/services/callback/src/test/resources/application-callback-registration.yaml
+++ b/services/callback/src/test/resources/application-callback-registration.yaml
@@ -1,4 +1,4 @@
 services:
   callback:
-    register-on-startup: false
+    register-on-startup: true
     endpoint-url: url

--- a/services/callback/src/test/resources/application-callback-registration.yaml
+++ b/services/callback/src/test/resources/application-callback-registration.yaml
@@ -1,0 +1,4 @@
+services:
+  callback:
+    register-on-startup: false
+    endpoint-url: url

--- a/services/callback/src/test/resources/application.yaml
+++ b/services/callback/src/test/resources/application.yaml
@@ -21,6 +21,18 @@ services:
     monitoring:
       batch-size: 5
     efgs-cert-cn: localhost
+    register-on-startup: true
+    endpoint-url: url
+
+federation-gateway:
+  base-url: http://localhost:1234
+  connection-pool-size: 200
+  ssl:
+    key-password: 123456
+    key-store: ../../docker-compose-test-secrets/ssl.p12
+    key-store-password: 123456
+    trust-store: ../../docker-compose-test-secrets/contains_efgs_truststore.jks
+    trust-store-password: 123456
 
 management:
   endpoint:

--- a/services/callback/src/test/resources/application.yaml
+++ b/services/callback/src/test/resources/application.yaml
@@ -21,7 +21,7 @@ services:
     monitoring:
       batch-size: 5
     efgs-cert-cn: localhost
-    register-on-startup: true
+    register-on-startup: false
     endpoint-url: url
 
 federation-gateway:


### PR DESCRIPTION
This feature enables the automated callback registration at the EFGS during startup.
- The env variable CALLBACK_REGISTER_ON_STARTUP determines if the registration should take place
- The route of the callback service to be registered must be placed in the env variable CALLBACK_ENDPOINT_URL
- The federation-gateway.ssl variables are required to establish the connection to the EFGS