### PR TITLE
chore(app-config): increase upper bound for high risk per day

### DIFF
--- a/services/distribution/src/main/resources/main-config/v2/risk-calculation-parameters.yaml
+++ b/services/distribution/src/main/resources/main-config/v2/risk-calculation-parameters.yaml
@@ -61,7 +61,7 @@ normalized-time-per-day-to-risk-level-mapping:
   -
     normalized-time-range:
       min: 15
-      max: 9999
+      max: 99999
     risk-level: 2
 
 transmission-risk-level-multiplier: 0.2


### PR DESCRIPTION
This is in response to EXPOSUREAPP-4856, which was found internally during testing. The tester hat 1.687 exposure windows on the device accumulating to a normalized time per day of more than 11.000 minutes (aka _risk minutes_).

This PR changes the upper bound by accomodate this scenario. We have no indication that this happens in reality but who knows...