### PR TITLE
Ubuntu 16.04 reaches the end of its LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/cwa-server
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202101-01
       docker_layer_caching: true
     steps:
       - checkout


### PR DESCRIPTION
Ubuntu 16.04 reaches the end of its LTS window at the end of April 2021
and will no longer be supported by Canonical. As a result, the final
16.04 CircleCI machine image release by us will take place in April to
include the most recent security patches. We suggest upgrading to the
Ubuntu 20.04 image for continued releases past April. 2021.