### PR TITLE
All SSL params need be specified for `management.server.ssl.*`

### DIFF
--- a/services/callback/src/main/resources/application.yaml
+++ b/services/callback/src/main/resources/application.yaml
@@ -48,6 +48,26 @@ spring:
 management:
   server:
     port: 8081
+    ssl:
+      enabled: true
+      enabled-protocols: TLSv1.2,TLSv1.3
+      protocol: TLS
+      ciphers: >-
+        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        TLS_DHE_DSS_WITH_AES_128_GCM_SHA256
+        TLS_DHE_DSS_WITH_AES_256_GCM_SHA384
+        TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+        TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+        TLS_AES_128_GCM_SHA256
+        TLS_AES_256_GCM_SHA384
+        TLS_AES_128_CCM_SHA256
+      key-password: ${SSL_CALLBACK_KEYSTORE_PASSWORD}
+      key-store: ${SSL_CALLBACK_KEYSTORE_PATH}
+      key-store-password: ${SSL_CALLBACK_KEYSTORE_PASSWORD}
+      client-auth: none
   endpoint:
     metrics:
       enabled: true


### PR DESCRIPTION
Once a single parameter is specified at `management.server.ssl.*` it requires specifying all parameters again

As of this post: https://github.com/spring-projects/spring-boot/issues/15437 currently, all
