### PR TITLE
Fix exception logging (closes EXPOSUREBACK-1020)

### DIFF
--- a/services/callback/src/main/resources/log4j2.xml
+++ b/services/callback/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{100000}}{CRLF} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{100000}}{CRLF} %exception{10}{separator(\u2028)} %n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">

--- a/services/distribution/src/main/resources/log4j2.xml
+++ b/services/distribution/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{100000}}{CRLF} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{100000}}{CRLF} %exception{10}{separator(\u2028)} %n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">

--- a/services/download/src/main/resources/log4j2.xml
+++ b/services/download/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{100000}}{CRLF} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{100000}}{CRLF} %exception{10}{separator(\u2028)} %n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">

--- a/services/submission/src/main/resources/log4j2.xml
+++ b/services/submission/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{100000}}{CRLF} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{100000}}{CRLF} %exception{10}{separator(\u2028)} %n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">

--- a/services/upload/src/main/resources/log4j2.xml
+++ b/services/upload/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{100000}}{CRLF} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %enc{%maxLen{%m}{100000}}{CRLF} %exception{10}{separator(\u2028)} %n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">


### PR DESCRIPTION
No apparent downside to using the fix everywhere, so after testing it for submission, it was rolled out to every service:

Replaced `%replace{%rException}{[\r\n]+}{\u2028}` with `%exception{10}{separator(\u2028)} %n`

Before submitting, please take the time to check the points below and provide some descriptive information.
[x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
[x] Make sure `mvn -P integration-tests clean verify` runs for the whole project and, if you touched any code for a service in the `services` folder, ensure it can be run with `spring-boot:run`
