### PR TITLE
Use spring-vault-core 2.3.2 instead of 2.3.0 to fix error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,11 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>org.springframework.vault</groupId>
+        <artifactId>spring-vault-core</artifactId>
+        <version>2.3.2</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>${protobuf.version}</version>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -22,14 +22,13 @@
   </modules>
 
   <dependencies>
-	<dependency>
-	    <groupId>org.springframework.vault</groupId>
-	    <artifactId>spring-vault-core</artifactId>
-	    <version>2.3.2</version>
-	</dependency>
     <dependency>
-      <!-- The cloud bootstrap starter is needed due to a breaking change implemented in Spring Cloud 2020.0.0 which turns off
-	  the Bootstrap context (used throughout the services for vault config) by default -->
+      <groupId>org.springframework.vault</groupId>
+      <artifactId>spring-vault-core</artifactId>
+    </dependency>
+    <dependency>
+      <!-- The cloud bootstrap starter is needed due to a breaking change implemented in Spring Cloud 2020.0.0 which turns off the Bootstrap 
+        context (used throughout the services for vault config) by default -->
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-bootstrap</artifactId>
     </dependency>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -22,15 +22,26 @@
   </modules>
 
   <dependencies>
-	 <!-- The cloud bootstrap starter is needed due to a breaking change implemented in Spring Cloud 2020.0.0 which turns off
-	  the Bootstrap context (used throughout the services for vault config) by default -->
+	<dependency>
+	    <groupId>org.springframework.vault</groupId>
+	    <artifactId>spring-vault-core</artifactId>
+	    <version>2.3.2</version>
+	</dependency>
     <dependency>
+      <!-- The cloud bootstrap starter is needed due to a breaking change implemented in Spring Cloud 2020.0.0 which turns off
+	  the Bootstrap context (used throughout the services for vault config) by default -->
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-bootstrap</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-vault-config</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.vault</groupId>
+          <artifactId>spring-vault-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.opencwa</groupId>


### PR DESCRIPTION
Fixes (hopefully) the following error:

***************************
APPLICATION FAILED TO START
***************************

Description:
An attempt was made to call a method that does not exist. The attempt was made from the following location:
    org.springframework.cloud.vault.config.VaultConfiguration.createSslConfiguration(VaultConfiguration.java:101)

The following method did not exist:
    'void org.springframework.vault.support.SslConfiguration.<init>(org.springframework.vault.support.SslConfiguration$KeyStoreConfiguration, org.springframework.vault.support.SslConfiguration$KeyStoreConfiguration, java.util.List, java.util.List)'

The method's class, org.springframework.vault.support.SslConfiguration, is available from the following locations:
    jar:file:/service.jar!/BOOT-INF/lib/spring-vault-core-2.3.0.jar!/org/springframework/vault/support/SslConfiguration.class

The class hierarchy was loaded from the following locations:
    org.springframework.vault.support.SslConfiguration: jar:file:/service.jar!/BOOT-INF/lib/spring-vault-core-2.3.0.jar!/

Action:
Correct the classpath of your application so that it contains a single, compatible version of org.springframework.vault.support.SslConfiguration