### PR TITLE
Feature/upgrade spring vault core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
       <dependency>
         <groupId>org.springframework.vault</groupId>
         <artifactId>spring-vault-core</artifactId>
-        <version>spring-vault-core.version</version>
+        <version>${spring-vault-core.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
     <spring-boot.version>2.4.4</spring-boot.version>
     <!-- https://spring.io/projects/spring-cloud#release-trains -->
     <spring-cloud.version>2020.0.2</spring-cloud.version>
+    <!-- If you update spring-cloud, see if it references the correct spring-vault-core version again, then remove the following: -->
+    <spring-vault-core.version>2.3.2</spring-vault-core.version>
     <spring-retry.version>1.3.1</spring-retry.version>
     <protobuf.version>3.15.6</protobuf.version>
     <json-simple.version>1.1.1</json-simple.version>
@@ -130,7 +132,7 @@
       <dependency>
         <groupId>org.springframework.vault</groupId>
         <artifactId>spring-vault-core</artifactId>
-        <version>2.3.2</version>
+        <version>spring-vault-core.version</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,11 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>org.springframework.vault</groupId>
+        <artifactId>spring-vault-core</artifactId>
+        <version>2.3.2</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>${protobuf.version}</version>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -22,14 +22,13 @@
   </modules>
 
   <dependencies>
-	<dependency>
-	    <groupId>org.springframework.vault</groupId>
-	    <artifactId>spring-vault-core</artifactId>
-	    <version>2.3.2</version>
-	</dependency>
     <dependency>
-      <!-- The cloud bootstrap starter is needed due to a breaking change implemented in Spring Cloud 2020.0.0 which turns off
-	  the Bootstrap context (used throughout the services for vault config) by default -->
+      <groupId>org.springframework.vault</groupId>
+      <artifactId>spring-vault-core</artifactId>
+    </dependency>
+    <dependency>
+      <!-- The cloud bootstrap starter is needed due to a breaking change implemented in Spring Cloud 2020.0.0 which turns off the Bootstrap 
+        context (used throughout the services for vault config) by default -->
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-bootstrap</artifactId>
     </dependency>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -22,15 +22,26 @@
   </modules>
 
   <dependencies>
-	 <!-- The cloud bootstrap starter is needed due to a breaking change implemented in Spring Cloud 2020.0.0 which turns off
-	  the Bootstrap context (used throughout the services for vault config) by default -->
+	<dependency>
+	    <groupId>org.springframework.vault</groupId>
+	    <artifactId>spring-vault-core</artifactId>
+	    <version>2.3.2</version>
+	</dependency>
     <dependency>
+      <!-- The cloud bootstrap starter is needed due to a breaking change implemented in Spring Cloud 2020.0.0 which turns off
+	  the Bootstrap context (used throughout the services for vault config) by default -->
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-bootstrap</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-vault-config</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.vault</groupId>
+          <artifactId>spring-vault-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.opencwa</groupId>


### PR DESCRIPTION
Since the wrong dependency to spring-vault-core 2.3.0 is defined in the spring-cloud-dependencies pom, we need to explicitly define the dependency to override the wrong version number.

[Exclusions aren't possible with Maven import scope](https://developer.jboss.org/docs/DOC-15811), which would be preferable:
> The import scope can be used to include dependency management information from a remote POM into the current project. One of the limitations of this is that it does not allow additional excludes to be defined for a multi module project.

Likewise, there is a confirmation from the [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-customize-dependency-versions-with-maven):
> If you have added spring-boot-dependencies in your own dependencyManagement section with <scope>import</scope> you have to redefine the artifact yourself [...].