### PR TITLE
Obvious fix as suggested in the warning message itself

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,11 @@
             <compilerArgs>
               <arg>-Xlint:all</arg>
             </compilerArgs>
+            <!-- Missing parameter metadata for FederationBatchSourceSystem(String, int),
+            which declares implicit or synthetic parameters. Automatic resolution of generic type information
+            for method parameters may yield incorrect results if multiple parameters have the same erasure.
+            To solve this, compile your code with the '-parameters' flag. -->
+            <parameters>true</parameters>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
I tried various other things and researched the topic, but this seems the easiest fix.

https://stackoverflow.com/questions/64699000/javabeanexecutable-hv000254-missing-parameter-metadata-for-java-enum