### PR TITLE
fix: use hex decoding in config because pepper is prob. a hexadecimal…

### DIFF
--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/config/SubmissionServiceConfig.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/config/SubmissionServiceConfig.java
@@ -1,16 +1,13 @@
-
-
 package app.coronawarn.server.services.submission.config;
 
 import app.coronawarn.server.common.persistence.domain.config.TekFieldDerivations;
 import java.io.File;
-import java.io.UnsupportedEncodingException;
-import java.util.Base64;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import org.bouncycastle.util.encoders.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -106,7 +103,7 @@ public class SubmissionServiceConfig {
   }
 
   public byte[] getRandomCheckinsPaddingPepperAsByteArray() {
-    return Base64.getDecoder().decode(randomCheckinsPaddingPepper.getBytes());
+    return Hex.decode(randomCheckinsPaddingPepper.getBytes());
   }
 
   public void setRandomCheckinsPaddingPepper(String randomCheckinsPaddingPepper) {

--- a/services/submission/src/test/resources/application.yaml
+++ b/services/submission/src/test/resources/application.yaml
@@ -25,7 +25,7 @@ services:
     retention-days: 14
     random-key-padding-multiplier: 10
     random-checkins-padding-multiplier: 1
-    random-checkins-padding-pepper: 73TZ2xq0rHDDeOXqVpSugQ==
+    random-checkins-padding-pepper: 0efbb3d683b713857750eec4b042ca1a7c50b5e4
     connection-pool-size: 200
     maximum-request-size: 100KB
     max-rolling-period: 144


### PR DESCRIPTION
- adding hex decoding for the pepper because it is prob. a hexadecimal string (need to check vault after the CR is done)