### PR TITLE
Sort TraceTimeIntervalWarnings via TraceLocationIDs…

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/structure/file/TemporaryExposureKeyExportFile.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/structure/file/TemporaryExposureKeyExportFile.java
@@ -11,7 +11,7 @@ import app.coronawarn.server.services.distribution.config.DistributionServiceCon
 import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -21,13 +21,13 @@ import java.util.stream.Collectors;
  */
 public class TemporaryExposureKeyExportFile extends FileOnDiskWithChecksum {
 
-  private final Collection<TemporaryExposureKey> temporaryExposureKeys;
+  private final List<TemporaryExposureKey> temporaryExposureKeys;
   private final String region;
   private final long startTimestamp;
   private final long endTimestamp;
   private final DistributionServiceConfig distributionServiceConfig;
 
-  private TemporaryExposureKeyExportFile(Collection<TemporaryExposureKey> temporaryExposureKeys, String region,
+  private TemporaryExposureKeyExportFile(List<TemporaryExposureKey> temporaryExposureKeys, String region,
       long startTimestamp, long endTimestamp, DistributionServiceConfig distributionServiceConfig) {
     super(distributionServiceConfig.getTekExport().getFileName(), new byte[0]);
     this.region = region;
@@ -55,7 +55,7 @@ public class TemporaryExposureKeyExportFile extends FileOnDiskWithChecksum {
    * @return A new {@link TemporaryExposureKeyExportFile}.
    */
   public static TemporaryExposureKeyExportFile fromTemporaryExposureKeys(
-      Collection<TemporaryExposureKey> temporaryExposureKeys, String region, long startTimestamp, long endTimestamp,
+      List<TemporaryExposureKey> temporaryExposureKeys, String region, long startTimestamp, long endTimestamp,
       DistributionServiceConfig distributionServiceConfig) {
     return new TemporaryExposureKeyExportFile(temporaryExposureKeys, region, startTimestamp, endTimestamp,
         distributionServiceConfig);
@@ -74,7 +74,7 @@ public class TemporaryExposureKeyExportFile extends FileOnDiskWithChecksum {
    * @param distributionServiceConfig The distribution service configuration {@link DistributionServiceConfig}
    * @return A new {@link TemporaryExposureKeyExportFile}.
    */
-  public static TemporaryExposureKeyExportFile fromDiagnosisKeys(Collection<DiagnosisKey> diagnosisKeys, String region,
+  public static TemporaryExposureKeyExportFile fromDiagnosisKeys(List<DiagnosisKey> diagnosisKeys, String region,
       long startTimestamp, long endTimestamp, DistributionServiceConfig distributionServiceConfig) {
     return new TemporaryExposureKeyExportFile(getTemporaryExposureKeysFromDiagnosisKeys(diagnosisKeys), region,
         startTimestamp, endTimestamp, distributionServiceConfig);
@@ -111,8 +111,8 @@ public class TemporaryExposureKeyExportFile extends FileOnDiskWithChecksum {
         .toByteArray();
   }
 
-  private static Set<TemporaryExposureKey> getTemporaryExposureKeysFromDiagnosisKeys(
-      Collection<DiagnosisKey> diagnosisKeys) {
+  private static List<TemporaryExposureKey> getTemporaryExposureKeysFromDiagnosisKeys(
+      List<DiagnosisKey> diagnosisKeys) {
     return diagnosisKeys.stream().map(diagnosisKey -> TemporaryExposureKey.newBuilder()
         .setKeyData(ByteString.copyFrom(diagnosisKey.getKeyData()))
         .setTransmissionRiskLevel(diagnosisKey.getTransmissionRiskLevel())
@@ -121,7 +121,7 @@ public class TemporaryExposureKeyExportFile extends FileOnDiskWithChecksum {
         .setReportType(diagnosisKey.getReportType())
         .setDaysSinceOnsetOfSymptoms(diagnosisKey.getDaysSinceOnsetOfSymptoms())
         .build())
-        .collect(Collectors.toSet());
+        .collect(Collectors.toList());
   }
 
   private byte[] getHeaderBytes() {

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/file/TraceTimeIntervalWarningExportFile.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/file/TraceTimeIntervalWarningExportFile.java
@@ -6,24 +6,25 @@ import app.coronawarn.server.services.distribution.assembly.structure.file.FileO
 import app.coronawarn.server.services.distribution.assembly.structure.util.ImmutableStack;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import com.google.protobuf.ByteString;
-import java.util.Collection;
-import java.util.Set;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Collectors;
 
 /**
  * A {@link app.coronawarn.server.services.distribution.assembly.structure.file.File} containing a
  * list of {@link app.coronawarn.server.common.protocols.internal.pt.TraceTimeIntervalWarning}
- * serliazed protos.
+ * serialized protos.
  */
 public class TraceTimeIntervalWarningExportFile extends FileOnDiskWithChecksum {
 
-  private final Set<app.coronawarn.server.common.protocols.internal.pt.TraceTimeIntervalWarning>
+  private final List<app.coronawarn.server.common.protocols.internal.pt.TraceTimeIntervalWarning>
                 traceTimeIntervalWarnings;
   private final String region;
   private final int intervalNumber;
 
   TraceTimeIntervalWarningExportFile(
-      Set<app.coronawarn.server.common.protocols.internal.pt.TraceTimeIntervalWarning> traceTimeIntervalWarnings,
+      List<app.coronawarn.server.common.protocols.internal.pt.TraceTimeIntervalWarning> traceTimeIntervalWarnings,
       String region, int intervalNumber, DistributionServiceConfig distributionServiceConfig) {
     super(distributionServiceConfig.getTekExport().getFileName(), new byte[0]);
 
@@ -42,7 +43,7 @@ public class TraceTimeIntervalWarningExportFile extends FileOnDiskWithChecksum {
    * Creates a binary export file by converting the given warnings to their proto structures.
    */
   public static TraceTimeIntervalWarningExportFile fromTraceTimeIntervalWarnings(
-      Collection<TraceTimeIntervalWarning> traceTimeIntervalWarnings, String country,
+      List<TraceTimeIntervalWarning> traceTimeIntervalWarnings, String country,
       int intervalNumber, DistributionServiceConfig distributionServiceConfig) {
     return new TraceTimeIntervalWarningExportFile(
         getTraceIntervalWarningsFromTraceIntervalWarnings(traceTimeIntervalWarnings), country,
@@ -55,16 +56,18 @@ public class TraceTimeIntervalWarningExportFile extends FileOnDiskWithChecksum {
         .toByteArray();
   }
 
-  private static Set<app.coronawarn.server.common.protocols.internal.pt.TraceTimeIntervalWarning>
+  private static List<app.coronawarn.server.common.protocols.internal.pt.TraceTimeIntervalWarning>
       getTraceIntervalWarningsFromTraceIntervalWarnings(
-      Collection<TraceTimeIntervalWarning> traceTimeIntervalWarnings) {
+      List<TraceTimeIntervalWarning> traceTimeIntervalWarnings) {
 
-    return traceTimeIntervalWarnings.stream().map(
-        intervalWarning -> app.coronawarn.server.common.protocols.internal.pt.TraceTimeIntervalWarning
+    return traceTimeIntervalWarnings.stream()
+        .sorted((o1, o2) -> Arrays.compare(o1.getTraceLocationId(), o2.getTraceLocationId()))
+        .map(
+          intervalWarning -> app.coronawarn.server.common.protocols.internal.pt.TraceTimeIntervalWarning
             .newBuilder()
             .setLocationIdHash(ByteString.copyFrom(intervalWarning.getTraceLocationId()))
             .setStartIntervalNumber(intervalWarning.getStartIntervalNumber())
             .setTransmissionRiskLevel(intervalWarning.getTransmissionRiskLevel()).build())
-        .collect(Collectors.toSet());
+        .collect(Collectors.toList());
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/file/TraceTimeIntervalWarningExportFile.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/file/TraceTimeIntervalWarningExportFile.java
@@ -61,7 +61,7 @@ public class TraceTimeIntervalWarningExportFile extends FileOnDiskWithChecksum {
       List<TraceTimeIntervalWarning> traceTimeIntervalWarnings) {
 
     return traceTimeIntervalWarnings.stream()
-        .sorted((o1, o2) -> Arrays.compare(o1.getTraceLocationId(), o2.getTraceLocationId()))
+        .sorted(Comparator.comparing(TraceTimeIntervalWarning::getId))
         .map(
           intervalWarning -> app.coronawarn.server.common.protocols.internal.pt.TraceTimeIntervalWarning
             .newBuilder()

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/structure/file/TemporaryExposureKeyExportFileTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/structure/file/TemporaryExposureKeyExportFileTest.java
@@ -14,7 +14,7 @@ import app.coronawarn.server.services.distribution.config.DistributionServiceCon
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Set;
+import java.util.List;
 import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,7 +75,7 @@ class TemporaryExposureKeyExportFileTest {
 
   private TemporaryExposureKeyExportFile createTemporaryExposureKeyExportFile() {
     return TemporaryExposureKeyExportFile.fromDiagnosisKeys(
-        Set.of(
+        List.of(
             buildDiagnosisKeyForSubmissionTimestamp(1)
         ),
         "DE", 0, 10, distributionServiceConfig

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/common/Helpers.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/common/Helpers.java
@@ -214,7 +214,12 @@ public class Helpers {
     final byte[] guid = UUID.randomUUID().toString().getBytes();
     final int transmissionRiskLevel = 5;
     return new TraceTimeIntervalWarning(guid, startIntervalNumber, endIntervalNumber,
-        transmissionRiskLevel, submissionHourSinceEpoch);
+        transmissionRiskLevel, submissionHourSinceEpoch){
+      @Override
+      public Long getId() {
+        return Long.valueOf(Arrays.hashCode(guid));
+      }
+    };
   }
 
   public static List<TraceTimeIntervalWarning> buildTraceTimeIntervalWarning(


### PR DESCRIPTION
… as this is unambiguous and guaranteed to be unique

Good catch from Pit, related to https://github.com/corona-warn-app/cwa-server/pull/1307

_NOTE:_ While I edited this code to resemble TEKs (https://github.com/corona-warn-app/cwa-server/blob/d398d0d4212ab959ac4e686f20b2d934d237266c/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/diagnosiskeys/structure/file/TemporaryExposureKeyExportFile.java#L40), I noticed some problems there also: Either we need a Set in between to remove duplicates, than we need the same for TWPs, or we don't...