### PR TITLE
Revert "Add "cwa-empty-pkg" header to all files"

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
@@ -125,12 +125,6 @@ public class ObjectStoreAccess {
       headers.put(HeaderKey.CWA_HASH, file.getChecksum());
     }
 
-    if (file.getFile().toFile().length() > 0) {
-      headers.put(HeaderKey.CWA_EMPTY_PKG, "0");
-    } else {
-      headers.put(HeaderKey.CWA_EMPTY_PKG, "1");
-    }
-
     headers.put(HeaderKey.CONTENT_TYPE, file.getContentType());
 
     return headers;

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClient.java
@@ -63,7 +63,6 @@ public interface ObjectStoreClient {
     CACHE_CONTROL("Cache-Control"),
     AMZ_ACL("x-amz-acl"),
     CWA_HASH("cwa-hash"),
-    CWA_EMPTY_PKG("cwa-empty-pkg"),
     /**
      * To control which content type is sent, when objects are retrieved from the object store.
      */

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -149,14 +148,11 @@ public class S3ClientWrapper implements ObjectStoreClient {
     if (headers.containsKey(HeaderKey.CACHE_CONTROL)) {
       requestBuilder.cacheControl(headers.get(HeaderKey.CACHE_CONTROL));
     }
+    if (headers.containsKey(HeaderKey.CWA_HASH)) {
+      requestBuilder.metadata(Map.of(HeaderKey.CWA_HASH.withMetaPrefix(), headers.get(HeaderKey.CWA_HASH)));
+    }
     if (headers.containsKey(HeaderKey.CONTENT_TYPE)) {
       requestBuilder.contentType(headers.get(HeaderKey.CONTENT_TYPE));
-    }
-    Map<String, String> metadataHeaders = Set.of(HeaderKey.CWA_HASH, HeaderKey.CWA_EMPTY_PKG).stream()
-        .filter(headers::containsKey)
-        .collect(Collectors.toMap(HeaderKey::withMetaPrefix, headers::get));
-    if (!metadataHeaders.isEmpty()) {
-      requestBuilder.metadata(metadataHeaders);
     }
 
     RequestBody bodyFile = RequestBody.fromFile(filePath);

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccessUnitTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccessUnitTest.java
@@ -43,10 +43,8 @@ class ObjectStoreAccessUnitTest {
   private final DistributionServiceConfig distributionServiceConfig;
   private final String expBucketName;
   private LocalFile testLocalFile;
-  private LocalFile testLocalFileEmpty;
   private ObjectStoreAccess objectStoreAccess;
   private Path expPath;
-  private Path expPathEmpty;
 
   @MockBean
   private ObjectStoreClient objectStoreClient;
@@ -62,31 +60,15 @@ class ObjectStoreAccessUnitTest {
     when(objectStoreClient.bucketExists(any())).thenReturn(true);
     this.objectStoreAccess = new ObjectStoreAccess(distributionServiceConfig, objectStoreClient);
     this.testLocalFile = setUpLocalFileMock();
-    this.testLocalFileEmpty = setUpLocalFileMockEmpty();
   }
 
   private LocalFile setUpLocalFileMock() {
     var testLocalFile = mock(LocalFile.class);
     expPath = mock(Path.class);
-    var expFile = mock(File.class);
-    when(expPath.toFile()).thenReturn(expFile);
-    when(expFile.length()).thenReturn(1L);
 
     when(testLocalFile.getS3Key()).thenReturn(EXP_S3_KEY);
     when(testLocalFile.getFile()).thenReturn(expPath);
-
-    return testLocalFile;
-  }
-
-  private LocalFile setUpLocalFileMockEmpty() {
-    var testLocalFile = mock(LocalFile.class);
-    expPathEmpty = mock(Path.class);
-    var expFile = mock(File.class);
-    when(expPathEmpty.toFile()).thenReturn(expFile);
-    when(expFile.length()).thenReturn(0L);
-
-    when(testLocalFile.getS3Key()).thenReturn(EXP_S3_KEY);
-    when(testLocalFile.getFile()).thenReturn(expPathEmpty);
+    when(expPath.toFile()).thenReturn(mock(File.class));
 
     return testLocalFile;
   }
@@ -136,32 +118,6 @@ class ObjectStoreAccessUnitTest {
 
     verify(objectStoreClient, atLeastOnce())
         .putObject(eq(expBucketName), eq(EXP_S3_KEY), eq(expPath), headers.capture());
-    assertThat(headers.getValue()).contains(expHeader);
-  }
-
-  @Test
-  void putObjectSetsCwaEmptyPkgHeaderForNonEmptyFiles() {
-    ArgumentCaptor<Map<HeaderKey, String>> headers = ArgumentCaptor.forClass(Map.class);
-    var expMaxAge = 1337;
-    var expHeader = entry(HeaderKey.CWA_EMPTY_PKG, "0");
-
-    objectStoreAccess.putObject(testLocalFile, expMaxAge);
-
-    verify(objectStoreClient, atLeastOnce())
-        .putObject(eq(expBucketName), eq(EXP_S3_KEY), eq(expPath), headers.capture());
-    assertThat(headers.getValue()).contains(expHeader);
-  }
-
-  @Test
-  void putObjectSetsCwaEmptyPkgHeaderForEmptyFiles() {
-    ArgumentCaptor<Map<HeaderKey, String>> headers = ArgumentCaptor.forClass(Map.class);
-    var expMaxAge = 1337;
-    var expHeader = entry(HeaderKey.CWA_EMPTY_PKG, "1");
-
-    objectStoreAccess.putObject(testLocalFileEmpty, expMaxAge);
-
-    verify(objectStoreClient, atLeastOnce())
-        .putObject(eq(expBucketName), eq(EXP_S3_KEY), eq(expPathEmpty), headers.capture());
     assertThat(headers.getValue()).contains(expHeader);
   }
 


### PR DESCRIPTION
Reverts corona-warn-app/cwa-server#1310

Clients are now using the `Content-Length` header instead (@mlenkeit) 