### PR TITLE
Fix checkin interval checks

### DIFF
--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/checkins/EventCheckinDataValidator.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/checkins/EventCheckinDataValidator.java
@@ -39,8 +39,8 @@ public class EventCheckinDataValidator {
   boolean verifyEndIntervalNumber(CheckIn checkin, ConstraintValidatorContext validatorContext) {
     int startIntervalNumber = checkin.getStartIntervalNumber();
     int endIntervalNumber = checkin.getEndIntervalNumber();
-    if (endIntervalNumber <= startIntervalNumber) {
-      addViolation(validatorContext, "Checkin endIntervalNumber must be greater than startIntervalNumber");
+    if (endIntervalNumber < startIntervalNumber) {
+      addViolation(validatorContext, "Checkin endIntervalNumber must be greater than or equal to startIntervalNumber");
       return false;
     }
     return true;

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/SubmissionControllerTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/SubmissionControllerTest.java
@@ -462,21 +462,9 @@ class SubmissionControllerTest {
   }
 
   @Test
-  void testInvalidCheckinTime() {
-    final List<CheckIn> invalidCheckinData = List.of(
-        CheckIn.newBuilder().setTransmissionRiskLevel(2).setStartIntervalNumber(0).setEndIntervalNumber(1).build(),
-        CheckIn.newBuilder().setTransmissionRiskLevel(2).setStartIntervalNumber(0).setEndIntervalNumber(1).build());
-
-    final ResponseEntity<Void> actResponse = executor.executePost(buildPayloadWithCheckinData(invalidCheckinData));
-    assertThat(actResponse.getStatusCode()).isEqualTo(BAD_REQUEST);
-    assertTraceWarningsHaveBeenSaved(0);
-  }
-
-  @Test
   void testInvalidCheckOutTime() {
     final List<CheckIn> invalidCheckinData = List.of(
-        CheckIn.newBuilder().setTransmissionRiskLevel(2).setStartIntervalNumber(4).setEndIntervalNumber(3).build(),
-        CheckIn.newBuilder().setTransmissionRiskLevel(2).setStartIntervalNumber(2).setEndIntervalNumber(2).build());
+        CheckIn.newBuilder().setTransmissionRiskLevel(2).setStartIntervalNumber(4).setEndIntervalNumber(3).build());
 
     final ResponseEntity<Void> actResponse = executor.executePost(buildPayloadWithCheckinData(invalidCheckinData));
     assertThat(actResponse.getStatusCode()).isEqualTo(BAD_REQUEST);
@@ -528,6 +516,14 @@ class SubmissionControllerTest {
     final long eventCheckinInThePast = LocalDateTime.ofInstant(Instant.now(), UTC).minusDays(10).toEpochSecond(UTC);
 
     final List<CheckIn> validCheckinData = List.of(
+        CheckIn.newBuilder().setTransmissionRiskLevel(3)
+            .setStartIntervalNumber(TEN_MINUTE_INTERVAL_DERIVATION.apply(eventCheckinInThePast))
+            .setEndIntervalNumber(TEN_MINUTE_INTERVAL_DERIVATION.apply(eventCheckinInThePast))
+            .setLocationId(EventCheckinDataValidatorTest.CORRECT_LOCATION_ID).build(),
+        CheckIn.newBuilder().setTransmissionRiskLevel(3)
+            .setStartIntervalNumber(TEN_MINUTE_INTERVAL_DERIVATION.apply(eventCheckinInThePast))
+            .setEndIntervalNumber(TEN_MINUTE_INTERVAL_DERIVATION.apply(eventCheckinInThePast) + 1)
+            .setLocationId(EventCheckinDataValidatorTest.CORRECT_LOCATION_ID).build(),
         CheckIn.newBuilder().setTransmissionRiskLevel(3)
             .setStartIntervalNumber(TEN_MINUTE_INTERVAL_DERIVATION.apply(eventCheckinInThePast))
             .setEndIntervalNumber(TEN_MINUTE_INTERVAL_DERIVATION.apply(eventCheckinInThePast) + 10)


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Make sure `mvn -P integration-tests clean verify` runs for the whole project and, if you touched any code for a service in the `services` folder, ensure it can be run with `spring-boot:run`

## Description
- Allow `endIntervalNumber` to be greater than or equal to `startIntervalNumber`
- Fixes seemingly randomly failing SubmissionControllerTest.testCheckinDataIsFilteredForFutureEvents
  - The test was always failing when run at XX:X9 o'clock, because the 10-minute interval truncation would make the start and end time interval equal for this specific test at those specific times (difference between start and end was 9 minutes - after truncation, start and end are falling into the same 10-minute interval when run at XX:X9)
