### PR TITLE
Config Updates for PT

### DIFF
--- a/services/distribution/src/main/resources/main-config/v2/presence-tracing-parameters.yaml
+++ b/services/distribution/src/main/resources/main-config/v2/presence-tracing-parameters.yaml
@@ -44,7 +44,7 @@ risk-calculation-parameters:
       normalized-time-range:
         min: 10
         min-exclusive: false
-        max: 9999
+        max: 999999
         max-exclusive: false
       risk-level: 2 # 2 = High
   normalized-time-per-day-to-risk-level-mapping:
@@ -59,7 +59,7 @@ risk-calculation-parameters:
       normalized-time-range:
         min: 10
         min-exclusive: false
-        max: 9999
+        max: 999999
         max-exclusive: false
       risk-level: 2 # 2 = High
 
@@ -84,7 +84,7 @@ submission-parameters:
       minutes-range:
         min: 30
         min-exclusive: true
-        max: 9999
+        max: 999999
         max-exclusive: false
       slope: 0
       intercept: 30

--- a/services/distribution/src/main/resources/main-config/v2/presence-tracing-parameters.yaml
+++ b/services/distribution/src/main/resources/main-config/v2/presence-tracing-parameters.yaml
@@ -111,15 +111,6 @@ plausible-deniability-parameters:
 
 qr-code-descriptors:
   -
-    regex-pattern: https://e\.coronawarn\.app/c(\d+)/(.+)
-    # validation rule for versionGroupIndex:
-    #   * >= 0
-    version-group-index: 0
-    # validation rule for encodedPayloadGroupIndex:
-    #   * >= 0
-    encoded-payload-group-index: 1
-    payload-encoding: 0 # BASE32
-  -
     regex-pattern: https://e\.coronawarn\.app/?\?v=(\d+)\#(.+)
     # validation rule for versionGroupIndex:
     #   * >= 0


### PR DESCRIPTION
This PR makes two small changes to the PT config:
- it drops base32 QR codes as they are currently not created by the client
- it increases the upper bound of check-in duration intervals to account for long check-ins