### PR TITLE
Add Trace Time Interval Warning Retention Policy

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/TraceTimeIntervalWarningRepository.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/TraceTimeIntervalWarningRepository.java
@@ -21,4 +21,22 @@ public interface TraceTimeIntervalWarningRepository
       @Param("start_interval_number") Integer startIntervalNumber, @Param("period") Integer period,
       @Param("transmission_risk_level") Integer transmissionRiskLevel,
       @Param("submission_timestamp") Integer submissionTimestamp);
+
+  /**
+   * Counts all entries that have a submission timestamp older than the specified one.
+   *
+   * @param submissionTimestamp The submission timestamp up to which entries will be expired.
+   * @return The number of expired trace time warnings.
+   */
+  @Query("SELECT COUNT(*) FROM trace_time_interval_warning WHERE submission_timestamp<:threshold")
+  int countOlderThan(@Param("threshold") long submissionTimestamp);
+
+  /**
+   * Deletes all entries that have a submission timestamp older than the specified one.
+   *
+   * @param submissionTimestamp The submission timestamp up to which entries will be deleted.
+   */
+  @Modifying
+  @Query("DELETE FROM trace_time_interval_warning WHERE submission_timestamp<:threshold")
+  void deleteOlderThan(@Param("threshold") long submissionTimestamp);
 }

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/TraceTimeIntervalWarningService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/TraceTimeIntervalWarningService.java
@@ -1,14 +1,17 @@
 package app.coronawarn.server.common.persistence.service;
 
+import static app.coronawarn.server.common.persistence.domain.validation.ValidSubmissionTimestampValidator.SECONDS_PER_HOUR;
+import static java.time.ZoneOffset.UTC;
+
 import app.coronawarn.server.common.persistence.domain.TraceTimeIntervalWarning;
 import app.coronawarn.server.common.persistence.repository.TraceTimeIntervalWarningRepository;
-import app.coronawarn.server.common.persistence.service.utils.checkins.CheckinsDateSpecification;
 import app.coronawarn.server.common.persistence.service.utils.checkins.FakeCheckinsGenerator;
 import app.coronawarn.server.common.protocols.internal.pt.CheckIn;
 import com.google.protobuf.ByteString;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -28,15 +31,16 @@ public class TraceTimeIntervalWarningService {
   private static final Logger logger =
       LoggerFactory.getLogger(TraceTimeIntervalWarningService.class);
 
-
   private final TraceTimeIntervalWarningRepository traceTimeIntervalWarningRepo;
   private final FakeCheckinsGenerator fakeCheckinsGenerator;
   private final MessageDigest hashAlgorithm;
 
   /**
    * Constructs the service instance.
+   *
    * @param traceTimeIntervalWarningRepo Repository for {@link TraceTimeIntervalWarning} entities.
-   * @param fakeCheckinsGenerator Generator of fake data that gets stored side by side with the real checkin data.
+   * @param fakeCheckinsGenerator        Generator of fake data that gets stored side by side with the real checkin
+   *                                     data.
    * @throws NoSuchAlgorithmException In case the MessageDigest used in hashing can not be instantiated.
    */
   public TraceTimeIntervalWarningService(
@@ -48,16 +52,17 @@ public class TraceTimeIntervalWarningService {
   }
 
   /**
-   * Store the given checkin data as {@link TraceTimeIntervalWarning} entities. Returns the number
-   * of inserted entities, which is useful for the case where there might be conflicts with the
-   * table constraints during the db save operations.
+   * Store the given checkin data as {@link TraceTimeIntervalWarning} entities. Returns the number of inserted entities,
+   * which is useful for the case where there might be conflicts with the table constraints during the db save
+   * operations.
    */
   @Transactional
-  public int saveCheckins(List<CheckIn> checkins) {
-    return saveCheckins(checkins, this::hashLocationId);
+  public int saveCheckins(List<CheckIn> checkins, int submissionTimestamp) {
+    return saveCheckins(checkins, this::hashLocationId, submissionTimestamp);
   }
 
-  private int saveCheckins(List<CheckIn> checkins, Function<ByteString, byte[]> idHashGenerator) {
+  private int saveCheckins(List<CheckIn> checkins, Function<ByteString, byte[]> idHashGenerator,
+      int submissionTimestamp) {
     int numberOfInsertedTraceWarnings = 0;
 
     for (CheckIn checkin : checkins) {
@@ -66,8 +71,7 @@ public class TraceTimeIntervalWarningService {
           .saveDoNothingOnConflict(hashId, checkin.getStartIntervalNumber(),
               checkin.getEndIntervalNumber() - checkin.getStartIntervalNumber(),
               checkin.getTransmissionRiskLevel(),
-              CheckinsDateSpecification.HOUR_SINCE_EPOCH_DERIVATION
-                  .apply(Instant.now().getEpochSecond()));
+              submissionTimestamp);
 
       if (traceWarningInsertedSuccessfully) {
         numberOfInsertedTraceWarnings++;
@@ -78,7 +82,7 @@ public class TraceTimeIntervalWarningService {
     if (conflictingTraceWarnings > 0) {
       logger.warn(
           "{} out of {} TraceTimeIntervalWarnings conflicted with existing "
-          + "database entries or had errors while storing "
+              + "database entries or had errors while storing "
               + "and were ignored.",
           conflictingTraceWarnings, checkins.size());
     }
@@ -87,18 +91,17 @@ public class TraceTimeIntervalWarningService {
   }
 
   /**
-   * For each checkin in the given list, generate other fake checkin data based on the passed in
-   * number and store everything as {@link TraceTimeIntervalWarning} entities. Returns the number of
-   * inserted entities which is useful for the case where there might be conflicts with the table
-   * constraints during the db save operations.
+   * For each checkin in the given list, generate other fake checkin data based on the passed in number and store
+   * everything as {@link TraceTimeIntervalWarning} entities. Returns the number of inserted entities which is useful
+   * for the case where there might be conflicts with the table constraints during the db save operations.
    */
   @Transactional
   public int saveCheckinsWithFakeData(List<CheckIn> originalCheckins, int numberOfFakesToCreate,
-      byte[] pepper) {
+      byte[] pepper, int submissionTimestamp) {
     List<CheckIn> allCheckins = new ArrayList<>(originalCheckins);
     allCheckins.addAll(fakeCheckinsGenerator.generateFakeCheckins(originalCheckins,
         numberOfFakesToCreate, pepper));
-    return saveCheckins(allCheckins, this::hashLocationId);
+    return saveCheckins(allCheckins, this::hashLocationId, submissionTimestamp);
   }
 
   /**
@@ -113,5 +116,28 @@ public class TraceTimeIntervalWarningService {
 
   private byte[] hashLocationId(ByteString locationId) {
     return hashAlgorithm.digest(locationId.toByteArray());
+  }
+
+  /**
+   * Deletes all trace time warning entries which have a submission timestamp that is older than the specified number
+   * of days.
+   *
+   * @param daysToRetain the number of days until which trace time warnings will be retained.
+   * @throws IllegalArgumentException if {@code daysToRetain} is negative.
+   */
+  @Transactional
+  public void applyRetentionPolicy(int daysToRetain) {
+    if (daysToRetain < 0) {
+      throw new IllegalArgumentException("Number of days to retain must be greater or equal to 0.");
+    }
+
+    long threshold = LocalDateTime
+        .ofInstant(Instant.now(), UTC)
+        .minusDays(daysToRetain)
+        .toEpochSecond(UTC) / SECONDS_PER_HOUR;
+    int numberOfDeletions = traceTimeIntervalWarningRepo.countOlderThan(threshold);
+    logger.info("Deleting {} trace time warning(s) with a submission timestamp older than {} day(s) ago.",
+        numberOfDeletions, daysToRetain);
+    traceTimeIntervalWarningRepo.deleteOlderThan(threshold);
   }
 }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/TraceTimeIntervalWarningServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/TraceTimeIntervalWarningServiceTest.java
@@ -1,27 +1,35 @@
 package app.coronawarn.server.common.persistence.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
 import app.coronawarn.server.common.persistence.domain.TraceTimeIntervalWarning;
 import app.coronawarn.server.common.persistence.repository.TraceTimeIntervalWarningRepository;
 import app.coronawarn.server.common.persistence.service.utils.checkins.CheckinsDateSpecification;
 import app.coronawarn.server.common.protocols.internal.pt.CheckIn;
 import com.google.protobuf.ByteString;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
-import org.testcontainers.shaded.org.bouncycastle.util.encoders.Hex;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.time.Instant;
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
+import org.testcontainers.shaded.org.bouncycastle.util.encoders.Hex;
 
 @DataJdbcTest
 class TraceTimeIntervalWarningServiceTest {
@@ -32,70 +40,35 @@ class TraceTimeIntervalWarningServiceTest {
   @Autowired
   TraceTimeIntervalWarningRepository traceWarningsRepository;
 
+  private int currentTimestamp;
+
   @BeforeEach
   public void setup() {
     traceWarningsRepository.deleteAll();
+    currentTimestamp = CheckinsDateSpecification.HOUR_SINCE_EPOCH_DERIVATION.apply(Instant.now().getEpochSecond());
   }
 
   @Test
   void testStorage() {
     List<CheckIn> checkins = getRandomTestData();
-    traceWarningsService.saveCheckins(checkins);
+    traceWarningsService.saveCheckins(checkins, currentTimestamp);
 
     List<TraceTimeIntervalWarning> actualTraceWarningsStored =
         StreamSupport.stream(traceWarningsRepository.findAll().spliterator(), false)
             .collect(Collectors.toList());
 
-    assertCheckinsAndWarningsAreEqual(new ArrayList<>(checkins), actualTraceWarningsStored);
+    assertCheckinsAndWarningsAreEqual(checkins, actualTraceWarningsStored);
   }
 
   @Test
   void testStorageWithRandomPadding() {
     List<CheckIn> checkins = getRandomTestData();
-    traceWarningsService.saveCheckinsWithFakeData(checkins, 2, randomHashPepper());
+    traceWarningsService.saveCheckinsWithFakeData(checkins, 2, randomHashPepper(), currentTimestamp);
 
     List<TraceTimeIntervalWarning> actualTraceWarningsStored =
         StreamSupport.stream(traceWarningsRepository.findAll().spliterator(), false)
             .collect(Collectors.toList());
-    assertTrue(actualTraceWarningsStored.size() == checkins.size() + checkins.size() * 2);
-  }
-
-  private List<CheckIn> getRandomTestData() {
-    List<CheckIn> checkins = List.of(
-        CheckIn.newBuilder().setStartIntervalNumber(0).setEndIntervalNumber(1)
-            .setTransmissionRiskLevel(1)
-            .setLocationId(ByteString.copyFromUtf8("uuid1"))
-            .build(),
-        CheckIn.newBuilder().setStartIntervalNumber(23).setEndIntervalNumber(30)
-            .setTransmissionRiskLevel(2)
-            .setLocationId(ByteString.copyFromUtf8("uuid1"))
-            .build(),
-        CheckIn.newBuilder().setStartIntervalNumber(40).setEndIntervalNumber(50)
-            .setTransmissionRiskLevel(3)
-            .setLocationId(ByteString.copyFromUtf8("uuid1"))
-            .build());
-    return checkins;
-  }
-
-  private void assertCheckinsAndWarningsAreEqual(List<CheckIn> checkins,
-      List<TraceTimeIntervalWarning> actualTraceWarningsStored) {
-
-    assertEquals(checkins.size(), actualTraceWarningsStored.size());
-
-    Collections.sort(checkins, Comparator.comparing(CheckIn::getTransmissionRiskLevel));
-    Collections.sort(actualTraceWarningsStored,
-        Comparator.comparing(TraceTimeIntervalWarning::getTransmissionRiskLevel));
-
-    for (int i = 0; i < checkins.size(); i++) {
-      CheckIn checkin = checkins.get(i);
-      TraceTimeIntervalWarning warning = actualTraceWarningsStored.get(i);
-      assertEquals(checkin.getTransmissionRiskLevel(),
-          warning.getTransmissionRiskLevel().intValue());
-      assertEquals(checkin.getStartIntervalNumber(), warning.getStartIntervalNumber().intValue());
-      assertEquals(checkin.getEndIntervalNumber() - checkin.getStartIntervalNumber(), warning.getPeriod().intValue());
-      assertArrayEquals(hashLocationId(checkin.getLocationId()),
-          warning.getTraceLocationId());
-    }
+    assertEquals(actualTraceWarningsStored.size(), checkins.size() + checkins.size() * 2);
   }
 
   @Test
@@ -115,7 +88,7 @@ class TraceTimeIntervalWarningServiceTest {
             CheckinsDateSpecification.HOUR_SINCE_EPOCH_DERIVATION
                 .apply(Instant.now().getEpochSecond()) - 10);
 
-    List<CheckIn> checkins = new ArrayList<>(List.of(
+    List<CheckIn> checkins = new java.util.ArrayList<>(List.of(
         CheckIn.newBuilder().setStartIntervalNumber(56).setEndIntervalNumber(66)
             .setTransmissionRiskLevel(3)
             .setLocationId(ByteString.copyFromUtf8("sorted-uuid2"))
@@ -128,8 +101,7 @@ class TraceTimeIntervalWarningServiceTest {
     // Reverse as we tempered with submission timestamp
     Collections.reverse(checkins);
 
-    List<TraceTimeIntervalWarning> checkinsFromDB = new ArrayList<>(
-        traceWarningsService.getTraceTimeIntervalWarnings());
+    var checkinsFromDB = traceWarningsService.getTraceTimeIntervalWarnings();
 
     assertCheckinsAndWarningsAreEqual(checkins, checkinsFromDB);
   }
@@ -149,11 +121,95 @@ class TraceTimeIntervalWarningServiceTest {
     assertEquals("0f37dac11d1b8118ea0b44303400faa5e3b876da9d758058b5ff7dc2e5da8230", s);
   }
 
+  @DisplayName("Assert a positive retention period is accepted.")
+  @ValueSource(ints = {0, 1, Integer.MAX_VALUE})
+  @ParameterizedTest
+  void testApplyRetentionPolicyForValidNumberOfDays(int daysToRetain) {
+    assertThatCode(() -> traceWarningsService.applyRetentionPolicy(daysToRetain))
+        .doesNotThrowAnyException();
+  }
+
+  @DisplayName("Assert a negative retention period is rejected.")
+  @ValueSource(ints = {Integer.MIN_VALUE, -1})
+  @ParameterizedTest
+  void testApplyRetentionPolicyForNegativeNumberOfDays(int daysToRetain) {
+    assertThat(catchThrowable(() -> traceWarningsService.applyRetentionPolicy(daysToRetain)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void testApplyRetentionPolicyForEmptyDb() {
+    traceWarningsService.applyRetentionPolicy(1);
+    var actKeys = traceWarningsService.getTraceTimeIntervalWarnings();
+    assertThat(actKeys).isEmpty();
+  }
+
+  @Test
+  void testApplyRetentionPolicyForNotApplicableEntries() {
+    var expKeys = getRandomTestData();
+
+    traceWarningsService.saveCheckins(expKeys, currentTimestamp);
+    traceWarningsService.applyRetentionPolicy(1);
+    var actKeys = traceWarningsService.getTraceTimeIntervalWarnings();
+
+    assertCheckinsAndWarningsAreEqual(expKeys, actKeys);
+  }
+
+  @Test
+  void testApplyRetentionPolicyForOneApplicableEntry() {
+    var keys = getRandomTestData();
+
+    traceWarningsService.saveCheckins(keys, currentTimestamp - (int) TimeUnit.DAYS.toHours(1) - 1);
+    traceWarningsService.applyRetentionPolicy(1);
+    var actKeys = traceWarningsService.getTraceTimeIntervalWarnings();
+
+    assertThat(actKeys).isEmpty();
+  }
+
+  private List<CheckIn> getRandomTestData() {
+    return List.of(
+        CheckIn.newBuilder().setStartIntervalNumber(0).setEndIntervalNumber(1)
+            .setTransmissionRiskLevel(1)
+            .setLocationId(ByteString.copyFromUtf8("uuid1"))
+            .build(),
+        CheckIn.newBuilder().setStartIntervalNumber(23).setEndIntervalNumber(30)
+            .setTransmissionRiskLevel(2)
+            .setLocationId(ByteString.copyFromUtf8("uuid1"))
+            .build(),
+        CheckIn.newBuilder().setStartIntervalNumber(40).setEndIntervalNumber(50)
+            .setTransmissionRiskLevel(3)
+            .setLocationId(ByteString.copyFromUtf8("uuid1"))
+            .build());
+  }
+
+  private void assertCheckinsAndWarningsAreEqual(Collection<CheckIn> checkins,
+      Collection<TraceTimeIntervalWarning> actualTraceWarningsStored) {
+
+    assertEquals(checkins.size(), actualTraceWarningsStored.size());
+
+    var sortedCheckins = checkins.stream()
+        .sorted(Comparator.comparing(CheckIn::getTransmissionRiskLevel))
+        .collect(Collectors.toList());
+    var sortedTraceTimeWarnings = actualTraceWarningsStored.stream()
+        .sorted(Comparator.comparing(TraceTimeIntervalWarning::getTransmissionRiskLevel))
+        .collect(Collectors.toList());
+
+    for (int i = 0; i < checkins.size(); i++) {
+      CheckIn checkin = sortedCheckins.get(i);
+      TraceTimeIntervalWarning warning = sortedTraceTimeWarnings.get(i);
+      assertEquals(checkin.getTransmissionRiskLevel(),
+          warning.getTransmissionRiskLevel().intValue());
+      assertEquals(checkin.getStartIntervalNumber(), warning.getStartIntervalNumber().intValue());
+      assertEquals(checkin.getEndIntervalNumber() - checkin.getStartIntervalNumber(), warning.getPeriod().intValue());
+      assertArrayEquals(hashLocationId(checkin.getLocationId()),
+          warning.getTraceLocationId());
+    }
+  }
 
   private byte[] hashLocationId(ByteString locationId) {
     try {
       return MessageDigest.getInstance("SHA-256").digest(locationId.toByteArray());
-    } catch (NoSuchAlgorithmException e) {
+    } catch (NoSuchAlgorithmException ignored) {
     }
     return new byte[0];
   }

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -42,7 +42,7 @@ The index will be regenerated whenever new export files are distributed to the o
 
 ## Data Retention
 
-The retention period is set to 14 days. Therefore, all keys whose _submission date_ is older than 14 days are removed from the system. This includes the database persistence layer, as well as files stored on the object store.
+The retention period is set to 14 days. Therefore, all diagnosis keys and trace time warnings whose _submission date_ is older than 14 days are removed from the system. This includes the database persistence layer, as well as files stored on the object store.
 The retention mechanism is enforced automatically by the Distribution Service upon each distribution run (multiple runs per day). The retention trigger by distribution will also be reflected within the keys pending upload to the
 federation gateway. This is especially important in scenarios where the upload service may not of run for some time or there are some failures to ensure invalid keys are not accidentally propagated.
 No manual trigger or action is required.
@@ -50,12 +50,15 @@ No manual trigger or action is required.
 Data is deleted by normal means. For PostgreSQL, the identified rows will be deleted by normal __DELETE__ calls to the database, and
 cleaned up when auto vacuuming is executed.
 
-When data deletion is executed on the object store, the object store is instructed to delete all
-files with the following prefix:
+When data deletion is executed on the object store, the object store is instructed to delete all files with the following prefixes:
 
-`version/v1/diagnosis-keys/country/<country_code>/<date>`
+`version/v1/diagnosis-keys/country/<country_code>/date/<date>`
 
-In which `<date>` stands for the ISO formatted date (e.g. `2012-06-05`), and is before the retention cutoff date (today - 14 days).
+- In which `<date>` stands for the ISO formatted date (e.g. `2012-06-05`), and is before the retention cutoff date (today - 14 days).
+
+`version/v1/twp/country/<country_code>/hour/<hour>`
+
+- In which `<hour>` stands for the hour since Unix epoch, and is before the retention cutoff date (today - 14 days).
 
 ## Spring Profiles
 
@@ -165,12 +168,15 @@ The same 14 days retention period (like the database) is also enforced on the S3
 run will execute the retention policy.
 
 When data deletion is executed on the object store, the object store is instructed to delete all files with the following
-prefix:
+prefixes:
 
-`version/v1/diagnosis-keys/country/DE/<date>`
+`version/v1/diagnosis-keys/country/<country_code>/date/<date>`
 
-In which `<date>` stands for the ISO formatted date (e.g. `2012-06-05`), and is before the retention cutoff date
-(today - 14 days).
+- In which `<date>` stands for the ISO formatted date (e.g. `2012-06-05`), and is before the retention cutoff date (today - 14 days).
+
+`version/v1/twp/country/<country_code>/hour/<hour>`
+
+- In which `<hour>` stands for the hour since Unix epoch, and is before the retention cutoff date (today - 14 days).
 
 ## Assembly Process
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/S3RetentionPolicy.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/S3RetentionPolicy.java
@@ -6,12 +6,16 @@ import app.coronawarn.server.services.distribution.config.DistributionServiceCon
 import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreOperationFailedException;
 import app.coronawarn.server.services.distribution.objectstore.client.S3Object;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -29,9 +33,11 @@ public class S3RetentionPolicy {
   private final String euPackageName;
 
   public static final String DATE_REGEX = ".*([0-9]{4}-[0-9]{2}-[0-9]{2}).*";
-  public static final String HOUR_REGEX = ".*(hour).*";
+  public static final String EPOCH_HOUR_REGEX = ".*([0-9]{6,7})";
+  public static final String HOUR_PATH_REGEX = ".*(hour).*";
   private final Pattern datePattern = Pattern.compile(DATE_REGEX);
-  private final Pattern hourPattern = Pattern.compile(HOUR_REGEX);
+  private final Pattern epochHourPattern = Pattern.compile(EPOCH_HOUR_REGEX);
+  private final Pattern hourPathPattern = Pattern.compile(HOUR_PATH_REGEX);
 
   private static final Logger logger = LoggerFactory
       .getLogger(S3RetentionPolicy.class);
@@ -39,9 +45,9 @@ public class S3RetentionPolicy {
   /**
    * Creates an {@link S3RetentionPolicy} instance with the specified parameters.
    *
-   * @param objectStoreAccess ObjectStoreAccess
+   * @param objectStoreAccess         ObjectStoreAccess
    * @param distributionServiceConfig config containing the API, origin Country and origin country
-   * @param failedOperationsCounter FailedObjectStoreOperationsCounter
+   * @param failedOperationsCounter   FailedObjectStoreOperationsCounter
    */
   public S3RetentionPolicy(ObjectStoreAccess objectStoreAccess, DistributionServiceConfig distributionServiceConfig,
       FailedObjectStoreOperationsCounter failedOperationsCounter) {
@@ -53,38 +59,60 @@ public class S3RetentionPolicy {
   }
 
   /**
-   * Deletes all diagnosis-key files from S3 that are older than retentionDays.
+   * Deletes all diagnosis-key day files from S3 that are older than retentionDays.
    *
    * @param retentionDays the number of days, that files should be retained on S3.
    */
-  public void applyRetentionPolicy(int retentionDays) {
+  public void applyDiagnosisKeyDayRetentionPolicy(int retentionDays) {
     Set<String> countries = Set.of(originCountry, euPackageName);
     countries.forEach(country -> {
-      List<S3Object> diagnosisKeysObjects = objectStoreAccess.getObjectsWithPrefix(getPrefix(country));
+      List<S3Object> diagnosisKeysObjects = objectStoreAccess.getObjectsWithPrefix(getDiagnosisKeyPrefix(country));
       final LocalDate cutOffDate = TimeUtils.getUtcDate().minusDays(retentionDays);
       diagnosisKeysObjects.stream()
-          .filter(diagnosisKeysObject -> isFilePathOlderThan(diagnosisKeysObject, cutOffDate))
-          .forEach(this::deleteDiagnosisKey);
+          .filter(diagnosisKeysObject -> isDiagnosisKeyFilePathOlderThan(diagnosisKeysObject, cutOffDate))
+          .forEach(this::deleteS3Object);
     });
   }
 
   /**
-   * Delete old hourly files based on retention policy.
+   * Deletes all diagnosis-key hour files from S3 that are older than retentionDays.
    *
    * @param retentionDays number of days back where hourly files should be deleted
    */
-  public void applyHourFileRetentionPolicy(long retentionDays) {
+  public void applyDiagnosisKeyHourRetentionPolicy(long retentionDays) {
     Set<String> countries = Set.of(originCountry, euPackageName);
     countries.forEach(country -> {
-      List<S3Object> diagnosisKeysObjects = objectStoreAccess.getObjectsWithPrefix(getPrefix(country));
+      List<S3Object> diagnosisKeysObjects = objectStoreAccess.getObjectsWithPrefix(getDiagnosisKeyPrefix(country));
       final LocalDate cutOffDate = TimeUtils.getUtcDate().minusDays(retentionDays - 1L);
       var deletableKeys = diagnosisKeysObjects.stream()
-          .filter(diagnosisKeysObject -> isFilePathOlderThan(diagnosisKeysObject, cutOffDate))
-          .filter(this::isFilePathOnHourFolder)
+          .filter(diagnosisKeysObject -> isDiagnosisKeyFilePathOlderThan(diagnosisKeysObject, cutOffDate))
+          .filter(this::isDiagnosisKeyFilePathOnHourFolder)
           .collect(Collectors.toList());
 
-      logger.info("Deleting {} files from hourly folders older than {}", deletableKeys.size(), cutOffDate.toString());
-      deletableKeys.forEach(this::deleteDiagnosisKey);
+      logger.info("Deleting {} diagnosis key files from hourly folders older than {}", deletableKeys.size(),
+          cutOffDate.toString());
+      deletableKeys.forEach(this::deleteS3Object);
+    });
+  }
+
+  /**
+   * Deletes all trace time warning hour files from S3 that are older than retentionDays.
+   *
+   * @param retentionDays number of days back where hourly files should be deleted
+   */
+  public void applyTraceTimeWarningHourRetentionPolicy(long retentionDays) {
+    Set<String> countries = Set.of(originCountry, euPackageName);
+    countries.forEach(country -> {
+      List<S3Object> traceTimeWarningsObjects = objectStoreAccess
+          .getObjectsWithPrefix(getTraceTimeWarningPrefix(country));
+      final LocalDateTime cutOffTime = TimeUtils.getCurrentUtcHour().minusDays(retentionDays);
+      final LocalDate cutOffDate = TimeUtils.getUtcDate().minusDays(retentionDays - 1L);
+      var deletableKeys = traceTimeWarningsObjects.stream()
+          .filter(traceTimeWarningsObject -> isTraceTimeWarningFilePathOlderThan(traceTimeWarningsObject, cutOffTime))
+          .collect(Collectors.toList());
+
+      logger.info("Deleting {} trace time warning files older than {}", deletableKeys.size(), cutOffDate.toString());
+      deletableKeys.forEach(this::deleteS3Object);
     });
   }
 
@@ -92,30 +120,49 @@ public class S3RetentionPolicy {
    * Java stream do not support checked exceptions within streams. This helper method rethrows them as unchecked
    * expressions, so they can be passed up to the Retention Policy.
    *
-   * @param diagnosisKey the  diagnosis key, that should be deleted.
+   * @param s3Object the S3 object, that should be deleted.
    */
-  public void deleteDiagnosisKey(S3Object diagnosisKey) {
+  public void deleteS3Object(S3Object s3Object) {
     try {
-      objectStoreAccess.deleteObjectsWithPrefix(diagnosisKey.getObjectName());
+      objectStoreAccess.deleteObjectsWithPrefix(s3Object.getObjectName());
     } catch (ObjectStoreOperationFailedException e) {
       failedObjectStoreOperationsCounter.incrementAndCheckThreshold(e);
     }
   }
 
 
-  private boolean isFilePathOnHourFolder(S3Object diagnosisKeysObject) {
-    Matcher matcher = hourPattern.matcher(diagnosisKeysObject.getObjectName());
+  private boolean isDiagnosisKeyFilePathOnHourFolder(S3Object s3Object) {
+    Matcher matcher = hourPathPattern.matcher(s3Object.getObjectName());
     return matcher.matches();
   }
 
-  private boolean isFilePathOlderThan(S3Object diagnosisKeysObject, LocalDate cutOffDate) {
-    Matcher matcher = datePattern.matcher(diagnosisKeysObject.getObjectName());
+  private boolean isDiagnosisKeyFilePathOlderThan(S3Object s3Object, LocalDate cutOffDate) {
+    Matcher matcher = datePattern.matcher(s3Object.getObjectName());
     return matcher.matches() && LocalDate.parse(matcher.group(1), DateTimeFormatter.ISO_LOCAL_DATE)
         .isBefore(cutOffDate);
   }
 
-  private String getPrefix(String country) {
+  private boolean isTraceTimeWarningFilePathOlderThan(S3Object s3Object, LocalDateTime cutOffTime) {
+    return Stream.of(s3Object)
+        .map(S3Object::getObjectName)
+        .map(epochHourPattern::matcher)
+        .filter(Matcher::matches)
+        .map(match -> match.group(1))
+        .map(Integer::parseInt)
+        .map(TimeUnit.HOURS::toSeconds)
+        .map(epochSeconds -> LocalDateTime.ofEpochSecond(epochSeconds, 0, ZoneOffset.UTC))
+        .map(packageHour -> packageHour.isBefore(cutOffTime))
+        .findFirst()
+        .orElse(false);
+  }
+
+  private String getDiagnosisKeyPrefix(String country) {
     return api.getVersionPath() + "/" + api.getVersionV1() + "/" + api.getDiagnosisKeysPath() + "/"
         + api.getCountryPath() + "/" + country + "/" + api.getDatePath() + "/";
+  }
+
+  private String getTraceTimeWarningPrefix(String country) {
+    return api.getVersionPath() + "/" + api.getVersionV1() + "/" + api.getTraceWarningsPath() + "/"
+        + api.getCountryPath() + "/" + country + "/" + api.getHourPath() + "/";
   }
 }

--- a/services/distribution/src/main/resources/application.yaml
+++ b/services/distribution/src/main/resources/application.yaml
@@ -18,7 +18,7 @@ services:
     output-file-name: index
     # The name of the distribution output file v2.
     output-file-name-v2: index-v2
-    # The number of days to retain diagnosis keys for both database persistency layer and files stored on the object store.
+    # The number of days to retain diagnosis keys and trace time warnings for both database persistency layer and files stored on the object store.
     retention-days: 14
     # The number of minutes that diagnosis keys must have been expired for (since the end of the rolling interval window) before they can be distributed.
     expiry-policy-minutes: 120

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/S3RetentionPolicyTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/S3RetentionPolicyTest.java
@@ -2,10 +2,10 @@
 
 package app.coronawarn.server.services.distribution.objectstore;
 
+import static app.coronawarn.server.services.distribution.assembly.structure.util.TimeUtils.getCurrentUtcHour;
 import static app.coronawarn.server.services.distribution.assembly.structure.util.TimeUtils.getUtcDate;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
-import static org.assertj.core.util.Lists.emptyList;
 import static org.assertj.core.util.Lists.list;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -21,11 +21,16 @@ import app.coronawarn.server.services.distribution.config.DistributionServiceCon
 import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreOperationFailedException;
 import app.coronawarn.server.services.distribution.objectstore.client.S3Object;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,51 +58,47 @@ class S3RetentionPolicyTest {
   @Autowired
   private DistributionServiceConfig distributionServiceConfig;
 
-  private List<String> generateHourFilesForDay(LocalDate day, String country) {
-    List<String> files = new ArrayList<>();
-    for (var i = 0; i <= 24; i++) {
-      files.add(generateHourFilename(day, country, Integer.toString(i)));
-    }
-    return files;
-  }
+  private LocalDateTime currentTime;
 
-  private List<S3Object> s3ObjectsFromFilenames(List<String> filenames) {
-    return filenames.stream().map(S3Object::new).collect(Collectors.toUnmodifiableList());
+  @BeforeEach
+  void setup() {
+    currentTime = getCurrentUtcHour();
   }
 
   @Test
-  void shouldDeleteHourFile() {
-    var toBeKept = generateHourFilesForDay(getUtcDate().minusDays(1), "DE");
-    var toBeDeleted = generateHourFilesForDay(getUtcDate().minusDays(2), "DE");
+  void shouldDeleteDiagnosisKeyHourFiles() {
+    var toBeKept = generateDiagnosisKeyHourFilesForDay(getUtcDate().minusDays(1), "DE");
+    var toBeDeleted = generateDiagnosisKeyHourFilesForDay(getUtcDate().minusDays(2), "DE");
 
     List<S3Object> mockResponse = this.s3ObjectsFromFilenames(Stream.concat(toBeDeleted.stream(), toBeKept.stream())
         .collect(Collectors.toUnmodifiableList()));
 
-    when(objectStoreAccess.getObjectsWithPrefix(eq(this.getPrefix("DE")))).thenReturn(mockResponse);
-    s3RetentionPolicy.applyHourFileRetentionPolicy(2);
+    when(objectStoreAccess.getObjectsWithPrefix(eq(this.getDiagnosisKeyPrefix("DE")))).thenReturn(mockResponse);
+    s3RetentionPolicy.applyDiagnosisKeyHourRetentionPolicy(2);
 
     toBeDeleted.forEach(f -> verify(objectStoreAccess, times(1)).deleteObjectsWithPrefix(eq(f)));
     toBeKept.forEach(f -> verify(objectStoreAccess, never()).deleteObjectsWithPrefix(eq(f)));
   }
 
   @Test
-  void shouldDeleteHourFileFromAllBuckets() {
-    var toBeKeptDE = generateHourFilesForDay(getUtcDate().minusDays(1), "DE");
-    var toBeKeptEUR = generateHourFilesForDay(getUtcDate().minusDays(1), "EUR");
+  void shouldDeleteDiagnosisKeyHourFilesFromAllBuckets() {
+    var toBeKeptDE = generateDiagnosisKeyHourFilesForDay(getUtcDate().minusDays(1), "DE");
+    var toBeKeptEUR = generateDiagnosisKeyHourFilesForDay(getUtcDate().minusDays(1), "EUR");
 
-    var toBeDeletedDE = generateHourFilesForDay(getUtcDate().minusDays(2), "DE");
-    var toBeDeletedEUR = generateHourFilesForDay(getUtcDate().minusDays(2), "EUR");
+    var toBeDeletedDE = generateDiagnosisKeyHourFilesForDay(getUtcDate().minusDays(2), "DE");
+    var toBeDeletedEUR = generateDiagnosisKeyHourFilesForDay(getUtcDate().minusDays(2), "EUR");
 
+    List<S3Object> mockResponseDE = this
+        .s3ObjectsFromFilenames(Stream.concat(toBeDeletedDE.stream(), toBeKeptDE.stream())
+            .collect(Collectors.toUnmodifiableList()));
+    when(objectStoreAccess.getObjectsWithPrefix(eq(this.getDiagnosisKeyPrefix("DE")))).thenReturn(mockResponseDE);
 
-    List<S3Object> mockResponseDE = this.s3ObjectsFromFilenames(Stream.concat(toBeDeletedDE.stream(), toBeKeptDE.stream())
-        .collect(Collectors.toUnmodifiableList()));
-    when(objectStoreAccess.getObjectsWithPrefix(eq(this.getPrefix("DE")))).thenReturn(mockResponseDE);
+    List<S3Object> mockResponseEUR = this
+        .s3ObjectsFromFilenames(Stream.concat(toBeDeletedEUR.stream(), toBeKeptEUR.stream())
+            .collect(Collectors.toUnmodifiableList()));
+    when(objectStoreAccess.getObjectsWithPrefix(eq(this.getDiagnosisKeyPrefix("EUR")))).thenReturn(mockResponseEUR);
 
-    List<S3Object> mockResponseEUR = this.s3ObjectsFromFilenames(Stream.concat(toBeDeletedEUR.stream(), toBeKeptEUR.stream())
-        .collect(Collectors.toUnmodifiableList()));
-    when(objectStoreAccess.getObjectsWithPrefix(eq(this.getPrefix("EUR")))).thenReturn(mockResponseEUR);
-
-    s3RetentionPolicy.applyHourFileRetentionPolicy(2);
+    s3RetentionPolicy.applyDiagnosisKeyHourRetentionPolicy(2);
 
     toBeDeletedDE.forEach(f -> verify(objectStoreAccess, times(1)).deleteObjectsWithPrefix(eq(f)));
     toBeKeptDE.forEach(f -> verify(objectStoreAccess, never()).deleteObjectsWithPrefix(eq(f)));
@@ -106,46 +107,46 @@ class S3RetentionPolicyTest {
   }
 
   @Test
-  void shouldRemoveIndexFileFromDEBucket() {
-    var validHourFile = generateHourIndex(getUtcDate().minusDays(1), "DE");
-    var invalidHourFile = generateHourIndex(getUtcDate().minusDays(2), "DE");
+  void shouldRemoveDiagnosisKeyHourIndexFilesFromDEBucket() {
+    var validHourFile = generateDiagnosisKeyHourIndex(getUtcDate().minusDays(1), "DE");
+    var invalidHourFile = generateDiagnosisKeyHourIndex(getUtcDate().minusDays(2), "DE");
 
     List<S3Object> mockResponse = this.s3ObjectsFromFilenames(list(validHourFile, invalidHourFile));
 
-    when(objectStoreAccess.getObjectsWithPrefix(eq(this.getPrefix("DE")))).thenReturn(mockResponse);
+    when(objectStoreAccess.getObjectsWithPrefix(eq(this.getDiagnosisKeyPrefix("DE")))).thenReturn(mockResponse);
 
-    s3RetentionPolicy.applyHourFileRetentionPolicy(2);
+    s3RetentionPolicy.applyDiagnosisKeyHourRetentionPolicy(2);
 
     verify(objectStoreAccess, times(1)).deleteObjectsWithPrefix(eq(invalidHourFile));
     verify(objectStoreAccess, never()).deleteObjectsWithPrefix(eq(validHourFile));
   }
 
   @Test
-  void shouldRemoveIndexFileFromEURBucket() {
-    var validHourFile = generateHourIndex(getUtcDate().minusDays(1), "EUR");
-    var invalidHourFile = generateHourIndex(getUtcDate().minusDays(2), "EUR");
+  void shouldRemoveDiagnosisKeyHourIndexFilesFromEURBucket() {
+    var validHourFile = generateDiagnosisKeyHourIndex(getUtcDate().minusDays(1), "EUR");
+    var invalidHourFile = generateDiagnosisKeyHourIndex(getUtcDate().minusDays(2), "EUR");
 
     List<S3Object> mockResponse = this.s3ObjectsFromFilenames(list(validHourFile, invalidHourFile));
 
-    when(objectStoreAccess.getObjectsWithPrefix(eq(this.getPrefix("EUR")))).thenReturn(mockResponse);
+    when(objectStoreAccess.getObjectsWithPrefix(eq(this.getDiagnosisKeyPrefix("EUR")))).thenReturn(mockResponse);
 
-    s3RetentionPolicy.applyHourFileRetentionPolicy(2);
+    s3RetentionPolicy.applyDiagnosisKeyHourRetentionPolicy(2);
 
     verify(objectStoreAccess, times(1)).deleteObjectsWithPrefix(eq(invalidHourFile));
     verify(objectStoreAccess, never()).deleteObjectsWithPrefix(eq(validHourFile));
   }
 
   @Test
-  void shouldRemoveFilesOlderThanCutoffDate() {
-    var validHourFile = generateHourIndex(getUtcDate().minusDays(1), "DE");
-    var invalidHourFile1 = generateHourIndex(getUtcDate().minusDays(2), "DE");
-    var invalidHourFile2 = generateHourIndex(getUtcDate().minusDays(3), "DE");
+  void shouldRemoveDiagnosisKeyIndexFilesOlderThanCutoffDate() {
+    var validHourFile = generateDiagnosisKeyHourIndex(getUtcDate().minusDays(1), "DE");
+    var invalidHourFile1 = generateDiagnosisKeyHourIndex(getUtcDate().minusDays(2), "DE");
+    var invalidHourFile2 = generateDiagnosisKeyHourIndex(getUtcDate().minusDays(3), "DE");
 
     List<S3Object> mockResponse = this.s3ObjectsFromFilenames(list(validHourFile, invalidHourFile1, invalidHourFile2));
 
-    when(objectStoreAccess.getObjectsWithPrefix(eq(this.getPrefix("DE")))).thenReturn(mockResponse);
+    when(objectStoreAccess.getObjectsWithPrefix(eq(this.getDiagnosisKeyPrefix("DE")))).thenReturn(mockResponse);
 
-    s3RetentionPolicy.applyHourFileRetentionPolicy(2);
+    s3RetentionPolicy.applyDiagnosisKeyHourRetentionPolicy(2);
 
     verify(objectStoreAccess, times(1)).deleteObjectsWithPrefix(eq(invalidHourFile1));
     verify(objectStoreAccess, times(1)).deleteObjectsWithPrefix(eq(invalidHourFile2));
@@ -153,41 +154,41 @@ class S3RetentionPolicyTest {
   }
 
   @Test
-  void shouldDeleteOldFiles() {
+  void shouldDeleteOldDiagnosisKeyFiles() {
     Collection<String> supportedCounties = asList(distributionServiceConfig.getSupportedCountries());
 
     Collection<String> expectedFilesToBeDeleted = supportedCounties.stream()
-        .map(country -> generateHourFilename(getUtcDate().minusDays(2), country))
+        .map(country -> generateDiagnosisKeyHourFilename(getUtcDate().minusDays(2), country))
         .collect(toList());
 
     List<S3Object> mockResponse = list(new S3Object("version/v1/configuration/country/DE/app_config"));
     mockResponse.addAll(
-        supportedCounties.stream().map(country -> new S3Object(generateHourFilename(getUtcDate(), country)))
+        supportedCounties.stream().map(country -> new S3Object(generateDiagnosisKeyHourFilename(getUtcDate(), country)))
             .collect(toList()));
     mockResponse.addAll(expectedFilesToBeDeleted.stream().map(S3Object::new).collect(toList()));
 
     when(objectStoreAccess.getObjectsWithPrefix(any())).thenReturn(mockResponse);
 
-    s3RetentionPolicy.applyRetentionPolicy(1);
+    s3RetentionPolicy.applyDiagnosisKeyDayRetentionPolicy(1);
 
     expectedFilesToBeDeleted.forEach(expectedFileToBeDeleted ->
         verify(objectStoreAccess, atLeastOnce()).deleteObjectsWithPrefix(eq(expectedFileToBeDeleted)));
   }
 
   @Test
-  void shouldNotDeleteFilesIfAllAreValid() {
+  void shouldNotDeleteDiagnosisKeyFilesIfAllAreValid() {
     Collection<String> supportedCounties = asList(distributionServiceConfig.getSupportedCountries());
 
     List<S3Object> mockResponse = list(new S3Object("version/v1/configuration/country/DE/app_config"));
     mockResponse.addAll(
         supportedCounties.stream().map(country -> asList(
-            new S3Object(generateHourFilename(getUtcDate().minusDays(1), country)),
-            new S3Object(generateHourFilename(getUtcDate().plusDays(1), country)),
-            new S3Object(generateHourFilename(getUtcDate(), country)))).flatMap(List::stream)
+            new S3Object(generateDiagnosisKeyHourFilename(getUtcDate().minusDays(1), country)),
+            new S3Object(generateDiagnosisKeyHourFilename(getUtcDate().plusDays(1), country)),
+            new S3Object(generateDiagnosisKeyHourFilename(getUtcDate(), country)))).flatMap(List::stream)
             .collect(toList()));
 
     when(objectStoreAccess.getObjectsWithPrefix(any())).thenReturn(mockResponse);
-    s3RetentionPolicy.applyRetentionPolicy(1);
+    s3RetentionPolicy.applyDiagnosisKeyDayRetentionPolicy(1);
 
     verify(objectStoreAccess, never()).deleteObjectsWithPrefix(any());
   }
@@ -196,29 +197,76 @@ class S3RetentionPolicyTest {
   void deleteDiagnosisKeysUpdatesFailedOperationCounter() {
     doThrow(ObjectStoreOperationFailedException.class).when(objectStoreAccess).deleteObjectsWithPrefix(any());
 
-    s3RetentionPolicy.deleteDiagnosisKey(new S3Object("foo"));
+    s3RetentionPolicy.deleteS3Object(new S3Object("foo"));
 
     verify(failedObjectStoreOperationsCounter, times(1))
         .incrementAndCheckThreshold(any(ObjectStoreOperationFailedException.class));
   }
 
-  private String getPrefix(String country) {
+  @Test
+  void shouldDeleteTraceTimeWarningFilesOlderThanCutoffDate() {
+    var toBeKept = generateTraceTimeWarningFilenamesForRange(
+        currentTime.minusHours(TimeUnit.DAYS.toHours(2)), currentTime);
+    var toBeDeleted = generateTraceTimeWarningFilenamesForRange(
+        currentTime.minusHours(TimeUnit.DAYS.toHours(5)), currentTime.minusHours(TimeUnit.DAYS.toHours(2)));
+
+    List<S3Object> mockResponse = this.s3ObjectsFromFilenames(Stream.concat(toBeDeleted.stream(), toBeKept.stream())
+        .collect(Collectors.toUnmodifiableList()));
+
+    when(objectStoreAccess.getObjectsWithPrefix(eq(this.getTraceTimeWarningPrefix("DE")))).thenReturn(mockResponse);
+    s3RetentionPolicy.applyTraceTimeWarningHourRetentionPolicy(2);
+
+    toBeDeleted.forEach(f -> verify(objectStoreAccess, times(1)).deleteObjectsWithPrefix(eq(f)));
+    toBeKept.forEach(f -> verify(objectStoreAccess, never()).deleteObjectsWithPrefix(eq(f)));
+  }
+
+  private String getDiagnosisKeyPrefix(String country) {
     var api = distributionServiceConfig.getApi();
     return api.getVersionPath() + "/" + api.getVersionV1() + "/" + api.getDiagnosisKeysPath() + "/"
         + api.getCountryPath() + "/" + country + "/" + api.getDatePath() + "/";
   }
 
-  private String generateHourIndex(LocalDate date, String country) {
+  private String getTraceTimeWarningPrefix(String country) {
     var api = distributionServiceConfig.getApi();
-    return this.getPrefix(country) + date.toString() + "/" + api.getHourPath();
+    return api.getVersionPath() + "/" + api.getVersionV1() + "/" + api.getTraceWarningsPath() + "/"
+        + api.getCountryPath() + "/" + country + "/" + api.getHourPath() + "/";
   }
 
-  private String generateHourFilename(LocalDate date, String country) {
-    return generateHourFilename(date, country, "0");
+  private String generateDiagnosisKeyHourIndex(LocalDate date, String country) {
+    var api = distributionServiceConfig.getApi();
+    return this.getDiagnosisKeyPrefix(country) + date.toString() + "/" + api.getHourPath();
   }
 
-  private String generateHourFilename(LocalDate date, String country, String hour) {
+  private String generateDiagnosisKeyHourFilename(LocalDate date, String country) {
+    return generateDiagnosisKeyHourFilename(date, country, "0");
+  }
+
+  private String generateDiagnosisKeyHourFilename(LocalDate date, String country, String hour) {
     var api = distributionServiceConfig.getApi();
-    return this.getPrefix(country) + date.toString() + "/" + api.getHourPath() + "/" + hour;
+    return this.getDiagnosisKeyPrefix(country) + date.toString() + "/" + api.getHourPath() + "/" + hour;
+  }
+
+  private String generateTraceTimeWarningFilename(long epochHour, String country) {
+    return this.getTraceTimeWarningPrefix(country) + epochHour;
+  }
+
+  private List<String> generateTraceTimeWarningFilenamesForRange(LocalDateTime startInclusive,
+      LocalDateTime endExclusive) {
+    return LongStream.range(TimeUnit.SECONDS.toHours(startInclusive.toEpochSecond(ZoneOffset.UTC)),
+        TimeUnit.SECONDS.toHours(endExclusive.toEpochSecond(ZoneOffset.UTC)))
+        .mapToObj(epochHour -> generateTraceTimeWarningFilename(epochHour, "DE"))
+        .collect(Collectors.toList());
+  }
+
+  private List<String> generateDiagnosisKeyHourFilesForDay(LocalDate day, String country) {
+    List<String> files = new ArrayList<>();
+    for (var i = 0; i <= 24; i++) {
+      files.add(generateDiagnosisKeyHourFilename(day, country, Integer.toString(i)));
+    }
+    return files;
+  }
+
+  private List<S3Object> s3ObjectsFromFilenames(List<String> filenames) {
+    return filenames.stream().map(S3Object::new).collect(Collectors.toUnmodifiableList());
   }
 }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/integration/ObjectStoreFilePreservationIT.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/integration/ObjectStoreFilePreservationIT.java
@@ -4,6 +4,7 @@ package app.coronawarn.server.services.distribution.objectstore.integration;
 
 import app.coronawarn.server.common.persistence.service.DiagnosisKeyService;
 import app.coronawarn.server.common.persistence.service.StatisticsDownloadService;
+import app.coronawarn.server.common.persistence.service.TraceTimeIntervalWarningService;
 import app.coronawarn.server.services.distribution.Application;
 import app.coronawarn.server.services.distribution.assembly.component.OutputDirectoryProvider;
 import app.coronawarn.server.services.distribution.assembly.structure.directory.DirectoryOnDisk;
@@ -49,6 +50,8 @@ class ObjectStoreFilePreservationIT extends BaseS3IntegrationTest {
 
   @Autowired
   private DiagnosisKeyService diagnosisKeyService;
+  @Autowired
+  private TraceTimeIntervalWarningService traceTimeIntervalWarningService;
   @Autowired
   private Assembly fileAssembler;
   @Autowired
@@ -160,8 +163,8 @@ class ObjectStoreFilePreservationIT extends BaseS3IntegrationTest {
     DistributionServiceConfig mockDistributionConfig = new DistributionServiceConfig();
     mockDistributionConfig.setRetentionDays(numberOfDaysSince(fromDate));
     mockDistributionConfig.setObjectStore(distributionServiceConfig.getObjectStore());
-    new RetentionPolicy(diagnosisKeyService, applicationContext, mockDistributionConfig,
-        s3RetentionPolicy, statisticsDownloadService).run(null);
+    new RetentionPolicy(diagnosisKeyService, traceTimeIntervalWarningService, applicationContext,
+        mockDistributionConfig, s3RetentionPolicy, statisticsDownloadService).run(null);
   }
 
   private Integer numberOfDaysSince(LocalDate testStartDate) {

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/runner/RetentionPolicyRunnerTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/runner/RetentionPolicyRunnerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 
 import app.coronawarn.server.common.persistence.service.DiagnosisKeyService;
 import app.coronawarn.server.common.persistence.service.StatisticsDownloadService;
+import app.coronawarn.server.common.persistence.service.TraceTimeIntervalWarningService;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.objectstore.S3RetentionPolicy;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,9 @@ class RetentionPolicyRunnerTest {
   DiagnosisKeyService diagnosisKeyService;
 
   @MockBean
+  TraceTimeIntervalWarningService traceTimeIntervalWarningService;
+
+  @MockBean
   S3RetentionPolicy s3RetentionPolicy;
 
   @MockBean
@@ -42,10 +46,17 @@ class RetentionPolicyRunnerTest {
   void shouldCallDatabaseAndS3RetentionRunner() {
     retentionPolicy.run(null);
 
-    verify(statisticsDownloadService, times(1)).applyRetentionPolicy(distributionServiceConfig.getRetentionDays());
-    verify(diagnosisKeyService, times(1)).applyRetentionPolicy(distributionServiceConfig.getRetentionDays());
-    verify(s3RetentionPolicy, times(1)).applyRetentionPolicy(distributionServiceConfig.getRetentionDays());
+    verify(statisticsDownloadService, times(1))
+        .applyRetentionPolicy(distributionServiceConfig.getRetentionDays());
+    verify(diagnosisKeyService, times(1))
+        .applyRetentionPolicy(distributionServiceConfig.getRetentionDays());
+    verify(traceTimeIntervalWarningService, times(1))
+        .applyRetentionPolicy(distributionServiceConfig.getRetentionDays());
     verify(s3RetentionPolicy, times(1))
-        .applyHourFileRetentionPolicy(distributionServiceConfig.getObjectStore().getHourFileRetentionDays());
+        .applyDiagnosisKeyDayRetentionPolicy(distributionServiceConfig.getRetentionDays());
+    verify(s3RetentionPolicy, times(1))
+        .applyDiagnosisKeyHourRetentionPolicy(distributionServiceConfig.getObjectStore().getHourFileRetentionDays());
+    verify(s3RetentionPolicy, times(1))
+        .applyTraceTimeWarningHourRetentionPolicy(distributionServiceConfig.getRetentionDays());
   }
 }

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
@@ -3,6 +3,7 @@ package app.coronawarn.server.services.submission.controller;
 import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
 import app.coronawarn.server.common.persistence.service.DiagnosisKeyService;
 import app.coronawarn.server.common.persistence.service.TraceTimeIntervalWarningService;
+import app.coronawarn.server.common.persistence.service.utils.checkins.CheckinsDateSpecification;
 import app.coronawarn.server.common.protocols.external.exposurenotification.TemporaryExposureKey;
 import app.coronawarn.server.common.protocols.internal.SubmissionPayload;
 import app.coronawarn.server.common.protocols.internal.pt.CheckIn;
@@ -15,6 +16,7 @@ import app.coronawarn.server.services.submission.validation.ValidSubmissionPaylo
 import app.coronawarn.server.services.submission.verification.TanVerifier;
 import io.micrometer.core.annotation.Timed;
 import java.security.SecureRandom;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -46,9 +48,9 @@ public class SubmissionController {
    */
   public static final String SUBMISSION_ROUTE = "/diagnosis-keys";
   private static final Logger logger = LoggerFactory.getLogger(SubmissionController.class);
-  
+
   public static final Marker EVENT = MarkerFactory.getMarker("EVENT");
-  
+
   private final SubmissionMonitor submissionMonitor;
   private final DiagnosisKeyService diagnosisKeyService;
   private final TanVerifier tanVerifier;
@@ -134,7 +136,8 @@ public class SubmissionController {
       numberOfFilteredCheckins.set(submissionPayload.getCheckInsList().size() - checkins.size());
       numberOfSavedCheckins.set(traceTimeIntervalWarningSevice.saveCheckinsWithFakeData(checkins,
           submissionServiceConfig.getRandomCheckinsPaddingMultiplier(),
-          submissionServiceConfig.getRandomCheckinsPaddingPepperAsByteArray()));
+          submissionServiceConfig.getRandomCheckinsPaddingPepperAsByteArray(),
+          CheckinsDateSpecification.HOUR_SINCE_EPOCH_DERIVATION.apply(Instant.now().getEpochSecond())));
     } catch (final TooManyCheckInsAtSameDay e) {
       logger.error(EVENT, e.getMessage());
     } catch (final Exception e) {


### PR DESCRIPTION
[EXPOSUREBACK-1130](https://jira-ibs.wbs.net.sap/browse/EXPOSUREBACK-1130)

## Description
- Analogous to diagnosis key, trace time interval warnings will now be deleted from both the DB as well as the object store after a set amount of days (currently 14)
