### PR TITLE
Feature/submission type not persisted

### DIFF
--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/SubmissionController.java
@@ -202,6 +202,7 @@ public class SubmissionController {
         .addAllVisitedCountries(submissionPayload.getVisitedCountriesList())
         .setOrigin(originCountry)
         .setConsentToFederation(submissionPayload.getConsentToFederation())
+        .setSubmissionType(submissionPayload.getSubmissionType())
         .build();
   }
 

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/integration/SubmissionPersistenceIT.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/integration/SubmissionPersistenceIT.java
@@ -112,12 +112,12 @@ class SubmissionPersistenceIT {
   @ParameterizedTest
   @MethodSource("validSubmissionPayload")
   void okKeyInsertionWithMobileClientProtoBuf(List<String> visitedCountries, String originCountry,
-      Boolean consentToFederation) throws IOException {
+      Boolean consentToFederation, SubmissionType submissionType) throws IOException {
 
     List<TemporaryExposureKey> temporaryExposureKeys = createValidTemporaryExposureKeys();
 
     SubmissionPayload submissionPayload = buildSubmissionPayload(visitedCountries, originCountry, consentToFederation,
-        temporaryExposureKeys, SubmissionType.SUBMISSION_TYPE_PCR_TEST);
+        temporaryExposureKeys, submissionType);
 
     writeSubmissionPayloadProtobufFile(submissionPayload);
 
@@ -144,6 +144,7 @@ class SubmissionPersistenceIT {
         .addAllVisitedCountries(expectedVisitedCountries)
         .setOrigin(StringUtils.defaultIfBlank(payload.getOrigin(), config.getDefaultOriginCountry()))
         .setConsentToFederation(payload.getConsentToFederation())
+        .setSubmissionType(submissionType)
         .build();
 
     assertEquals(payload.getKeysList().size(), result);


### PR DESCRIPTION
For some reason, nobody spotted that both the test AND the prod code miss setting the submission type, which defaults to PCR.