### PR TITLE
Revert "Bump maven-dependency-plugin from 3.1.2 to 3.2.0 (#1439)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
This reverts commit 9b5e55aa58feaa32669d641fd5579d2de5af8311.

`mvn dependency:tree -DoutputFile=mvn_dependency_tree.txt -Dverbose -DoutputType=text -T1`
doesn't work anymore with version `3.2.0`

https://github.com/corona-warn-app/cwa-ppa-server/pull/254