### PR TITLE
Junit/disable tests

### DIFF
--- a/common/jupiterHelpers/pom.xml
+++ b/common/jupiterHelpers/pom.xml
@@ -3,22 +3,19 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <artifactId>server</artifactId>
+    <artifactId>common</artifactId>
     <groupId>app.coronawarn.server</groupId>
     <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>common</artifactId>
+  <artifactId>jupiterHelpers</artifactId>
 
-  <packaging>pom</packaging>
-
-  <modules>
-    <module>jupiterHelpers</module>
-    <module>shared</module>
-    <module>protocols</module>
-    <module>persistence</module>
-    <module>federation</module>
-  </modules>
-
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/common/jupiterHelpers/src/main/java/app/coronawarn/server/junit/DisabledAroundMidnight.java
+++ b/common/jupiterHelpers/src/main/java/app/coronawarn/server/junit/DisabledAroundMidnight.java
@@ -1,0 +1,22 @@
+package app.coronawarn.server.junit;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ METHOD, TYPE, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+@ExtendWith(DisabledAroundMidnightCondition.class)
+public @interface DisabledAroundMidnight {
+  /**
+   * Minutes before/after midnight the test should be disabled.
+   * 
+   * @return <code>60</code> as default.
+   */
+  int offsetInMinutes() default 60;
+}

--- a/common/jupiterHelpers/src/main/java/app/coronawarn/server/junit/DisabledAroundMidnightCondition.java
+++ b/common/jupiterHelpers/src/main/java/app/coronawarn/server/junit/DisabledAroundMidnightCondition.java
@@ -1,0 +1,37 @@
+package app.coronawarn.server.junit;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class DisabledAroundMidnightCondition implements ExecutionCondition {
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext context) {
+    final Optional<DisabledAroundMidnight> optional = findAnnotation(context.getElement(),
+        DisabledAroundMidnight.class);
+    if (optional.isEmpty()) {
+      return enabled("@DisabledAroundMidnight is not present");
+    }
+
+    final LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+    final LocalDateTime tonight = LocalDateTime.of(LocalDate.now(ZoneOffset.UTC), LocalTime.MIDNIGHT);
+    final LocalDateTime nextnight = LocalDateTime.of(LocalDate.now(ZoneOffset.UTC).plusDays(1), LocalTime.MIDNIGHT);
+    final int minutes = optional.get().offsetInMinutes();
+
+    if (MINUTES.between(tonight, now) <= minutes || MINUTES.between(now, nextnight) <= minutes) {
+      return disabled(now + " is closer than " + minutes + " minutes to midnight that's why we skip the test.");
+    }
+    return enabled(now + " is more than " + minutes + " minutes off by midnight that's why we execute the test.");
+  }
+}

--- a/common/jupiterHelpers/src/test/java/jupiterHelpers/DisabledAroundMidnightConditionTest.java
+++ b/common/jupiterHelpers/src/test/java/jupiterHelpers/DisabledAroundMidnightConditionTest.java
@@ -1,0 +1,22 @@
+package jupiterHelpers;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import app.coronawarn.server.junit.DisabledAroundMidnight;
+import org.junit.jupiter.api.Test;
+
+class DisabledAroundMidnightConditionTest {
+
+  @Test
+  @DisabledAroundMidnight(offsetInMinutes = 12 * 60)
+  void testDisabledAroundMidnight() {
+    fail("Test should be disabled and therefore NOT fail!");
+  }
+
+  @Test
+  @DisabledAroundMidnight(offsetInMinutes = 0)
+  void testEndabledAroundMidnight() {
+    assertTrue(true, "Test should always be executed!");
+  }
+}

--- a/common/persistence/pom.xml
+++ b/common/persistence/pom.xml
@@ -18,6 +18,10 @@
     </dependency>
     <dependency>
       <groupId>${project.parent.groupId}</groupId>
+      <artifactId>jupiterHelpers</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.parent.groupId}</groupId>
       <artifactId>shared</artifactId>
     </dependency>
     <dependency>

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/common/DiagnosisKeyExpirationCheckerTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/common/DiagnosisKeyExpirationCheckerTest.java
@@ -1,11 +1,12 @@
-
-
 package app.coronawarn.server.common.persistence.service.common;
 
 import static app.coronawarn.server.common.persistence.service.DiagnosisKeyServiceTestHelper.getKeySubmittedHoursAfterMidnightExpiration;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.of;
 
+import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
+import app.coronawarn.server.junit.DisabledAroundMidnight;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -16,41 +17,48 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
-
 class DiagnosisKeyExpirationCheckerTest {
+
+  /**
+   * Midnight - start of this day.
+   */
+  private static final LocalDateTime MN = LocalDateTime.of(LocalDate.now(ZoneOffset.UTC), LocalTime.MIDNIGHT);
+
+  private static Stream<Arguments> expiredKeysDataset() {
+    return Stream.of(
+        of(getKeySubmittedHoursAfterMidnightExpiration(1), ExpirationPolicy.of(60, ChronoUnit.MINUTES),
+            MN.plusHours(2)),
+        of(getKeySubmittedHoursAfterMidnightExpiration(2), ExpirationPolicy.of(60, ChronoUnit.MINUTES),
+            MN.plusHours(3)),
+        of(getKeySubmittedHoursAfterMidnightExpiration(2), ExpirationPolicy.of(120, ChronoUnit.MINUTES),
+            MN.plusHours(3)),
+        of(getKeySubmittedHoursAfterMidnightExpiration(4), ExpirationPolicy.of(120, ChronoUnit.MINUTES),
+            MN.plusHours(4)));
+  }
+
+  private static Stream<Arguments> notExpiredKeysDataset() {
+    return Stream.of(
+        of(getKeySubmittedHoursAfterMidnightExpiration(1), ExpirationPolicy.of(120, ChronoUnit.MINUTES),
+            MN.plusHours(1).plusMinutes(30)),
+        of(getKeySubmittedHoursAfterMidnightExpiration(2), ExpirationPolicy.of(180, ChronoUnit.MINUTES),
+            MN.plusHours(2).plusMinutes(30)),
+        of(getKeySubmittedHoursAfterMidnightExpiration(3), ExpirationPolicy.of(240, ChronoUnit.MINUTES),
+            MN.plusHours(3).plusMinutes(30)));
+  }
 
   private final KeySharingPoliciesChecker sharingPoliciesChecker = new KeySharingPoliciesChecker();
 
-
-  @ParameterizedTest
-  @MethodSource("notExpiredKeysDataset")
-  void shouldComputeThatKeyIsNotExpired(DiagnosisKey key, ExpirationPolicy expirationPolicy, LocalDateTime shareTime) {
-    assertFalse(sharingPoliciesChecker.canShareKeyAtTime(key, expirationPolicy, shareTime));
-  }
-
   @ParameterizedTest
   @MethodSource("expiredKeysDataset")
+  @DisabledAroundMidnight(offsetInMinutes = 4 * 60 + 1)
   void shouldComputeThatKeyIsExpired(DiagnosisKey key, ExpirationPolicy expirationPolicy, LocalDateTime shareTime) {
     assertTrue(sharingPoliciesChecker.canShareKeyAtTime(key, expirationPolicy, shareTime));
   }
 
-  private static Stream<Arguments> expiredKeysDataset() {
-    LocalDateTime midnight = LocalDateTime.of(LocalDate.now(ZoneOffset.UTC), LocalTime.MIDNIGHT);
-    return Stream.of(
-        Arguments.of(getKeySubmittedHoursAfterMidnightExpiration(1), ExpirationPolicy.of(60, ChronoUnit.MINUTES), midnight.plusHours(2)),
-        Arguments.of(getKeySubmittedHoursAfterMidnightExpiration(2), ExpirationPolicy.of(60, ChronoUnit.MINUTES), midnight.plusHours(3)),
-        Arguments.of(getKeySubmittedHoursAfterMidnightExpiration(2), ExpirationPolicy.of(120, ChronoUnit.MINUTES), midnight.plusHours(3)),
-        Arguments.of(getKeySubmittedHoursAfterMidnightExpiration(4), ExpirationPolicy.of(120, ChronoUnit.MINUTES), midnight.plusHours(4))
-    );
-  }
-
-  private static Stream<Arguments> notExpiredKeysDataset() {
-    LocalDateTime midnight = LocalDateTime.of(LocalDate.now(ZoneOffset.UTC), LocalTime.MIDNIGHT);
-    return Stream.of(
-        Arguments.of(getKeySubmittedHoursAfterMidnightExpiration(1), ExpirationPolicy.of(120, ChronoUnit.MINUTES), midnight.plusHours(1).plusMinutes(30)),
-        Arguments.of(getKeySubmittedHoursAfterMidnightExpiration(2), ExpirationPolicy.of(180, ChronoUnit.MINUTES), midnight.plusHours(2).plusMinutes(30)),
-        Arguments.of(getKeySubmittedHoursAfterMidnightExpiration(3), ExpirationPolicy.of(240, ChronoUnit.MINUTES), midnight.plusHours(3).plusMinutes(30))
-    );
+  @ParameterizedTest
+  @MethodSource("notExpiredKeysDataset")
+  @DisabledAroundMidnight(offsetInMinutes = 3 * 60 + 1)
+  void shouldComputeThatKeyIsNotExpired(DiagnosisKey key, ExpirationPolicy expirationPolicy, LocalDateTime shareTime) {
+    assertFalse(sharingPoliciesChecker.canShareKeyAtTime(key, expirationPolicy, shareTime));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@
         <artifactId>federation</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>jupiterHelpers</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+      </dependency>
       <!-- other third party libraries -->
       <dependency>
         <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
because of all our checks, we do have a lot of tests that are time dependent - especially around midnight...

this is my try to avoid circleci failures like this: https://app.circleci.com/pipelines/github/corona-warn-app/cwa-server/6746/workflows/a8b03982-7153-405c-8ab6-86aceb06a845/jobs/6788/steps