### PR TITLE
use Trend.UNRECOGNIZED as default

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/config/RegionMappingConfig.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/config/RegionMappingConfig.java
@@ -28,7 +28,7 @@ public class RegionMappingConfig {
   RegionMappingConfig() {
   }
 
-  public Optional<Integer> getFederalStateGroup(Integer federalStateId) {
+  public Optional<Integer> getFederalStateGroup(int federalStateId) {
     return Optional.ofNullable(
         federalStatesGroups.get(getFederalStateConfigIndex(federalStateId)));
   }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsToProtobufMapping.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/StatisticsToProtobufMapping.java
@@ -26,7 +26,6 @@ import app.coronawarn.server.services.distribution.statistics.keyfigurecard.fact
 import app.coronawarn.server.services.distribution.statistics.validation.StatisticsJsonValidator;
 import java.io.IOException;
 import java.time.LocalDate;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -79,7 +78,7 @@ public class StatisticsToProtobufMapping {
   }
 
   private void updateETag(String newETag) {
-    var currentTimestamp = TimeUtils.getCurrentUtcHour().toEpochSecond(ZoneOffset.UTC);
+    var currentTimestamp = TimeUtils.getNow().getEpochSecond();
     this.statisticsDownloadService.store(currentTimestamp, newETag);
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/local/BuildLocalStatisticsHelper.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/local/BuildLocalStatisticsHelper.java
@@ -76,7 +76,7 @@ public class BuildLocalStatisticsHelper {
    * @param federalStateId - federal state id.
    * @return - federal state index in configurations and protobuf enum.
    */
-  public static int getFederalStateConfigIndex(Integer federalStateId) {
+  public static int getFederalStateConfigIndex(int federalStateId) {
     return federalStateId - 1;
   }
 
@@ -97,7 +97,7 @@ public class BuildLocalStatisticsHelper {
       case 1:
         return Trend.forNumber(2);
       default:
-        return Trend.forNumber(-1);
+        return Trend.UNRECOGNIZED;
     }
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/local/LocalStatisticsToProtobufMapping.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/local/LocalStatisticsToProtobufMapping.java
@@ -122,7 +122,7 @@ public class LocalStatisticsToProtobufMapping {
   }
 
   private void updateETag(String newETag) {
-    var currentTimestamp = TimeUtils.getCurrentUtcHour().toEpochSecond(ZoneOffset.UTC);
+    var currentTimestamp = TimeUtils.getNow().getEpochSecond();
     this.localStatisticsDownloadService.store(currentTimestamp, newETag);
   }
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/local/BuildLocalStatisticsHelperTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/local/BuildLocalStatisticsHelperTest.java
@@ -1,0 +1,42 @@
+package app.coronawarn.server.services.distribution.statistics.local;
+
+import static app.coronawarn.server.common.protocols.internal.stats.KeyFigure.Trend.DECREASING;
+import static app.coronawarn.server.common.protocols.internal.stats.KeyFigure.Trend.INCREASING;
+import static app.coronawarn.server.common.protocols.internal.stats.KeyFigure.Trend.STABLE;
+import static app.coronawarn.server.common.protocols.internal.stats.KeyFigure.Trend.UNRECOGNIZED;
+import static app.coronawarn.server.services.distribution.statistics.local.BuildLocalStatisticsHelper.findFederalStateByProvinceCode;
+import static app.coronawarn.server.services.distribution.statistics.local.BuildLocalStatisticsHelper.findTrendBySevenDayIncidence;
+import static app.coronawarn.server.services.distribution.statistics.local.BuildLocalStatisticsHelper.getFederalStateConfigIndex;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class BuildLocalStatisticsHelperTest {
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 0, 1, 2, 3, 5, 7, 11})
+  void testGetFederalStateConfigIndex(int i) {
+    assertEquals(i, getFederalStateConfigIndex(i + 1));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-2, 2, 3, 5, 7, 11})
+  void testFindTrendBySevenDayIncidenceUnrecognized(int i) {
+    assertEquals(UNRECOGNIZED, findTrendBySevenDayIncidence(i));
+  }
+
+  @Test
+  void testFindTrendBySevenDayIncidence() {
+    assertEquals(DECREASING, findTrendBySevenDayIncidence(-1));
+    assertEquals(STABLE, findTrendBySevenDayIncidence(0));
+    assertEquals(INCREASING, findTrendBySevenDayIncidence(1));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1111, 0, 1111, 2222, 3333, 5555, 7777})
+  void testFindFederalStateByProvinceCode(int i) {
+    assertEquals(i / 1000, findFederalStateByProvinceCode(i));
+  }
+}


### PR DESCRIPTION
weird protobuf...

on the one hand it generates:
```
    public static Trend forNumber(int value) {
      switch (value) {
        case 0: return UNSPECIFIED_TREND;
        case 1: return STABLE;
        case 2: return INCREASING;
        case 3: return DECREASING;
        default: return null;
      }
    }
```

on the other hand it throws NPE, when setting Trend `null`

```
    public Builder setTrend(app.coronawarn.server.common.protocols.internal.stats.KeyFigure.Trend value) {
      if (value == null) {
        throw new NullPointerException();
      }
      
      trend_ = value.getNumber();
      onChanged();
      return this;
    }
```