### PR TITLE
fix: remove v2 outputfile name because it will create index-v2 index-…

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/CwaApiStructureProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/CwaApiStructureProvider.java
@@ -62,7 +62,6 @@ public class CwaApiStructureProvider {
         ignoredValue -> Set.of(distributionServiceConfig.getApi().getVersionV1()),
         Object::toString);
 
-
     versionDirectory.addWritableToAll(
         ignoredValue -> Optional.of(appConfigurationStructureProvider.getAppConfiguration()));
     versionDirectory.addWritableToAll(
@@ -107,6 +106,6 @@ public class CwaApiStructureProvider {
     versionDirectory.addWritableToAll(
         ignoredValue -> Optional.of(traceWarningsStructureProvider.getCheckInProtectedReportsDirectory()));
 
-    return new IndexingDecoratorOnDisk<>(versionDirectory, distributionServiceConfig.getOutputFileNameV2());
+    return new IndexingDecoratorOnDisk<>(versionDirectory, distributionServiceConfig.getOutputFileName());
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/TraceTimeIntervalWarningsDirectory.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/TraceTimeIntervalWarningsDirectory.java
@@ -9,17 +9,21 @@ import app.coronawarn.server.services.distribution.assembly.structure.directory.
 import app.coronawarn.server.services.distribution.assembly.structure.directory.IndexDirectoryOnDisk;
 import app.coronawarn.server.services.distribution.assembly.structure.directory.decorator.indexing.IndexingDecoratorOnDisk;
 import app.coronawarn.server.services.distribution.assembly.tracewarnings.TraceTimeIntervalWarningsPackageBundler;
+import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.v1.TraceTimeIntervalWarningsCountryV1Directory;
+import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.v2.TraceTimeIntervalWarningsCountryV2Directory;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 
 public class TraceTimeIntervalWarningsDirectory extends DirectoryOnDisk {
 
+  private static final String VERSION_V1 = "v1";
+  private static final String VERSION_V2 = "v2";
   private final CryptoProvider cryptoProvider;
   private final DistributionServiceConfig distributionServiceConfig;
   private final TraceTimeIntervalWarningsPackageBundler traceWarningsBundler;
 
   /**
-   * Creates an instance of the custom directory that includes the entire
-   * {@link TraceTimeIntervalWarning} package structure as per the API specification.
+   * Creates an instance of the custom directory that includes the entire {@link TraceTimeIntervalWarning} package
+   * structure as per the API specification.
    */
   public TraceTimeIntervalWarningsDirectory(
       TraceTimeIntervalWarningsPackageBundler traceWarningsBundler, CryptoProvider cryptoProvider,
@@ -33,8 +37,13 @@ public class TraceTimeIntervalWarningsDirectory extends DirectoryOnDisk {
   @Override
   public void prepare(ImmutableStack<Object> indices) {
     String version = (String) indices.peek();
-    this.addWritable(decorateCountryDirectory(new TraceTimeIntervalWarningsCountryDirectory(
-        traceWarningsBundler, cryptoProvider, distributionServiceConfig, version)));
+    if (version.equals(VERSION_V1)) {
+      this.addWritable(decorateCountryDirectory(new TraceTimeIntervalWarningsCountryV1Directory(
+          traceWarningsBundler, cryptoProvider, distributionServiceConfig)));
+    } else if (version.equals(VERSION_V2)) {
+      this.addWritable(decorateCountryDirectory(new TraceTimeIntervalWarningsCountryV2Directory(
+          traceWarningsBundler, cryptoProvider, distributionServiceConfig)));
+    }
     super.prepare(indices);
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/decorator/HourIntervalIndexingV1Decorator.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/decorator/HourIntervalIndexingV1Decorator.java
@@ -4,7 +4,7 @@ import app.coronawarn.server.common.shared.collection.ImmutableStack;
 import app.coronawarn.server.services.distribution.assembly.structure.file.FileOnDisk;
 import app.coronawarn.server.services.distribution.assembly.structure.file.FileOnDiskWithChecksum;
 import app.coronawarn.server.services.distribution.assembly.tracewarnings.TraceTimeIntervalWarningsPackageBundler;
-import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.TraceTimeIntervalWarningsHourV1Directory;
+import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.v1.TraceTimeIntervalWarningsHourV1Directory;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/decorator/HourIntervalIndexingV2Decorator.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/decorator/HourIntervalIndexingV2Decorator.java
@@ -4,7 +4,7 @@ import app.coronawarn.server.common.shared.collection.ImmutableStack;
 import app.coronawarn.server.services.distribution.assembly.structure.file.FileOnDisk;
 import app.coronawarn.server.services.distribution.assembly.structure.file.FileOnDiskWithChecksum;
 import app.coronawarn.server.services.distribution.assembly.tracewarnings.TraceTimeIntervalWarningsPackageBundler;
-import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.TraceTimeIntervalWarningsHourV2Directory;
+import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.v2.TraceTimeIntervalWarningsHourV2Directory;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/v1/TraceTimeIntervalWarningsCountryV1Directory.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/v1/TraceTimeIntervalWarningsCountryV1Directory.java
@@ -1,0 +1,64 @@
+package app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.v1;
+
+import app.coronawarn.server.common.persistence.domain.TraceTimeIntervalWarning;
+import app.coronawarn.server.common.shared.collection.ImmutableStack;
+import app.coronawarn.server.services.distribution.assembly.component.CryptoProvider;
+import app.coronawarn.server.services.distribution.assembly.structure.WritableOnDisk;
+import app.coronawarn.server.services.distribution.assembly.structure.directory.IndexDirectory;
+import app.coronawarn.server.services.distribution.assembly.structure.directory.IndexDirectoryOnDisk;
+import app.coronawarn.server.services.distribution.assembly.tracewarnings.TraceTimeIntervalWarningsPackageBundler;
+import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.decorator.HourIntervalIndexingV1Decorator;
+import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Country directory for v1 implementation of check ins.
+ */
+@Deprecated(since = "2.8")
+public class TraceTimeIntervalWarningsCountryV1Directory extends IndexDirectoryOnDisk<String> {
+
+  protected final TraceTimeIntervalWarningsPackageBundler traceWarningsBundler;
+  private final CryptoProvider cryptoProvider;
+  private final DistributionServiceConfig distributionServiceConfig;
+
+  /**
+   * Creates an instance of the custom directory that includes the entire {@link TraceTimeIntervalWarning} package
+   * structure for a country as per the API specification.
+   *
+   * @deprecated in favor of checkin protected results.
+   */
+  @Deprecated(since = "2.8")
+  public TraceTimeIntervalWarningsCountryV1Directory(
+      TraceTimeIntervalWarningsPackageBundler traceWarningsBundler, CryptoProvider cryptoProvider,
+      DistributionServiceConfig distributionServiceConfig) {
+    super(distributionServiceConfig.getApi().getCountryPath(),
+        ignoredValue -> Set.of(distributionServiceConfig.getApi().getOriginCountry()),
+        Object::toString);
+    this.traceWarningsBundler = traceWarningsBundler;
+    this.cryptoProvider = cryptoProvider;
+    this.distributionServiceConfig = distributionServiceConfig;
+  }
+
+  @Override
+  public void prepare(ImmutableStack<Object> indices) {
+    this.addWritableToAll(ignoredValue -> Optional
+        .of(decorateV1HourDirectory(
+            new TraceTimeIntervalWarningsHourV1Directory(traceWarningsBundler, cryptoProvider,
+                distributionServiceConfig)
+        )));
+    super.prepare(indices);
+  }
+
+  /**
+   * Decorate v1 directory.
+   *
+   * @param hourDirectory the directory to decorate.
+   * @deprecated because trace time warnings are being replaced by protected reports.
+   */
+  @Deprecated(since = "2.8")
+  private IndexDirectory<Integer, WritableOnDisk> decorateV1HourDirectory(
+      TraceTimeIntervalWarningsHourV1Directory hourDirectory) {
+    return new HourIntervalIndexingV1Decorator(hourDirectory, traceWarningsBundler, distributionServiceConfig);
+  }
+}

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/v1/TraceTimeIntervalWarningsHourV1Directory.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/v1/TraceTimeIntervalWarningsHourV1Directory.java
@@ -1,6 +1,6 @@
-package app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory;
+package app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.v1;
 
-import app.coronawarn.server.common.persistence.domain.CheckInProtectedReports;
+import app.coronawarn.server.common.persistence.domain.TraceTimeIntervalWarning;
 import app.coronawarn.server.common.shared.collection.ImmutableStack;
 import app.coronawarn.server.services.distribution.assembly.component.CryptoProvider;
 import app.coronawarn.server.services.distribution.assembly.structure.WritableOnDisk;
@@ -9,30 +9,31 @@ import app.coronawarn.server.services.distribution.assembly.structure.archive.Ar
 import app.coronawarn.server.services.distribution.assembly.structure.file.File;
 import app.coronawarn.server.services.distribution.assembly.structure.file.FileOnDiskWithChecksum;
 import app.coronawarn.server.services.distribution.assembly.tracewarnings.TraceTimeIntervalWarningsPackageBundler;
-import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.file.CheckInProtectedReportsExportFile;
+import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.AbstractTraceTimeIntervalWarningsHourDirectory;
+import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.file.TraceTimeIntervalWarningExportFile;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import java.util.List;
 import java.util.Optional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Hour directory for checkins in the v2 implementation.
+ * Hour directory for checkins in the v1 implementation.
  */
-public class TraceTimeIntervalWarningsHourV2Directory extends AbstractTraceTimeIntervalWarningsHourDirectory {
-
-  private static final Logger logger = LoggerFactory.getLogger(TraceTimeIntervalWarningsHourV2Directory.class);
+@Deprecated(since = "2.8")
+public class TraceTimeIntervalWarningsHourV1Directory extends AbstractTraceTimeIntervalWarningsHourDirectory {
 
   /**
    * Creates an instance of the directory that holds packages for an hour since epoch, as defined by the API spec.
+   *
+   * @deprecated because trace time warnings are being replaced by protected reports.
    */
-  public TraceTimeIntervalWarningsHourV2Directory(
+  @Deprecated(since = "2.8")
+  public TraceTimeIntervalWarningsHourV1Directory(
       TraceTimeIntervalWarningsPackageBundler traceWarningsBundler, CryptoProvider cryptoProvider,
       DistributionServiceConfig distributionServiceConfig) {
     super(traceWarningsBundler, cryptoProvider, distributionServiceConfig,
         indices -> {
           String country = (String) indices.peek();
-          return traceWarningsBundler.getHoursForDistributableCheckInProtectedReports(country);
+          return traceWarningsBundler.getHoursForDistributableWarnings(country);
         }, Integer::valueOf);
   }
 
@@ -42,20 +43,19 @@ public class TraceTimeIntervalWarningsHourV2Directory extends AbstractTraceTimeI
       Integer hourSinceEpoch = (Integer) currentIndices.peek();
       String country = (String) currentIndices.pop().peek();
 
-      List<CheckInProtectedReports> checkInReportsForHour =
-          this.traceWarningsBundler.getCheckInProtectedReportsForHour(hourSinceEpoch);
-      if (checkInReportsForHour.isEmpty()) {
+      List<TraceTimeIntervalWarning> traceWarningsForCurrentHour =
+          this.traceWarningsBundler.getTraceTimeWarningsForHour(hourSinceEpoch);
+      if (traceWarningsForCurrentHour.isEmpty()) {
         return Optional.of(new FileOnDiskWithChecksum("index", new byte[0]));
       }
-      logger.debug("Building protected reports export file for hour {} and country {} with {} encrypted checkins.",
-          hourSinceEpoch, country, checkInReportsForHour.size());
-      File<WritableOnDisk> checkInProtectedReportsExportFile =
-          CheckInProtectedReportsExportFile.fromCheckInProtectedReports(
-              checkInReportsForHour, country, hourSinceEpoch, distributionServiceConfig);
+
+      File<WritableOnDisk> traceTimeIntervalWarningExportFile =
+          TraceTimeIntervalWarningExportFile.fromTraceTimeIntervalWarnings(
+              traceWarningsForCurrentHour, country, hourSinceEpoch, distributionServiceConfig);
 
       Archive<WritableOnDisk> hourArchive =
-          new ArchiveOnDisk(distributionServiceConfig.getOutputFileNameV2());
-      hourArchive.addWritable(checkInProtectedReportsExportFile);
+          new ArchiveOnDisk(distributionServiceConfig.getOutputFileName());
+      hourArchive.addWritable(traceTimeIntervalWarningExportFile);
 
       return Optional.of(decorateTraceWarningArchives(hourArchive));
     });

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/v2/TraceTimeIntervalWarningsCountryV2Directory.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/v2/TraceTimeIntervalWarningsCountryV2Directory.java
@@ -1,4 +1,4 @@
-package app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory;
+package app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.v2;
 
 import app.coronawarn.server.common.persistence.domain.TraceTimeIntervalWarning;
 import app.coronawarn.server.common.shared.collection.ImmutableStack;
@@ -7,73 +7,42 @@ import app.coronawarn.server.services.distribution.assembly.structure.WritableOn
 import app.coronawarn.server.services.distribution.assembly.structure.directory.IndexDirectory;
 import app.coronawarn.server.services.distribution.assembly.structure.directory.IndexDirectoryOnDisk;
 import app.coronawarn.server.services.distribution.assembly.tracewarnings.TraceTimeIntervalWarningsPackageBundler;
-import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.decorator.HourIntervalIndexingV1Decorator;
 import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.decorator.HourIntervalIndexingV2Decorator;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import java.util.Optional;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class TraceTimeIntervalWarningsCountryDirectory extends IndexDirectoryOnDisk<String> {
+public class TraceTimeIntervalWarningsCountryV2Directory extends IndexDirectoryOnDisk<String> {
 
-  private static final String VERSION_V2 = "v2";
-  private static final String VERSION_V1 = "v1";
-  private final String version;
   protected final TraceTimeIntervalWarningsPackageBundler traceWarningsBundler;
   private final CryptoProvider cryptoProvider;
   private final DistributionServiceConfig distributionServiceConfig;
-
-  private static final Logger logger = LoggerFactory.getLogger(TraceTimeIntervalWarningsCountryDirectory.class);
 
   /**
    * Creates an instance of the custom directory that includes the entire {@link TraceTimeIntervalWarning} package
    * structure for a country as per the API specification.
    */
-  public TraceTimeIntervalWarningsCountryDirectory(
+  public TraceTimeIntervalWarningsCountryV2Directory(
       TraceTimeIntervalWarningsPackageBundler traceWarningsBundler, CryptoProvider cryptoProvider,
-      DistributionServiceConfig distributionServiceConfig, String version) {
+      DistributionServiceConfig distributionServiceConfig) {
     super(distributionServiceConfig.getApi().getCountryPath(),
         ignoredValue -> Set.of(distributionServiceConfig.getApi().getOriginCountry()),
         Object::toString);
     this.traceWarningsBundler = traceWarningsBundler;
     this.cryptoProvider = cryptoProvider;
     this.distributionServiceConfig = distributionServiceConfig;
-    this.version = version;
+
   }
 
   @Override
   public void prepare(ImmutableStack<Object> indices) {
-    if (this.version.equals(VERSION_V1)) {
-      this.addWritableToAll(ignoredValue -> Optional
-          .of(decorateV1HourDirectory(
-              new TraceTimeIntervalWarningsHourV1Directory(traceWarningsBundler, cryptoProvider,
-                  distributionServiceConfig)
-          )));
-    } else if (this.version.equals(VERSION_V2)) {
-      logger.debug("Preparing encrypted checkins for version {}", this.version);
-      this.addWritableToAll(ignoredValue -> Optional
-          .of(decorateV2HourDirectory(
-              new TraceTimeIntervalWarningsHourV2Directory(traceWarningsBundler, cryptoProvider,
-                  distributionServiceConfig)
-          )));
-    }
+    this.addWritableToAll(ignoredValue -> Optional
+        .of(decorateV2HourDirectory(
+            new TraceTimeIntervalWarningsHourV2Directory(traceWarningsBundler, cryptoProvider,
+                distributionServiceConfig)
+        )));
     super.prepare(indices);
-
   }
-
-  /**
-   * Decorate v1 directory.
-   *
-   * @param hourDirectory the directory to decorate.
-   * @deprecated because trace time warnings are being replaced by protected reports.
-   */
-  @Deprecated(since = "2.8")
-  private IndexDirectory<Integer, WritableOnDisk> decorateV1HourDirectory(
-      TraceTimeIntervalWarningsHourV1Directory hourDirectory) {
-    return new HourIntervalIndexingV1Decorator(hourDirectory, traceWarningsBundler, distributionServiceConfig);
-  }
-
 
   private IndexDirectory<Integer, WritableOnDisk> decorateV2HourDirectory(
       TraceTimeIntervalWarningsHourV2Directory hourDirectory) {

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/decorator/HourIntervalIndexingDecoratorTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/decorator/HourIntervalIndexingDecoratorTest.java
@@ -11,7 +11,7 @@ import app.coronawarn.server.common.shared.util.TimeUtils;
 import app.coronawarn.server.services.distribution.assembly.component.CryptoProvider;
 import app.coronawarn.server.services.distribution.assembly.structure.file.FileOnDisk;
 import app.coronawarn.server.services.distribution.assembly.tracewarnings.TraceTimeIntervalWarningsPackageBundler;
-import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.TraceTimeIntervalWarningsHourV1Directory;
+import app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.v1.TraceTimeIntervalWarningsHourV1Directory;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig.Api;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/integration/TraceTimeIntervalWarningsDistributionIT.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/integration/TraceTimeIntervalWarningsDistributionIT.java
@@ -116,15 +116,17 @@ class TraceTimeIntervalWarningsDistributionIT {
     // then
     Set<String> expectedPaths = new java.util.HashSet<>(
         Set.of(PARENT_DIRECTORY, StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION, "v1", "twp"),
-            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION,"v1", "twp", "country"),
-            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION,"v1", "twp", "country", "DE"),
-            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION,"v1", "twp", "country", "DE", "hour"),
-            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION,"v1", "twp", "country", "index"),
-            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION,"v1", "twp", "country", "index.checksum"),
-            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION,"v1", "twp", "country", "DE", "hour", "index"),
-            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION,"v1", "twp", "country", "DE", "hour", "index.checksum")));
+            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION, "v1", "twp", "country"),
+            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION, "v1", "twp", "country", "DE"),
+            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION, "v1", "twp", "country", "DE", "hour"),
+            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION, "v1", "twp", "country", "index"),
+            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION, "v1", "twp", "country", "index.checksum"),
+            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION, "v1", "twp", "country", "DE", "hour", "index"),
+            StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION, "v1", "twp", "country", "DE", "hour",
+                "index.checksum")));
     IntStream.range(oldestHour, latestHour + 1).forEach(hour -> {
-      expectedPaths.add(StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION, "v1", "twp", "country", "DE", "hour", hour));
+      expectedPaths
+          .add(StringUtils.joinWith(separator, PARENT_DIRECTORY, VERSION, "v1", "twp", "country", "DE", "hour", hour));
     });
     Set<String> actualFiles = Helpers.getSubFoldersPaths(tempFolder.getRoot().getAbsolutePath(), PARENT_DIRECTORY);
     actualFiles.addAll(Helpers.getFilePaths(tempFolder.getRoot(), tempFolder.getRoot().getAbsolutePath()));
@@ -168,12 +170,10 @@ class TraceTimeIntervalWarningsDistributionIT {
     // - add all to the test parent folder
     final Directory<WritableOnDisk> traceWarningsDirectory = traceTimeIntervalWarningsStructureProvider
         .getCheckInProtectedReportsDirectory();
+
     final Directory<WritableOnDisk> directory = outputDirectoryProvider.getDirectory();
     directory.addWritable(traceWarningsDirectory);
 
-    // Prepare indices.
-    // In this case push the version ("v2" for encrypted checkins) onto the indices to indicate that the root starts with "v2".
-    // This is needed for the correct handling of the version.
     ImmutableStack<Object> indices = new ImmutableStack<>();
     indices = indices.push("v2");
     directory.prepare(indices);


### PR DESCRIPTION
- outputfile name for index files should NOT be index-v2 because then the index file cannot be accessed anymore
- This PR removes the outputfile name index-v2 when creating indices