### PR TITLE
fix: use correct length attributes for encrypted check in validation

### DIFF
--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/checkins/EventCheckInProtectedReportsValidator.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/checkins/EventCheckInProtectedReportsValidator.java
@@ -10,6 +10,10 @@ import org.springframework.util.ObjectUtils;
 @Component
 public class EventCheckInProtectedReportsValidator {
 
+  public static final int INIT_VECTOR_LENGTH = 16;
+  public static final int LOCATION_ID_HASH_LENGTH = 32;
+  public static final int ENCRYPTED_CHECK_IN_RECORD_LENGTH = 16;
+
   /**
    * Given the submission payload, it verifies whether user event checkInProtectedReports data is aligned with the
    * application constraints. For each checkInProtectedReports:
@@ -29,7 +33,7 @@ public class EventCheckInProtectedReportsValidator {
   boolean verifyLocationIdHashLength(CheckInProtectedReport checkInProtectedReport,
       ConstraintValidatorContext validatorContext) {
     if (ObjectUtils.isEmpty(checkInProtectedReport.getLocationIdHash())
-        || checkInProtectedReport.getLocationIdHash().size() != 32) {
+        || checkInProtectedReport.getLocationIdHash().size() != LOCATION_ID_HASH_LENGTH) {
       addViolation(validatorContext, "CheckInProtectedReports locationIdHash must have 32 bytes not "
           + (checkInProtectedReport.getLocationIdHash() == null ? 0
           : checkInProtectedReport.getLocationIdHash().size()));
@@ -41,7 +45,7 @@ public class EventCheckInProtectedReportsValidator {
   boolean verifyIvLength(CheckInProtectedReport checkInProtectedReport,
       ConstraintValidatorContext validatorContext) {
     if (ObjectUtils.isEmpty(checkInProtectedReport.getIv())
-        || checkInProtectedReport.getIv().size() != 32) {
+        || checkInProtectedReport.getIv().size() != INIT_VECTOR_LENGTH) {
       addViolation(validatorContext, "CheckInProtectedReports iv must have 32 bytes not "
           + (checkInProtectedReport.getIv() == null ? 0 : checkInProtectedReport.getIv().size()));
       return false;
@@ -52,7 +56,7 @@ public class EventCheckInProtectedReportsValidator {
   boolean verifyEncryptedCheckInRecordLength(CheckInProtectedReport checkInProtectedReport,
       ConstraintValidatorContext validatorContext) {
     if (ObjectUtils.isEmpty(checkInProtectedReport.getEncryptedCheckInRecord())
-        || checkInProtectedReport.getEncryptedCheckInRecord().size() != 16) {
+        || checkInProtectedReport.getEncryptedCheckInRecord().size() != ENCRYPTED_CHECK_IN_RECORD_LENGTH) {
       addViolation(validatorContext, "CheckInProtectedReports encryptedCheckInRecord must have 16 bytes not "
           + (checkInProtectedReport.getEncryptedCheckInRecord() == null ? 0
           : checkInProtectedReport.getEncryptedCheckInRecord().size()));

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/checkins/EventCheckInProtectedReportsValidatorTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/checkins/EventCheckInProtectedReportsValidatorTest.java
@@ -48,7 +48,7 @@ public class EventCheckInProtectedReportsValidatorTest {
                 .setEncryptedCheckInRecord(ByteString
                     .copyFrom(generateSecureRandomByteArrayData(16)))
                 .setIv(ByteString
-                    .copyFrom(generateSecureRandomByteArrayData(32)))
+                    .copyFrom(generateSecureRandomByteArrayData(16)))
                 .setLocationIdHash(ByteString
                     .copyFrom(generateSecureRandomByteArrayData(32)))
                 .build()))
@@ -85,7 +85,7 @@ public class EventCheckInProtectedReportsValidatorTest {
   @Test
   void verifyIvLengthIsTrue() {
     CheckInProtectedReport checkInProtectedReport = CheckInProtectedReport.newBuilder().setIv(
-        ByteString.copyFrom(generateSecureRandomByteArrayData(32))).build();
+        ByteString.copyFrom(generateSecureRandomByteArrayData(16))).build();
 
     boolean result = underTest.verifyIvLength(checkInProtectedReport, mockValidatorContext);
     assertThat(result).isTrue();
@@ -127,7 +127,7 @@ public class EventCheckInProtectedReportsValidatorTest {
   private static Stream<Arguments> generateWrongLengthByteStrings() {
     return Stream.of(
         Arguments.of(ByteString.copyFrom(generateSecureRandomByteArrayData(100))),
-        Arguments.of(ByteString.copyFrom(generateSecureRandomByteArrayData(0))),
+        Arguments.of(ByteString.copyFrom(generateSecureRandomByteArrayData(33))),
         Arguments.of(ByteString.EMPTY));
   }
 

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/integration/DataHelpers.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/integration/DataHelpers.java
@@ -57,7 +57,7 @@ public class DataHelpers {
 
   public static CheckInProtectedReport buildDefaultEncryptedCheckIn() {
     return buildEncryptedCheckIn(ByteString.copyFrom(generateSecureRandomByteArrayData(16)),
-        ByteString.copyFrom(generateSecureRandomByteArrayData(32)),
+        ByteString.copyFrom(generateSecureRandomByteArrayData(16)),
         ByteString.copyFrom(generateSecureRandomByteArrayData(32)));
   }
 


### PR DESCRIPTION
- uses the correct length according to the spec https://github.com/corona-warn-app/cwa-app-tech-spec/pull/87/files#diff-b5b7febc8f64577750ae7bbe6cc6fc1aeffdec9d8b318556523861b1d82327e5R255