### PR TITLE
Fix booster notification single rule

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/BoosterNotificationStructureProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/BoosterNotificationStructureProvider.java
@@ -11,7 +11,6 @@ import app.coronawarn.server.services.distribution.assembly.structure.file.FileO
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.dgc.DigitalGreenCertificateToCborMapping;
 import app.coronawarn.server.services.distribution.dgc.client.DigitalCovidCertificateClient;
-import app.coronawarn.server.services.distribution.dgc.client.ProdDigitalCovidCertificateClient;
 import app.coronawarn.server.services.distribution.dgc.exception.DigitalCovidCertificateException;
 import app.coronawarn.server.services.distribution.dgc.exception.FetchBusinessRulesException;
 import org.slf4j.Logger;
@@ -38,7 +37,6 @@ public class BoosterNotificationStructureProvider {
   /**
    * Create an instance.
    */
-
   public BoosterNotificationStructureProvider(DistributionServiceConfig distributionServiceConfig,
       CryptoProvider cryptoProvider, DigitalGreenCertificateToCborMapping dgcToCborMapping,
       DigitalCovidCertificateClient digitalCovidCertificateClient) {
@@ -58,8 +56,7 @@ public class BoosterNotificationStructureProvider {
 
   /**
    * Create business rules Archive. If any exception is thrown during fetching data and packaging process, an empty
-   * Archive will be published in order to not override any previous archive on CDN with broken data. Provided rules are
-   * filtered by rule type parameter which could be 'Acceptance', 'Invalidation' or 'BoosterNotification'.
+   * Archive will be published in order to not override any previous archive on CDN with broken data.
    *
    * @param archiveName - archive name for packaging rules
    * @return - business rules archive
@@ -71,7 +68,7 @@ public class BoosterNotificationStructureProvider {
           .addWritable(new FileOnDisk(EXPORT_BINARY_FILENAME,
               dgcToCborMapping
                   .constructCborRules(BoosterNotification, digitalCovidCertificateClient::getBoosterNotificationRules,
-                      digitalCovidCertificateClient::getBnRuleByHash)));
+                      digitalCovidCertificateClient::getBoosterNotificationRuleByHash)));
       logger.info(archiveName + " archive has been added to the DGC distribution folder");
     } catch (DigitalCovidCertificateException e) {
       logger.error(archiveName + " archive was not overwritten because of:", e);

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/BoosterNotificationStructureProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/BoosterNotificationStructureProvider.java
@@ -9,6 +9,7 @@ import app.coronawarn.server.services.distribution.assembly.structure.file.FileO
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.dgc.BusinessRule.RuleType;
 import app.coronawarn.server.services.distribution.dgc.DigitalGreenCertificateToCborMapping;
+import app.coronawarn.server.services.distribution.dgc.client.ProdDigitalCovidCertificateClient;
 import app.coronawarn.server.services.distribution.dgc.exception.DigitalCovidCertificateException;
 import app.coronawarn.server.services.distribution.dgc.exception.FetchBusinessRulesException;
 import org.slf4j.Logger;
@@ -30,15 +31,18 @@ public class BoosterNotificationStructureProvider {
   private final DistributionServiceConfig distributionServiceConfig;
   private final CryptoProvider cryptoProvider;
   private final DigitalGreenCertificateToCborMapping dgcToCborMapping;
-
+  private final ProdDigitalCovidCertificateClient digitalCovidCertificateClient;
   /**
    * Create an instance.
    */
+
   public BoosterNotificationStructureProvider(DistributionServiceConfig distributionServiceConfig,
-      CryptoProvider cryptoProvider, DigitalGreenCertificateToCborMapping dgcToCborMapping) {
+      CryptoProvider cryptoProvider, DigitalGreenCertificateToCborMapping dgcToCborMapping,
+      ProdDigitalCovidCertificateClient digitalCovidCertificateClient) {
     this.distributionServiceConfig = distributionServiceConfig;
     this.cryptoProvider = cryptoProvider;
     this.dgcToCborMapping = dgcToCborMapping;
+    this.digitalCovidCertificateClient = digitalCovidCertificateClient;
   }
 
   /**
@@ -63,7 +67,7 @@ public class BoosterNotificationStructureProvider {
 
     try {
       rulesArchive
-          .addWritable(new FileOnDisk(EXPORT_BINARY_FILENAME, dgcToCborMapping.constructCborRules(ruleType)));
+          .addWritable(new FileOnDisk(EXPORT_BINARY_FILENAME, dgcToCborMapping.constructCborBnRules(ruleType)));
       logger.info(archiveName + " archive has been added to the DGC distribution folder");
     } catch (DigitalCovidCertificateException e) {
       logger.error(archiveName + " archive was not overwritten because of:", e);

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/BoosterNotificationStructureProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/BoosterNotificationStructureProvider.java
@@ -1,14 +1,16 @@
 package app.coronawarn.server.services.distribution.assembly.component;
 
 
+import static app.coronawarn.server.services.distribution.dgc.BusinessRule.RuleType.BoosterNotification;
+
 import app.coronawarn.server.services.distribution.assembly.structure.Writable;
 import app.coronawarn.server.services.distribution.assembly.structure.WritableOnDisk;
 import app.coronawarn.server.services.distribution.assembly.structure.archive.ArchiveOnDisk;
 import app.coronawarn.server.services.distribution.assembly.structure.archive.decorator.signing.DistributionArchiveSigningDecorator;
 import app.coronawarn.server.services.distribution.assembly.structure.file.FileOnDisk;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
-import app.coronawarn.server.services.distribution.dgc.BusinessRule.RuleType;
 import app.coronawarn.server.services.distribution.dgc.DigitalGreenCertificateToCborMapping;
+import app.coronawarn.server.services.distribution.dgc.client.DigitalCovidCertificateClient;
 import app.coronawarn.server.services.distribution.dgc.client.ProdDigitalCovidCertificateClient;
 import app.coronawarn.server.services.distribution.dgc.exception.DigitalCovidCertificateException;
 import app.coronawarn.server.services.distribution.dgc.exception.FetchBusinessRulesException;
@@ -31,14 +33,15 @@ public class BoosterNotificationStructureProvider {
   private final DistributionServiceConfig distributionServiceConfig;
   private final CryptoProvider cryptoProvider;
   private final DigitalGreenCertificateToCborMapping dgcToCborMapping;
-  private final ProdDigitalCovidCertificateClient digitalCovidCertificateClient;
+  private final DigitalCovidCertificateClient digitalCovidCertificateClient;
+
   /**
    * Create an instance.
    */
 
   public BoosterNotificationStructureProvider(DistributionServiceConfig distributionServiceConfig,
       CryptoProvider cryptoProvider, DigitalGreenCertificateToCborMapping dgcToCborMapping,
-      ProdDigitalCovidCertificateClient digitalCovidCertificateClient) {
+      DigitalCovidCertificateClient digitalCovidCertificateClient) {
     this.distributionServiceConfig = distributionServiceConfig;
     this.cryptoProvider = cryptoProvider;
     this.dgcToCborMapping = dgcToCborMapping;
@@ -49,7 +52,7 @@ public class BoosterNotificationStructureProvider {
    * Returns the publishable archive with Booster Notification Business rules Cbor encoded structures.
    */
   public Writable<WritableOnDisk> getBoosterNotificationRules() {
-    return getBoosterNotificationRulesArchive(RuleType.BoosterNotification,
+    return getBoosterNotificationRulesArchive(
         distributionServiceConfig.getDigitalGreenCertificate().getBoosterNotification());
   }
 
@@ -58,16 +61,17 @@ public class BoosterNotificationStructureProvider {
    * Archive will be published in order to not override any previous archive on CDN with broken data. Provided rules are
    * filtered by rule type parameter which could be 'Acceptance', 'Invalidation' or 'BoosterNotification'.
    *
-   * @param ruleType    - rule type to receive rules for
    * @param archiveName - archive name for packaging rules
    * @return - business rules archive
    */
-  private Writable<WritableOnDisk> getBoosterNotificationRulesArchive(RuleType ruleType, String archiveName) {
+  private Writable<WritableOnDisk> getBoosterNotificationRulesArchive(String archiveName) {
     ArchiveOnDisk rulesArchive = new ArchiveOnDisk(archiveName);
-
     try {
       rulesArchive
-          .addWritable(new FileOnDisk(EXPORT_BINARY_FILENAME, dgcToCborMapping.constructCborBnRules(ruleType)));
+          .addWritable(new FileOnDisk(EXPORT_BINARY_FILENAME,
+              dgcToCborMapping
+                  .constructCborRules(BoosterNotification, digitalCovidCertificateClient::getBoosterNotificationRules,
+                      digitalCovidCertificateClient::getBnRuleByHash)));
       logger.info(archiveName + " archive has been added to the DGC distribution folder");
     } catch (DigitalCovidCertificateException e) {
       logger.error(archiveName + " archive was not overwritten because of:", e);

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/DigitalCertificatesStructureProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/DigitalCertificatesStructureProvider.java
@@ -13,6 +13,7 @@ import app.coronawarn.server.services.distribution.config.DistributionServiceCon
 import app.coronawarn.server.services.distribution.dgc.BusinessRule.RuleType;
 import app.coronawarn.server.services.distribution.dgc.DigitalGreenCertificateToCborMapping;
 import app.coronawarn.server.services.distribution.dgc.DigitalGreenCertificateToProtobufMapping;
+import app.coronawarn.server.services.distribution.dgc.client.DigitalCovidCertificateClient;
 import app.coronawarn.server.services.distribution.dgc.dsc.DigitalSigningCertificatesToProtobufMapping;
 import app.coronawarn.server.services.distribution.dgc.exception.DigitalCovidCertificateException;
 import app.coronawarn.server.services.distribution.dgc.exception.FetchBusinessRulesException;
@@ -44,6 +45,7 @@ public class DigitalCertificatesStructureProvider {
   private final DigitalGreenCertificateToProtobufMapping dgcToProtobufMapping;
   private final DigitalGreenCertificateToCborMapping dgcToCborMapping;
   private final DigitalSigningCertificatesToProtobufMapping digitalSigningCertificatesToProtobufMapping;
+  private final DigitalCovidCertificateClient digitalCovidCertificateClient;
 
   /**
    * Create an instance.
@@ -51,12 +53,14 @@ public class DigitalCertificatesStructureProvider {
   public DigitalCertificatesStructureProvider(DistributionServiceConfig distributionServiceConfig,
       CryptoProvider cryptoProvider, DigitalGreenCertificateToProtobufMapping dgcToProtobufMapping,
       DigitalGreenCertificateToCborMapping dgcToCborMapping,
-      DigitalSigningCertificatesToProtobufMapping digitalSigningCertificatesToProtobufMapping) {
+      DigitalSigningCertificatesToProtobufMapping digitalSigningCertificatesToProtobufMapping,
+      DigitalCovidCertificateClient digitalCovidCertificateClient) {
     this.distributionServiceConfig = distributionServiceConfig;
     this.cryptoProvider = cryptoProvider;
     this.dgcToProtobufMapping = dgcToProtobufMapping;
     this.dgcToCborMapping = dgcToCborMapping;
     this.digitalSigningCertificatesToProtobufMapping = digitalSigningCertificatesToProtobufMapping;
+    this.digitalCovidCertificateClient = digitalCovidCertificateClient;
   }
 
   /**
@@ -144,7 +148,9 @@ public class DigitalCertificatesStructureProvider {
 
     try {
       rulesArchive
-          .addWritable(new FileOnDisk("export.bin", dgcToCborMapping.constructCborRules(ruleType)));
+          .addWritable(new FileOnDisk("export.bin", dgcToCborMapping
+              .constructCborRules(ruleType, digitalCovidCertificateClient::getRules,
+                  digitalCovidCertificateClient::getCountryRuleByHash)));
       logger.info(archiveName + " archive has been added to the DGC distribution folder");
       return Optional.of(new DistributionArchiveSigningDecorator(rulesArchive, cryptoProvider,
           distributionServiceConfig));

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/DigitalGreenCertificateToCborMapping.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/DigitalGreenCertificateToCborMapping.java
@@ -39,7 +39,6 @@ public class DigitalGreenCertificateToCborMapping {
     return digitalCovidCertificateClient.getCountryList();
   }
 
-
   /**
    * Construct business rules retrieved from DCC client for CBOR encoding. Fetched rules are filtered by rule type
    * parameter which could be 'Acceptance' or 'Invalidation' or 'BoosterNotification'.
@@ -82,7 +81,6 @@ public class DigitalGreenCertificateToCborMapping {
     return businessRules;
   }
 
-
   /**
    * CBOR encoding of {@code constructCountryList}.
    */
@@ -90,7 +88,6 @@ public class DigitalGreenCertificateToCborMapping {
       FetchBusinessRulesException {
     return cborEncodeOrElseThrow(constructCountryList());
   }
-
 
   /**
    * CBOR encoding of {@code constructRules}.

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/DigitalGreenCertificateToCborMapping.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/DigitalGreenCertificateToCborMapping.java
@@ -42,14 +42,14 @@ public class DigitalGreenCertificateToCborMapping {
 
   /**
    * Construct business rules retrieved from DCC client for CBOR encoding. Fetched rules are filtered by rule type
-   * parameter.
+   * parameter which could be 'Acceptance' or 'Invalidation' or 'BoosterNotification'.
    *
    * @param ruleType                 the corresponding rule type that is used for creating the business rules.
    * @param businessRuleItemSupplier a functional interface that provides a function that will provide a list of
    *                                 business rule items.
    * @param businessRuleSupplier     a functional interface that provides a function that will provide single business
    *                                 rules.
-   * @return - Booster Notification business rules
+   * @return - list of the constructed business rules.
    * @throws DigitalCovidCertificateException - thrown if json validation schema is not found or the validation fails
    *                                          for a specific rule. This exception will propagate and will stop any
    *                                          archive to be published down in the execution.
@@ -79,7 +79,6 @@ public class DigitalGreenCertificateToCborMapping {
         }
       }
     }
-
     return businessRules;
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/DigitalCovidCertificateClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/DigitalCovidCertificateClient.java
@@ -27,4 +27,6 @@ public interface DigitalCovidCertificateClient {
   List<BusinessRuleItem> getBoosterNotificationRules() throws FetchBusinessRulesException;
 
   BusinessRule getCountryRuleByHash(String country, String hash) throws FetchBusinessRulesException;
+
+  BusinessRule getBnRuleByHash(String hash) throws FetchBusinessRulesException;
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/DigitalCovidCertificateClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/DigitalCovidCertificateClient.java
@@ -26,5 +26,5 @@ public interface DigitalCovidCertificateClient {
 
   BusinessRule getCountryRuleByHash(String country, String hash) throws FetchBusinessRulesException;
 
-  BusinessRule getBnRuleByHash(String country, String hash) throws FetchBusinessRulesException;
+  BusinessRule getBoosterNotificationRuleByHash(String country, String hash) throws FetchBusinessRulesException;
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/DigitalCovidCertificateClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/DigitalCovidCertificateClient.java
@@ -7,12 +7,10 @@ import app.coronawarn.server.services.distribution.dgc.ValueSetMetadata;
 import app.coronawarn.server.services.distribution.dgc.exception.FetchBusinessRulesException;
 import app.coronawarn.server.services.distribution.dgc.exception.FetchValueSetsException;
 import java.util.List;
-import java.util.Optional;
 
 /**
- * This is a wrapper interface retrieving Digital Covid Certificate data.
- * Used to make HTTP request to Digital Covid Certificate server.
- * Used to retrieve mock sample data from classpath.
+ * This is a wrapper interface retrieving Digital Covid Certificate data. Used to make HTTP request to Digital Covid
+ * Certificate server. Used to retrieve mock sample data from classpath.
  */
 public interface DigitalCovidCertificateClient {
 
@@ -28,5 +26,5 @@ public interface DigitalCovidCertificateClient {
 
   BusinessRule getCountryRuleByHash(String country, String hash) throws FetchBusinessRulesException;
 
-  BusinessRule getBnRuleByHash(String hash) throws FetchBusinessRulesException;
+  BusinessRule getBnRuleByHash(String country, String hash) throws FetchBusinessRulesException;
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/DigitalCovidCertificateFeignClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/DigitalCovidCertificateFeignClient.java
@@ -70,10 +70,10 @@ public interface DigitalCovidCertificateFeignClient {
   ResponseEntity<BusinessRule> getCountryRule(@PathVariable String country, @PathVariable String hash);
 
   /**
-   * HTTP GET to return a specific business rule based on its country and hash.
+   * HTTP GET to return a specific business rule based on its hash.
    * @param hash - business rule hash
    */
   @Timed
   @GetMapping(value = "${services.distribution.digital-green-certificate.client.bn-rules-path}/{hash}")
-  ResponseEntity<BusinessRule> getBnRule(@PathVariable String hash);
+  ResponseEntity<BusinessRule> getBoosterNotificationRule(@PathVariable String hash);
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/DigitalCovidCertificateFeignClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/DigitalCovidCertificateFeignClient.java
@@ -58,14 +58,22 @@ public interface DigitalCovidCertificateFeignClient {
   @Timed
   @GetMapping(value = "${services.distribution.digital-green-certificate.client.bn-rules-path}")
   ResponseEntity<List<BusinessRuleItem>> getBoosterNotificationRules();
+
   /**
    * HTTP GET to return a specific business rule based on its country and hash.
    *
    * @param country - business rule country code.
    * @param hash - business rule hash
    */
-
   @Timed
   @GetMapping(value = "${services.distribution.digital-green-certificate.client.rules-path}/{country}/{hash}")
   ResponseEntity<BusinessRule> getCountryRule(@PathVariable String country, @PathVariable String hash);
+
+  /**
+   * HTTP GET to return a specific business rule based on its country and hash.
+   * @param hash - business rule hash
+   */
+  @Timed
+  @GetMapping(value = "${services.distribution.digital-green-certificate.client.bn-rules-path}/{hash}")
+  ResponseEntity<BusinessRule> getBnRule(@PathVariable String hash);
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/ProdDigitalCovidCertificateClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/ProdDigitalCovidCertificateClient.java
@@ -82,6 +82,14 @@ public class ProdDigitalCovidCertificateClient implements DigitalCovidCertificat
         FetchBusinessRulesException::new);
   }
 
+  @Override
+  public BusinessRule getBnRuleByHash(String hash) throws FetchBusinessRulesException {
+    return getResponseAndTreatExceptions(
+        () -> digitalCovidCertificateClient.getBnRule(hash),
+        "country rule",
+        FetchBusinessRulesException::new);
+  }
+
   private <T, E extends ThirdPartyServiceException> T getResponseAndTreatExceptions(
       Supplier<ResponseEntity<T>> responseSupplier,
       String fetchEntityName,

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/ProdDigitalCovidCertificateClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/ProdDigitalCovidCertificateClient.java
@@ -83,10 +83,10 @@ public class ProdDigitalCovidCertificateClient implements DigitalCovidCertificat
   }
 
   @Override
-  public BusinessRule getBnRuleByHash(String hash) throws FetchBusinessRulesException {
+  public BusinessRule getBnRuleByHash(String country, String hash) throws FetchBusinessRulesException {
     return getResponseAndTreatExceptions(
         () -> digitalCovidCertificateClient.getBnRule(hash),
-        "country rule",
+        "bn rule",
         FetchBusinessRulesException::new);
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/ProdDigitalCovidCertificateClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/ProdDigitalCovidCertificateClient.java
@@ -83,9 +83,9 @@ public class ProdDigitalCovidCertificateClient implements DigitalCovidCertificat
   }
 
   @Override
-  public BusinessRule getBnRuleByHash(String country, String hash) throws FetchBusinessRulesException {
+  public BusinessRule getBoosterNotificationRuleByHash(String country, String hash) throws FetchBusinessRulesException {
     return getResponseAndTreatExceptions(
-        () -> digitalCovidCertificateClient.getBnRule(hash),
+        () -> digitalCovidCertificateClient.getBoosterNotificationRule(hash),
         "bn rule",
         FetchBusinessRulesException::new);
   }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/TestDigitalCovidCertificateClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/TestDigitalCovidCertificateClient.java
@@ -141,7 +141,7 @@ public class TestDigitalCovidCertificateClient implements DigitalCovidCertificat
   }
 
   @Override
-  public BusinessRule getBnRuleByHash(String country, String hash) throws FetchBusinessRulesException {
+  public BusinessRule getBoosterNotificationRuleByHash(String country, String hash) throws FetchBusinessRulesException {
     return getBusinessRuleOrThrow("dgc/bn_rule_1.json");
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/TestDigitalCovidCertificateClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/TestDigitalCovidCertificateClient.java
@@ -140,6 +140,11 @@ public class TestDigitalCovidCertificateClient implements DigitalCovidCertificat
     }
   }
 
+  @Override
+  public BusinessRule getBnRuleByHash(String hash) throws FetchBusinessRulesException {
+    return getBusinessRuleOrThrow("dgc/bn_rule_1.json");
+  }
+
   private BusinessRule getBusinessRuleOrThrow(String path) throws FetchBusinessRulesException {
     return readConfiguredJsonOrDefault(resourceLoader, null, path, BusinessRule.class)
         .orElseThrow(() -> new FetchBusinessRulesException("Business rule could not be found on path: " + path));

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/TestDigitalCovidCertificateClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/client/TestDigitalCovidCertificateClient.java
@@ -141,7 +141,7 @@ public class TestDigitalCovidCertificateClient implements DigitalCovidCertificat
   }
 
   @Override
-  public BusinessRule getBnRuleByHash(String hash) throws FetchBusinessRulesException {
+  public BusinessRule getBnRuleByHash(String country, String hash) throws FetchBusinessRulesException {
     return getBusinessRuleOrThrow("dgc/bn_rule_1.json");
   }
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/functions/BusinessRuleItemSupplier.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/functions/BusinessRuleItemSupplier.java
@@ -1,0 +1,11 @@
+package app.coronawarn.server.services.distribution.dgc.functions;
+
+
+import app.coronawarn.server.services.distribution.dgc.exception.FetchBusinessRulesException;
+
+public interface BusinessRuleItemSupplier<T> {
+
+
+  T get() throws FetchBusinessRulesException;
+}
+

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/functions/BusinessRuleSupplier.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/functions/BusinessRuleSupplier.java
@@ -1,0 +1,10 @@
+package app.coronawarn.server.services.distribution.dgc.functions;
+
+
+import app.coronawarn.server.services.distribution.dgc.exception.FetchBusinessRulesException;
+
+public interface BusinessRuleSupplier<R, A, B> {
+
+
+  R get(A a, B b) throws FetchBusinessRulesException;
+}

--- a/services/distribution/src/main/resources/application.yaml
+++ b/services/distribution/src/main/resources/application.yaml
@@ -242,7 +242,7 @@ services:
         country-list-path: ${BUSSINESS_RULES_COUNTRY_LIST_PATH:/countrylist}
         value-sets-path: ${BUSSINESS_RULES_VALUE_SETS_PATH:/valuesets}
         rules-path: ${BUSSINESS_RULES_RULES_PATH:/rules}
-        bn-rules-path: ${BUSSINESS_RULES_BN_RULES_PATH:/rules}
+        bn-rules-path: ${BUSSINESS_RULES_BN_RULES_PATH:/bnrules}
         ssl:
           trust-store: ${DCC_TRUST_STORE:../../docker-compose-test-secrets/dcc_truststore}
           trust-store-password: ${DCC_TRUST_STORE_PASSWORD:123456}

--- a/services/distribution/src/main/resources/dgc/bn_rule_1.json
+++ b/services/distribution/src/main/resources/dgc/bn_rule_1.json
@@ -1,0 +1,97 @@
+{
+  "Identifier": "BNR-DE-3298",
+  "Type": "BoosterNotification",
+  "Country": "DE",
+  "Version": "1.0.0",
+  "SchemaVersion": "1.0.0",
+  "Engine": "CERTLOGIC",
+  "EngineVersion": "1.0.0",
+  "CertificateType": "General",
+  "Description": [
+    {
+      "lang": "en",
+      "desc": "Remember to get your second vaccine shot! Your first vaccination was more than 2 months ago."
+    },
+    {
+      "desc": "Denken Sie an ihre zweite Impfung um ihre Grundimmunisierung abzuschließen! Ihre Erstimpfung war vor mehr als 2 Monaten.",
+      "lang": "de"
+    }
+  ],
+  "ValidFrom": "2021-07-01T00:00:00Z",
+  "ValidTo": "2030-06-01T00:00:00Z",
+  "AffectedFields": [
+
+  ],
+  "Logic": {
+    "and": [
+      {
+        "===": [
+          {
+            "var": "payload.v.0.dn"
+          },
+          1
+        ]
+      },
+      {
+        "===": [
+          {
+            "var": "payload.v.0.sd"
+          },
+          2
+        ]
+      },
+      {
+        "before": [
+          {
+            "plusTime": [
+              {
+                "var": "payload.v.0.dt"
+              },
+              60,
+              "day"
+            ]
+          },
+          {
+            "plusTime": [
+              {
+                "var": "external.validationClock"
+              },
+              0,
+              "day"
+            ]
+          }
+        ]
+      },
+      {
+        "if": [
+          {
+            "var": "payload.r.0"
+          },
+          {
+            "before": [
+              {
+                "plusTime": [
+                  {
+                    "var": "payload.r.0.df"
+                  },
+                  0,
+                  "day"
+                ]
+              },
+              {
+                "plusTime": [
+                  {
+                    "var": "payload.v.0.dt"
+                  },
+                  0,
+                  "day"
+                ]
+              }
+            ]
+          },
+          true
+        ]
+      }
+    ]
+  }
+}

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/component/BoosterNotificationStructureProviderTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/component/BoosterNotificationStructureProviderTest.java
@@ -55,7 +55,7 @@ class BoosterNotificationStructureProviderTest {
   BoosterNotificationStructureProvider underTest;
 
   @Test
-  void should_create_correct_file_structure_for_booster_notification_business_rules() {
+  void shouldCreateCorrectFileStructureForBoosterNotificationBusinessRules() {
     Writable<WritableOnDisk> boosterNotificationRules = underTest.getBoosterNotificationRules();
     boosterNotificationRules.prepare(new ImmutableStack<>());
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/component/DccRulesNotFetchedStructureProviderTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/component/DccRulesNotFetchedStructureProviderTest.java
@@ -3,7 +3,6 @@ package app.coronawarn.server.services.distribution.assembly.component;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import app.coronawarn.server.common.shared.collection.ImmutableStack;
@@ -90,7 +89,7 @@ class DccRulesNotFetchedStructureProviderTest {
   }
 
   @Test
-  void should_not_contain_acceptance_or_invalidation_rules() throws FetchBusinessRulesException {
+  void shouldNotContainAcceptanceOrInvalidationRules() throws FetchBusinessRulesException {
     when(digitalCovidCertificateClient.getRules()).thenThrow(FetchBusinessRulesException.class);
     when(digitalCovidCertificateClient.getCountryList()).thenReturn(Arrays.asList("DE", "RO"));
 
@@ -106,7 +105,7 @@ class DccRulesNotFetchedStructureProviderTest {
   }
 
   @Test
-  void should_contain_empty_acceptance_or_invalidation_rules() throws FetchBusinessRulesException {
+  void shouldContainEmptyAcceptanceOrInvalidationRules() throws FetchBusinessRulesException {
     when(digitalCovidCertificateClient.getRules()).thenReturn(Collections.emptyList());
     when(digitalCovidCertificateClient.getCountryList()).thenReturn(Arrays.asList("DE", "RO"));
 
@@ -124,7 +123,7 @@ class DccRulesNotFetchedStructureProviderTest {
   }
 
   @Test
-  void should_contain_empty_invalidation_rules() throws FetchBusinessRulesException {
+  void shouldContainEmptyInvalidationRules() throws FetchBusinessRulesException {
     BusinessRuleItem businessRuleItem = new BusinessRuleItem();
     businessRuleItem.setHash("test1");
     businessRuleItem.setCountry("test1");
@@ -139,9 +138,9 @@ class DccRulesNotFetchedStructureProviderTest {
     businessRule2.setType(RuleType.Acceptance.name());
 
     when(digitalCovidCertificateClient.getRules()).thenReturn(Arrays.asList(businessRuleItem, businessRuleItem2));
-    when(digitalCovidCertificateClient.getCountryRuleByHash(eq("test1"), eq("test1")))
+    when(digitalCovidCertificateClient.getCountryRuleByHash("test1", "test1"))
         .thenReturn(businessRule);
-    when(digitalCovidCertificateClient.getCountryRuleByHash(eq("test2"), eq("test2")))
+    when(digitalCovidCertificateClient.getCountryRuleByHash("test2", "test2"))
         .thenReturn(businessRule);
     when(digitalCovidCertificateClient.getCountryList()).thenReturn(Arrays.asList("DE", "RO"));
 
@@ -166,7 +165,7 @@ class DccRulesNotFetchedStructureProviderTest {
   private DirectoryOnDisk getStructureProviderDirectory() {
     DigitalCertificatesStructureProvider underTest = new DigitalCertificatesStructureProvider(
         distributionServiceConfig, cryptoProvider, dgcToProtobufMapping,
-        dgcToCborMappingMock, digitalSigningCertificatesToProtobufMapping);
+        dgcToCborMappingMock, digitalSigningCertificatesToProtobufMapping, digitalCovidCertificateClient);
     DirectoryOnDisk digitalGreenCertificates = underTest.getDigitalGreenCertificates();
     digitalGreenCertificates.prepare(new ImmutableStack<>());
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/component/ValueSetsNotFetchedStructureProviderTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/component/ValueSetsNotFetchedStructureProviderTest.java
@@ -8,13 +8,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import app.coronawarn.server.common.shared.collection.ImmutableStack;
-import app.coronawarn.server.services.distribution.assembly.structure.Writable;
 import app.coronawarn.server.services.distribution.assembly.structure.WritableOnDisk;
 import app.coronawarn.server.services.distribution.assembly.structure.directory.Directory;
 import app.coronawarn.server.services.distribution.assembly.structure.directory.DirectoryOnDisk;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.dgc.DigitalGreenCertificateToCborMapping;
 import app.coronawarn.server.services.distribution.dgc.DigitalGreenCertificateToProtobufMapping;
+import app.coronawarn.server.services.distribution.dgc.client.DigitalCovidCertificateClient;
 import app.coronawarn.server.services.distribution.dgc.client.TestDigitalCovidCertificateClient;
 import app.coronawarn.server.services.distribution.dgc.dsc.DigitalSigningCertificatesClient;
 import app.coronawarn.server.services.distribution.dgc.dsc.DigitalSigningCertificatesToProtobufMapping;
@@ -24,7 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,6 +72,9 @@ class ValueSetsNotFetchedStructureProviderTest {
   DigitalSigningCertificatesClient digitalSigningCertificatesClient;
 
   @Autowired
+  DigitalCovidCertificateClient digitalCovidCertificateClient;
+
+  @Autowired
   ResourceLoader resourceLoader;
 
   @Rule
@@ -92,7 +94,7 @@ class ValueSetsNotFetchedStructureProviderTest {
   void should_not_contain_valuesets_if_any_is_not_fetched() throws FetchValueSetsException {
     DigitalCertificatesStructureProvider underTest = new DigitalCertificatesStructureProvider(
         distributionServiceConfig, cryptoProvider, dgcToProtobufMapping, dgcToCborMappingMock,
-        digitalSigningCertificatesToProtobufMapping);
+        digitalSigningCertificatesToProtobufMapping, digitalCovidCertificateClient);
     DirectoryOnDisk digitalGreenCertificates = underTest.getDigitalGreenCertificates();
     digitalGreenCertificates.prepare(new ImmutableStack<>());
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/DigitalGreenCertificateJsonToCborSpringTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/DigitalGreenCertificateJsonToCborSpringTest.java
@@ -40,7 +40,7 @@ class DigitalGreenCertificateJsonToCborSpringTest {
   public static final String ID_ACCEPTANCE_1 = "RR-NL-0000";
   public static final String ID_ACCEPTANCE_2 = "TR-DE-0003";
   public static final String ID_INVALIDATION_1 = "RR-NL-0003";
-  public static final String ID_BN_1 = "RR-NL-0004";
+  public static final String ID_BN_1 = "BNR-DE-3298";
   public static final String RANDOM_STRING = "random_string";
   public static final String DE = "DE";
   public static final String BAD_IDENTIFIER = "BAD-IDENTIFIER";
@@ -63,7 +63,7 @@ class DigitalGreenCertificateJsonToCborSpringTest {
 
   @Test
   void shouldConstructCorrectBnRules() throws DigitalCovidCertificateException, FetchBusinessRulesException {
-    List<BusinessRule> businessRules = digitalGreenCertificateToCborMapping.constructRules(RuleType.BoosterNotification);
+    List<BusinessRule> businessRules = digitalGreenCertificateToCborMapping.constructBnRules(RuleType.BoosterNotification);
 
     assertThat(businessRules).hasSize(1);
     assertThat(businessRules.stream().filter(filterByRuleType(RuleType.BoosterNotification))).hasSize(1);

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/DigitalGreenCertificateJsonToCborSpringTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/DigitalGreenCertificateJsonToCborSpringTest.java
@@ -31,9 +31,7 @@ class DigitalGreenCertificateJsonToCborSpringTest {
   public static final String ID_ACCEPTANCE_2 = "TR-DE-0003";
   public static final String ID_INVALIDATION_1 = "RR-NL-0003";
   public static final String ID_BN_1 = "BNR-DE-3298";
-  public static final String RANDOM_STRING = "random_string";
   public static final String DE = "DE";
-  public static final String BAD_IDENTIFIER = "BAD-IDENTIFIER";
 
   @Autowired
   DistributionServiceConfig distributionServiceConfig;
@@ -60,7 +58,7 @@ class DigitalGreenCertificateJsonToCborSpringTest {
   void shouldConstructCorrectBnRules() throws DigitalCovidCertificateException, FetchBusinessRulesException {
     List<BusinessRule> businessRules = digitalGreenCertificateToCborMapping
         .constructRules(RuleType.BoosterNotification, digitalCovidCertificateClient::getBoosterNotificationRules,
-            digitalCovidCertificateClient::getBnRuleByHash);
+            digitalCovidCertificateClient::getBoosterNotificationRuleByHash);
     assertThat(businessRules).hasSize(1);
     assertThat(businessRules.stream().filter(filterByRuleType(RuleType.BoosterNotification))).hasSize(1);
     assertThat(businessRules.stream().filter(filterByRuleIdentifier(ID_BN_1)).findAny()).isPresent();

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/DigitalGreenCertificateJsonToCborUnitTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/DigitalGreenCertificateJsonToCborUnitTest.java
@@ -45,10 +45,12 @@ class DigitalGreenCertificateJsonToCborUnitTest {
   @Test
   void shouldThrowWhenRuleByHashAndCountryIsNotFetched() throws FetchBusinessRulesException {
     when(digitalCovidCertificateClient.getRules()).thenReturn(Collections.singletonList(mockBusinessRuleItem()));
-    when(digitalCovidCertificateClient.getCountryRuleByHash(any(),any())).thenThrow(FetchBusinessRulesException.class);
+    when(digitalCovidCertificateClient.getCountryRuleByHash(any(), any())).thenThrow(FetchBusinessRulesException.class);
 
     assertThatExceptionOfType(FetchBusinessRulesException.class).isThrownBy(
-        () -> digitalGreenCertificateToCborMapping.constructRules(RuleType.Acceptance));
+        () -> digitalGreenCertificateToCborMapping
+            .constructRules(RuleType.Acceptance, digitalCovidCertificateClient::getRules,
+                digitalCovidCertificateClient::getCountryRuleByHash));
   }
 
   @Test
@@ -57,10 +59,12 @@ class DigitalGreenCertificateJsonToCborUnitTest {
 
     when(resourceLoader.getResource(any())).thenReturn(validationSchema);
     when(digitalCovidCertificateClient.getRules()).thenReturn(Collections.singletonList(mockBusinessRuleItem()));
-    when(digitalCovidCertificateClient.getCountryRuleByHash(any(),any())).thenReturn(mockBusinessRule());
+    when(digitalCovidCertificateClient.getCountryRuleByHash(any(), any())).thenReturn(mockBusinessRule());
 
     DigitalCovidCertificateException exception = assertThrows(DigitalCovidCertificateException.class,
-        () -> digitalGreenCertificateToCborMapping.constructRules(RuleType.Acceptance));
+        () -> digitalGreenCertificateToCborMapping
+            .constructRules(RuleType.Acceptance, digitalCovidCertificateClient::getRules,
+                digitalCovidCertificateClient::getCountryRuleByHash));
     assertThat(exception.getMessage()).contains("is not valid");
   }
 
@@ -70,10 +74,12 @@ class DigitalGreenCertificateJsonToCborUnitTest {
 
     when(resourceLoader.getResource(any())).thenReturn(validationSchema);
     when(digitalCovidCertificateClient.getRules()).thenReturn(Collections.singletonList(mockBusinessRuleItem()));
-    when(digitalCovidCertificateClient.getCountryRuleByHash(any(),any())).thenReturn(mockBusinessRule());
+    when(digitalCovidCertificateClient.getCountryRuleByHash(any(), any())).thenReturn(mockBusinessRule());
 
     DigitalCovidCertificateException exception = assertThrows(DigitalCovidCertificateException.class,
-        () -> digitalGreenCertificateToCborMapping.constructRules(RuleType.Acceptance));
+        () -> digitalGreenCertificateToCborMapping
+            .constructRules(RuleType.Acceptance, digitalCovidCertificateClient::getRules,
+                digitalCovidCertificateClient::getCountryRuleByHash));
     assertThat(exception.getMessage()).contains("could not be found");
   }
 

--- a/services/distribution/src/test/resources/application.yaml
+++ b/services/distribution/src/test/resources/application.yaml
@@ -198,8 +198,8 @@ services:
         base-url: ${BUSSINESS_RULES_BASE_PATH:https://distribution-dfe4f5c711db.dcc-rules.de/}
         country-list-path: ${BUSSINESS_RULES_COUNTRY_LIST_PATH:/countrylist}
         value-sets-path: ${BUSSINESS_RULES_VALUE_SETS_PATH:/valuesets}
-        rules-path: ${BUSSINESS_RULES_PATH:/rules}
-        bn-rules-path: ${BOOSTER_NOTIFICATION_RULES_PATH:/rules}
+        rules-path: ${BUSSINESS_RULES_RULES_PATH:/rules}
+        bn-rules-path: ${BUSSINESS_RULES_BN_RULES_PATH:/bnrules}
         ssl:
           trust-store: ../../docker-compose-test-secrets/dcc_truststore
           trust-store-password: 123456


### PR DESCRIPTION
- refactoring of creating booster notification rules by introducing a more functional approach to avoid duplicated code
- refactored and renamed tests that include this construction of booster notification rules
- NOTE: add the possibility to fetch rules by hash for booster notification (previously fetched via normal rules)