### PR TITLE
remove compile dependency on log4j

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,3 @@ jobs:
       - run:
           command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
           when: always
-
-workflows:
-  circleci:
-    jobs:
-      - build:
-          context: SonarCloud

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-log4j2</artifactId>
+        <version>${spring-boot.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-web</artifactId>
         <version>${spring-boot.version}</version>
         <exclusions>
@@ -192,25 +198,21 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
         <version>${log4j.version}</version>
-        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-jul</artifactId>
         <version>${log4j.version}</version>
-        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
         <version>${log4j.version}</version>
-        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
         <version>${log4j.version}</version>
-        <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/ServerApplication.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/ServerApplication.java
@@ -4,10 +4,8 @@ import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.logging.log4j.LogManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -25,7 +23,7 @@ import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 @ComponentScan({"app.coronawarn.server.common.persistence", "app.coronawarn.server.common.federation.client.hostname",
     "app.coronawarn.server.services.callback", "app.coronawarn.server.common.federation.client"})
 @EnableConfigurationProperties
-public class ServerApplication implements EnvironmentAware, DisposableBean {
+public class ServerApplication implements EnvironmentAware {
 
   static final String DISABLE_SSL_CLIENT_POSTGRES = "disable-ssl-client-postgres";
 
@@ -39,14 +37,6 @@ public class ServerApplication implements EnvironmentAware, DisposableBean {
   @Bean
   TimedAspect timedAspect(MeterRegistry registry) {
     return new TimedAspect(registry);
-  }
-
-  /**
-   * Manual shutdown hook needed to avoid Log4j shutdown issues (see cwa-server/#589).
-   */
-  @Override
-  public void destroy() {
-    LogManager.shutdown();
   }
 
   @Override

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/Application.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/Application.java
@@ -1,20 +1,15 @@
-
-
 package app.coronawarn.server.services.distribution;
 
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfigValidator;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.logging.log4j.LogManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
@@ -34,21 +29,12 @@ import org.springframework.validation.Validator;
 @ComponentScan({"app.coronawarn.server.common.persistence", "app.coronawarn.server.services.distribution",
     "app.coronawarn.server.common.federation.client.hostname"})
 @EnableConfigurationProperties({DistributionServiceConfig.class})
-public class Application implements EnvironmentAware, DisposableBean {
+public class Application implements EnvironmentAware {
 
   private static final Logger logger = LoggerFactory.getLogger(Application.class);
 
   public static void main(String[] args) {
     SpringApplication.run(Application.class);
-  }
-
-  /**
-   * Manual shutdown hook needed to avoid Log4j shutdown issues (see cwa-server/#589).
-   */
-  @Override
-  public void destroy() {
-    logger.info("Shutting down log4j2.");
-    LogManager.shutdown();
   }
 
   @Bean

--- a/services/download/src/main/java/app/coronawarn/server/services/download/Application.java
+++ b/services/download/src/main/java/app/coronawarn/server/services/download/Application.java
@@ -1,13 +1,9 @@
-
-
 package app.coronawarn.server.services.download;
 
 import app.coronawarn.server.services.download.config.DownloadServiceConfigValidator;
-import org.apache.logging.log4j.LogManager;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -26,21 +22,12 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 @ComponentScan({"app.coronawarn.server.common.persistence", "app.coronawarn.server.services.download",
     "app.coronawarn.server.common.federation.client"})
 @EnableConfigurationProperties
-public class Application implements DisposableBean {
+public class Application {
 
   private static final Logger logger = LoggerFactory.getLogger(Application.class);
 
   public static void main(String[] args) {
     SpringApplication.run(Application.class);
-  }
-  
-  /**
-   * Manual shutdown hook needed to avoid Log4j shutdown issues (see cwa-server/#589).
-   */
-  @Override
-  public void destroy() {
-    logger.info("Shutting down log4j2.");
-    LogManager.shutdown();
   }
 
   /**

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/ServerApplication.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/ServerApplication.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.submission;
 
 import app.coronawarn.server.services.submission.config.SubmissionServiceConfigValidator;
@@ -7,10 +5,8 @@ import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.logging.log4j.LogManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -32,7 +28,7 @@ import org.springframework.validation.Validator;
     "app.coronawarn.server.services.submission", "app.coronawarn.server.common.federation.client.hostname"})
 @EnableConfigurationProperties
 @EnableFeignClients
-public class ServerApplication implements EnvironmentAware, DisposableBean {
+public class ServerApplication implements EnvironmentAware {
 
   static final String DISABLE_SSL_CLIENT_POSTGRES = "disable-ssl-client-postgres";
 
@@ -45,14 +41,6 @@ public class ServerApplication implements EnvironmentAware, DisposableBean {
   @Bean
   TimedAspect timedAspect(MeterRegistry registry) {
     return new TimedAspect(registry);
-  }
-
-  /**
-   * Manual shutdown hook needed to avoid Log4j shutdown issues (see cwa-server/#589).
-   */
-  @Override
-  public void destroy() {
-    LogManager.shutdown();
   }
 
   @Bean

--- a/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/Application.java
+++ b/services/upload/src/main/java/app/coronawarn/server/services/federation/upload/Application.java
@@ -1,14 +1,10 @@
-
-
 package app.coronawarn.server.services.federation.upload;
 
 import app.coronawarn.server.services.federation.upload.config.UploadServiceConfig;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.logging.log4j.LogManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -32,7 +28,7 @@ import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
     "app.coronawarn.server.services.federation.upload",
     "app.coronawarn.server.common.federation.client"})
 @EnableConfigurationProperties({UploadServiceConfig.class})
-public class Application implements EnvironmentAware, DisposableBean {
+public class Application implements EnvironmentAware {
 
   private static final Logger logger = LoggerFactory.getLogger(Application.class);
 
@@ -48,12 +44,6 @@ public class Application implements EnvironmentAware, DisposableBean {
     SpringApplication.exit(appContext);
     logger.error("Federation Upload Service terminated abnormally.");
     System.exit(1);
-  }
-
-  @Override
-  public void destroy() {
-    logger.info("Shutting down log4j2.");
-    LogManager.shutdown();
   }
 
   @Override


### PR DESCRIPTION
with #981 we have adjusted log4j config to NOT register shutdown hooks, so the original issue: #589 becomes obsolete and we can remove the compile-time dependency for log4j