### PR TITLE
still group by version, but deliver list of different identifiers

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/CommonCovidLogicArchiveBuilder.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/CommonCovidLogicArchiveBuilder.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -80,17 +81,18 @@ public class CommonCovidLogicArchiveBuilder {
     final DirectoryOnDisk rulesDirectory = new DirectoryOnDisk(
         ObjectUtils.isEmpty(directoryName) ? distributionServiceConfig.getDefaultArchiveName() : directoryName);
 
-    List<BusinessRule> businessRules = getValidBusinessRules(getBusinessRuleItemsFilterByIdentifier());
-    Map<Integer, BusinessRule> filteredBusinessRules = BusinessRule.filterAndSort(businessRules);
+    Collection<BusinessRule> businessRules = getValidBusinessRules(getBusinessRuleItemsFilterByIdentifier());
+    Map<Integer, Collection<BusinessRule>> filteredBusinessRules = BusinessRule.filterAndSort(businessRules);
 
-    List<Archive<WritableOnDisk>> rulesArchives = getCommonCovidLogicArchives(filteredBusinessRules);
+    Collection<Archive<WritableOnDisk>> rulesArchives = getCommonCovidLogicArchives(filteredBusinessRules);
 
     rulesArchives.forEach(rulesDirectory::addWritable);
 
     return Optional.of(rulesDirectory);
   }
 
-  private List<Archive<WritableOnDisk>> getCommonCovidLogicArchives(Map<Integer, BusinessRule> filteredBusinessRules) {
+  private Collection<Archive<WritableOnDisk>> getCommonCovidLogicArchives(
+      Map<Integer, Collection<BusinessRule>> filteredBusinessRules) {
     return filteredBusinessRules
         .keySet()
         .stream()
@@ -110,8 +112,8 @@ public class CommonCovidLogicArchiveBuilder {
         }).collect(Collectors.toList());
   }
 
-  private List<BusinessRule> getValidBusinessRules(List<BusinessRuleItem> businessRulesItems) {
-    List<BusinessRule> businessRules = new ArrayList<>();
+  private Collection<BusinessRule> getValidBusinessRules(Collection<BusinessRuleItem> businessRulesItems) {
+    Collection<BusinessRule> businessRules = new ArrayList<>();
     for (BusinessRuleItem businessRuleItem : businessRulesItems) {
       BusinessRule businessRule = null;
       try {
@@ -136,11 +138,10 @@ public class CommonCovidLogicArchiveBuilder {
     return businessRules;
   }
 
-  private List<BusinessRuleItem> getBusinessRuleItemsFilterByIdentifier() throws FetchBusinessRulesException {
+  private Collection<BusinessRuleItem> getBusinessRuleItemsFilterByIdentifier() throws FetchBusinessRulesException {
     return businessRuleItemSupplier.get().stream()
-        .filter(businessRuleItem ->
-            List.of(distributionServiceConfig.getDigitalGreenCertificate().getCclAllowList())
-                .contains(businessRuleItem.getIdentifier()))
+        .filter(businessRuleItem -> List.of(distributionServiceConfig.getDigitalGreenCertificate().getCclAllowList())
+            .contains(businessRuleItem.getIdentifier()))
         .collect(Collectors.toList());
   }
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/BusinessRuleTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/BusinessRuleTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Test;
 class BusinessRuleTest {
 
   @Test
-  void testFilterAndSortBusinessRuleArray() {
+  void testGroupByMajor() {
     final BusinessRule v1_0_0 = new BusinessRule();
     v1_0_0.setVersion("1.0.0");
 
@@ -24,7 +25,7 @@ class BusinessRuleTest {
     final BusinessRule v2_1_1 = new BusinessRule();
     v2_1_1.setVersion("2.1.1");
 
-    final Map<Integer, BusinessRule> map = BusinessRule.filterAndSort(List.of(v1_0_0, v1_0_5, v1_2_0, v2_0_42, v2_1_1));
+    final Map<Integer, BusinessRule> map = BusinessRule.groupByMajor(List.of(v1_0_0, v1_0_5, v1_2_0, v2_0_42, v2_1_1));
     assertEquals(2, map.size());
     assertEquals(v1_2_0, map.get(1));
     assertEquals(v2_1_1, map.get(2));
@@ -49,4 +50,61 @@ class BusinessRuleTest {
     r2.setVersion("2.0.0");
     assertTrue(r1.isSameMajorVersionButNewer(r2));
   }
+  
+  @Test
+  void testFilterAndSortWithSameIdentifier() {
+    final BusinessRule v1_0_0 = new BusinessRule();
+    v1_0_0.setVersion("1.0.0");
+    v1_0_0.setIdentifier("one");
+
+    final BusinessRule v1_0_5 = new BusinessRule();
+    v1_0_5.setVersion("1.0.5");
+    v1_0_5.setIdentifier("one");
+    
+    final BusinessRule v1_2_0 = new BusinessRule();
+    v1_2_0.setVersion("1.2.0");
+    v1_2_0.setIdentifier("one");
+    
+    final BusinessRule v2_0_42 = new BusinessRule();
+    v2_0_42.setVersion("2.0.42");
+    v2_0_42.setIdentifier("one");
+    
+    final BusinessRule v2_1_1 = new BusinessRule();
+    v2_1_1.setVersion("2.1.1");
+    v2_1_1.setIdentifier("one");
+
+    final Map<Integer, Collection<BusinessRule>> map = BusinessRule.filterAndSort(List.of(v1_0_0, v1_0_5, v1_2_0, v2_0_42, v2_1_1));
+    assertEquals(2, map.size());
+    assertEquals(v1_2_0, map.get(1).iterator().next());
+    assertEquals(v2_1_1, map.get(2).iterator().next());
+  }
+  
+  @Test
+  void testFilterAndSort() {
+    final BusinessRule one_v1_0_0 = new BusinessRule();
+    one_v1_0_0.setVersion("1.0.0");
+    one_v1_0_0.setIdentifier("one");
+
+    final BusinessRule two_v1_0_5 = new BusinessRule();
+    two_v1_0_5.setVersion("1.0.5");
+    two_v1_0_5.setIdentifier("two");
+    
+    final BusinessRule v1_2_0 = new BusinessRule();
+    v1_2_0.setVersion("1.2.0");
+    v1_2_0.setIdentifier("one");
+    
+    final BusinessRule v2_0_42 = new BusinessRule();
+    v2_0_42.setVersion("2.0.42");
+    v2_0_42.setIdentifier("one");
+    
+    final BusinessRule v2_1_1 = new BusinessRule();
+    v2_1_1.setVersion("2.1.1");
+    v2_1_1.setIdentifier("one");
+
+    final Map<Integer, Collection<BusinessRule>> map = BusinessRule.filterAndSort(List.of(one_v1_0_0, two_v1_0_5, v1_2_0, v2_0_42, v2_1_1));
+    assertEquals(2, map.size());
+    assertEquals(2, map.get(1).size());
+    assertEquals(v2_1_1, map.get(2).iterator().next());
+  }
+
 }


### PR DESCRIPTION
cbor should now be a list of rules, where every entry has a different identifier