### PR TITLE
distribution memory consumption optimization

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
@@ -77,12 +77,12 @@ public class DiagnosisKey {
   @ValidCountries
   private final Set<String> visitedCountries;
 
-  private final ReportType reportType;
+  private ReportType reportType;
 
   @Range(min = MIN_DAYS_SINCE_ONSET_OF_SYMPTOMS, max = MAX_DAYS_SINCE_ONSET_OF_SYMPTOMS,
       message = "Days since onset of symptoms value must be between " + MIN_DAYS_SINCE_ONSET_OF_SYMPTOMS + " and "
           + MAX_DAYS_SINCE_ONSET_OF_SYMPTOMS + ".")
-  private final int daysSinceOnsetOfSymptoms;
+  private int daysSinceOnsetOfSymptoms;
 
   /**
    * Should be called by builders.
@@ -99,7 +99,7 @@ public class DiagnosisKey {
     this.submissionTimestamp = submissionTimestamp;
     this.consentToFederation = consentToFederation;
     this.originCountry = originCountry;
-    this.visitedCountries = visitedCountries == null ? new HashSet<>() : visitedCountries;
+    this.visitedCountries = visitedCountries != null && visitedCountries.isEmpty() ? null : visitedCountries;
     this.reportType = reportType;
     // Workaround to avoid exception on loading old DiagnosisKeys after migration to EFGS
     this.daysSinceOnsetOfSymptoms = daysSinceOnsetOfSymptoms == null ? 0 : daysSinceOnsetOfSymptoms;
@@ -165,6 +165,14 @@ public class DiagnosisKey {
     this.transmissionRiskLevel = transmissionRiskLevel;
   }
 
+  public void setReportType(ReportType reportType) {
+    this.reportType = reportType;
+  }
+
+  public void setDaysSinceOnsetOfSymptoms(int daysSinceOnsetOfSymptoms) {
+    this.daysSinceOnsetOfSymptoms = daysSinceOnsetOfSymptoms;
+  }
+
   /**
    * Returns the timestamp associated with the submission of this {@link DiagnosisKey} as hours since epoch.
    *
@@ -183,7 +191,7 @@ public class DiagnosisKey {
   }
 
   public Set<String> getVisitedCountries() {
-    return visitedCountries;
+    return visitedCountries == null ? Collections.emptySet() : visitedCountries;
   }
 
   public ReportType getReportType() {

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
@@ -29,7 +29,7 @@ import org.springframework.data.annotation.Id;
  */
 public class DiagnosisKey {
 
-  public static final long ROLLING_PERIOD_MINUTES_INTERVAL = 10;
+  public static final int ROLLING_PERIOD_MINUTES_INTERVAL = 10;
 
   /**
    * According to "Setting Up an Exposure Notification Server" by Apple, exposure notification servers are expected to
@@ -63,11 +63,11 @@ public class DiagnosisKey {
 
   @Range(min = MIN_TRANSMISSION_RISK_LEVEL, max = MAX_TRANSMISSION_RISK_LEVEL,
       message = "Risk level must be between " + MIN_TRANSMISSION_RISK_LEVEL + " and " + MAX_TRANSMISSION_RISK_LEVEL
-          + ".")
+      + ".")
   private int transmissionRiskLevel;
 
   @ValidSubmissionTimestamp
-  private final long submissionTimestamp;
+  private final int submissionTimestamp;
 
   private final boolean consentToFederation;
 
@@ -81,7 +81,7 @@ public class DiagnosisKey {
 
   @Range(min = MIN_DAYS_SINCE_ONSET_OF_SYMPTOMS, max = MAX_DAYS_SINCE_ONSET_OF_SYMPTOMS,
       message = "Days since onset of symptoms value must be between " + MIN_DAYS_SINCE_ONSET_OF_SYMPTOMS + " and "
-          + MAX_DAYS_SINCE_ONSET_OF_SYMPTOMS + ".")
+      + MAX_DAYS_SINCE_ONSET_OF_SYMPTOMS + ".")
   private int daysSinceOnsetOfSymptoms;
 
   /**
@@ -96,7 +96,7 @@ public class DiagnosisKey {
     this.rollingStartIntervalNumber = rollingStartIntervalNumber;
     this.rollingPeriod = rollingPeriod;
     this.transmissionRiskLevel = transmissionRiskLevel;
-    this.submissionTimestamp = submissionTimestamp;
+    this.submissionTimestamp = (int) submissionTimestamp;
     this.consentToFederation = consentToFederation;
     this.originCountry = originCountry;
     this.visitedCountries = visitedCountries != null && visitedCountries.isEmpty() ? null : visitedCountries;
@@ -178,7 +178,7 @@ public class DiagnosisKey {
    *
    * @return submissionTimestamp
    */
-  public long getSubmissionTimestamp() {
+  public int getSubmissionTimestamp() {
     return submissionTimestamp;
   }
 

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKey.java
@@ -252,11 +252,11 @@ public class DiagnosisKey {
         && rollingPeriod == that.rollingPeriod
         && transmissionRiskLevel == that.transmissionRiskLevel
         && submissionTimestamp == that.submissionTimestamp
-        && Arrays.equals(keyData, that.keyData)
+        && reportType == that.reportType
+        && daysSinceOnsetOfSymptoms == that.daysSinceOnsetOfSymptoms
         && Objects.equals(originCountry, that.originCountry)
         && Objects.equals(visitedCountries, that.visitedCountries)
-        && reportType == that.reportType
-        && daysSinceOnsetOfSymptoms == that.daysSinceOnsetOfSymptoms;
+        && Arrays.equals(keyData, that.keyData);
   }
 
   @Override

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilder.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilder.java
@@ -100,9 +100,9 @@ public class DiagnosisKeyBuilder implements
   }
 
   /**
-   * Try to use smallest (memory) possible Set implementation.  
+   * Try to use smallest (memory) possible Set implementation.
    * 
-   * @param <E> generic
+   * @param <E>        generic
    * @param collection to be turned into Set
    * @return <code>null</code> if collection is null or empty, otherwise a Set
    */
@@ -118,7 +118,12 @@ public class DiagnosisKeyBuilder implements
     }
     if (collection.size() == 2) {
       Iterator<E> it = collection.iterator();
-      return Set.of(it.next(), it.next());
+      E v1 = it.next();
+      E v2 = it.next();
+      if (v1.equals(v2)) {
+        return Set.of(v1);
+      }
+      return Set.of(v1, v2);
     }
 
     final Set<E> set = new HashSet<>(collection.size(), 1f);

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilder.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilder.java
@@ -13,6 +13,7 @@ import app.coronawarn.server.common.protocols.external.exposurenotification.Repo
 import app.coronawarn.server.common.protocols.external.exposurenotification.TemporaryExposureKey;
 import app.coronawarn.server.common.protocols.internal.SubmissionPayload.SubmissionType;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -68,7 +69,8 @@ public class DiagnosisKeyBuilder implements
 
   @Override
   public FinalBuilder fromTemporaryExposureKeyAndMetadata(TemporaryExposureKey protoBufObject,
-      SubmissionType submissionType, List<String> visitedCountries, String originCountry, boolean consentToFederation) {
+      SubmissionType submissionType, Collection<String> visitedCountries, String originCountry,
+      boolean consentToFederation) {
     return this
         .withKeyDataAndSubmissionType(protoBufObject.getKeyData().toByteArray(), submissionType)
         .withRollingStartIntervalNumber(protoBufObject.getRollingStartIntervalNumber())

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilders.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilders.java
@@ -1,12 +1,10 @@
-
-
 package app.coronawarn.server.common.persistence.domain;
 
 import app.coronawarn.server.common.persistence.domain.normalization.DiagnosisKeyNormalizer;
 import app.coronawarn.server.common.protocols.external.exposurenotification.ReportType;
 import app.coronawarn.server.common.protocols.external.exposurenotification.TemporaryExposureKey;
 import app.coronawarn.server.common.protocols.internal.SubmissionPayload.SubmissionType;
-import java.util.List;
+import java.util.Collection;
 import java.util.Set;
 
 /**
@@ -37,7 +35,7 @@ interface DiagnosisKeyBuilders {
      * @return this Builder instance.
      */
     FinalBuilder fromTemporaryExposureKeyAndMetadata(TemporaryExposureKey protoBufObject,
-        SubmissionType submissionType, List<String> visitedCountries, String originCountry,
+        SubmissionType submissionType, Collection<String> visitedCountries, String originCountry,
         boolean consentToFederation);
 
     /**

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/validation/ValidSubmissionTimestampValidator.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/validation/ValidSubmissionTimestampValidator.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.common.persistence.domain.validation;
 
 import java.time.Instant;
@@ -8,13 +6,13 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 public class ValidSubmissionTimestampValidator
-    implements ConstraintValidator<ValidSubmissionTimestamp, Long> {
+    implements ConstraintValidator<ValidSubmissionTimestamp, Integer> {
 
   public static final long SECONDS_PER_HOUR = TimeUnit.HOURS.toSeconds(1);
 
   @Override
-  public boolean isValid(Long submissionTimestamp, ConstraintValidatorContext constraintValidatorContext) {
+  public boolean isValid(Integer submissionTimestamp, ConstraintValidatorContext constraintValidatorContext) {
     long currentHoursSinceEpoch = Instant.now().getEpochSecond() / SECONDS_PER_HOUR;
-    return submissionTimestamp >= 0L && submissionTimestamp <= currentHoursSinceEpoch;
+    return submissionTimestamp >= 0 && submissionTimestamp <= currentHoursSinceEpoch;
   }
 }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilderTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyBuilderTest.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.common.persistence.domain;
 
 import static app.coronawarn.server.common.persistence.domain.validation.ValidSubmissionTimestampValidator.SECONDS_PER_HOUR;
@@ -7,6 +5,8 @@ import static app.coronawarn.server.common.persistence.service.DiagnosisKeyServi
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import app.coronawarn.server.common.persistence.exception.InvalidDiagnosisKeyException;
 import app.coronawarn.server.common.protocols.external.exposurenotification.ReportType;
@@ -18,6 +18,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -174,7 +175,7 @@ class DiagnosisKeyBuilderTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {4200, 441552})
+  @ValueSource(ints = { 4200, 441552 })
   void rollingStartIntervalNumberDoesNotThrowForValid(int validRollingStartIntervalNumber) {
     assertThatCode(() -> keyWithRollingStartIntervalNumber(validRollingStartIntervalNumber)).doesNotThrowAnyException();
   }
@@ -227,7 +228,7 @@ class DiagnosisKeyBuilderTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"DER", "xx", "De", "dE", "DE,FRE", ""})
+  @ValueSource(strings = { "DER", "xx", "De", "dE", "DE,FRE", "" })
   void failsForInvalidOriginCountry(String countryCode) {
     assertThat(
         catchThrowable(() -> DiagnosisKey.builder()
@@ -241,7 +242,7 @@ class DiagnosisKeyBuilderTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"DER", "xx", "De", "dE", "DE,FRE", ""})
+  @ValueSource(strings = { "DER", "xx", "De", "dE", "DE,FRE", "" })
   void failsForInvalidVisitedCountries(String visitedCountries) {
     assertThat(
         catchThrowable(() -> DiagnosisKey.builder()
@@ -257,7 +258,7 @@ class DiagnosisKeyBuilderTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {DiagnosisKey.MIN_TRANSMISSION_RISK_LEVEL - 1, DiagnosisKey.MAX_TRANSMISSION_RISK_LEVEL + 1})
+  @ValueSource(ints = { DiagnosisKey.MIN_TRANSMISSION_RISK_LEVEL - 1, DiagnosisKey.MAX_TRANSMISSION_RISK_LEVEL + 1 })
   void transmissionRiskLevelMustBeInRange(int invalidRiskLevel) {
     assertThat(catchThrowable(() -> keyWithRiskLevel(invalidRiskLevel)))
         .isInstanceOf(InvalidDiagnosisKeyException.class)
@@ -267,13 +268,13 @@ class DiagnosisKeyBuilderTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {DiagnosisKey.MIN_TRANSMISSION_RISK_LEVEL, DiagnosisKey.MAX_TRANSMISSION_RISK_LEVEL})
+  @ValueSource(ints = { DiagnosisKey.MIN_TRANSMISSION_RISK_LEVEL, DiagnosisKey.MAX_TRANSMISSION_RISK_LEVEL })
   void transmissionRiskLevelDoesNotThrowForValid(int validRiskLevel) {
     assertThatCode(() -> keyWithRiskLevel(validRiskLevel)).doesNotThrowAnyException();
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {-15, -17, 4001})
+  @ValueSource(ints = { -15, -17, 4001 })
   void daysSinceOnsetSymptomsMustBeInRange(int invalidDsos) {
     assertThat(catchThrowable(() -> keyWithDsos(invalidDsos)))
         .isInstanceOf(InvalidDiagnosisKeyException.class)
@@ -282,13 +283,13 @@ class DiagnosisKeyBuilderTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {0, 8, -14, 3986})
+  @ValueSource(ints = { 0, 8, -14, 3986 })
   void daysSinceOnsetSymptomsValidationDoesNotThrowForValid(int validDsos) {
     assertThatCode(() -> keyWithDsos(validDsos)).doesNotThrowAnyException();
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {-3, 145})
+  @ValueSource(ints = { -3, 145 })
   void rollingPeriodMustBeExpectedValue(int invalidRollingPeriod) {
     assertThat(catchThrowable(() -> keyWithRollingPeriod(invalidRollingPeriod)))
         .isInstanceOf(InvalidDiagnosisKeyException.class)
@@ -298,17 +299,17 @@ class DiagnosisKeyBuilderTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {DiagnosisKey.MIN_ROLLING_PERIOD, 100, DiagnosisKey.MAX_ROLLING_PERIOD})
+  @ValueSource(ints = { DiagnosisKey.MIN_ROLLING_PERIOD, 100, DiagnosisKey.MAX_ROLLING_PERIOD })
   void rollingPeriodDoesNotThrowForValid(int validRollingPeriod) {
     assertThatCode(() -> keyWithRollingPeriod(validRollingPeriod)).doesNotThrowAnyException();
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"17--bytelongarray", "", "1"})
+  @ValueSource(strings = { "17--bytelongarray", "", "1" })
   void keyDataMustHaveValidLength(String invalidKeyString) {
     assertThat(
         catchThrowable(() -> keyWithKeyData(invalidKeyString.getBytes(StandardCharsets.US_ASCII))))
-        .isInstanceOf(InvalidDiagnosisKeyException.class);
+            .isInstanceOf(InvalidDiagnosisKeyException.class);
   }
 
   @Test
@@ -318,21 +319,21 @@ class DiagnosisKeyBuilderTest {
   }
 
   @ParameterizedTest
-  @ValueSource(longs = {-1L, Long.MAX_VALUE})
+  @ValueSource(longs = { -1L, Long.MAX_VALUE })
   void submissionTimestampMustBeValid(long submissionTimestamp) {
     assertThat(
         catchThrowable(() -> buildDiagnosisKeyForSubmissionTimestamp(submissionTimestamp)))
-        .isInstanceOf(InvalidDiagnosisKeyException.class);
+            .isInstanceOf(InvalidDiagnosisKeyException.class);
   }
 
   @Test
   void submissionTimestampMustNotBeInTheFuture() {
     assertThat(catchThrowable(
         () -> buildDiagnosisKeyForSubmissionTimestamp(getCurrentHoursSinceEpoch() + 1)))
-        .isInstanceOf(InvalidDiagnosisKeyException.class);
+            .isInstanceOf(InvalidDiagnosisKeyException.class);
     assertThat(catchThrowable(() -> buildDiagnosisKeyForSubmissionTimestamp(
         Instant.now().getEpochSecond() /* accidentally forgot to divide by SECONDS_PER_HOUR */)))
-        .isInstanceOf(InvalidDiagnosisKeyException.class);
+            .isInstanceOf(InvalidDiagnosisKeyException.class);
   }
 
   @Test
@@ -343,7 +344,7 @@ class DiagnosisKeyBuilderTest {
     assertThatCode(
         () -> buildDiagnosisKeyForSubmissionTimestamp(
             Instant.now().minus(Duration.ofHours(2)).getEpochSecond() / SECONDS_PER_HOUR, 144, false))
-        .doesNotThrowAnyException();
+                .doesNotThrowAnyException();
   }
 
   @Test
@@ -455,10 +456,6 @@ class DiagnosisKeyBuilderTest {
     assertDiagnosisKeyEquals(actDiagnosisKey, getCurrentHoursSinceEpoch());
   }
 
-  private long getCurrentHoursSinceEpoch() {
-    return Instant.now().getEpochSecond() / SECONDS_PER_HOUR;
-  }
-
   private void assertDiagnosisKeyEquals(DiagnosisKey actDiagnosisKey, long expSubmissionTimestamp) {
     assertThat(actDiagnosisKey.getKeyData()).isEqualTo(expKeyData);
     assertThat(actDiagnosisKey.getSubmissionType()).isEqualTo(expSubmissionType);
@@ -471,5 +468,39 @@ class DiagnosisKeyBuilderTest {
     assertThat(actDiagnosisKey.isConsentToFederation()).isEqualTo(expConsentToFederation);
     assertThat(actDiagnosisKey.getOriginCountry()).isEqualTo(originCountry);
     assertThat(actDiagnosisKey.getVisitedCountries()).isEqualTo(visitedCountries);
+  }
+
+  private long getCurrentHoursSinceEpoch() {
+    return Instant.now().getEpochSecond() / SECONDS_PER_HOUR;
+  }
+
+  @Test
+  void testCollectionToTinySet() {
+    assertNull(DiagnosisKeyBuilder.collectionToTinySet(null));
+    assertNull(DiagnosisKeyBuilder.collectionToTinySet(Collections.emptyList()));
+    assertNull(DiagnosisKeyBuilder.collectionToTinySet(Collections.emptySet()));
+    Set<Integer> set = new HashSet<>(Set.of(1, 2, 3, 4));
+    assertEquals(set, DiagnosisKeyBuilder.collectionToTinySet(set));
+
+    assertEquals("java.util.ImmutableCollections$Set12",
+        DiagnosisKeyBuilder.collectionToTinySet(Collections.singletonList(1)).getClass().getName());
+
+    List<Integer> list = List.of(1, 2);
+    assertEquals("java.util.ImmutableCollections$Set12",
+        DiagnosisKeyBuilder.collectionToTinySet(list).getClass().getName());
+    assertEquals(2,
+        DiagnosisKeyBuilder.collectionToTinySet(list).size());
+
+    List<Integer> one = List.of(1, 1);
+    assertEquals("java.util.ImmutableCollections$Set12",
+        DiagnosisKeyBuilder.collectionToTinySet(one).getClass().getName());
+    assertEquals(1,
+        DiagnosisKeyBuilder.collectionToTinySet(one).size());
+
+    List<Integer> roomForImproovement = List.of(1, 1, 1, 1);
+    assertEquals("java.util.HashSet",
+        DiagnosisKeyBuilder.collectionToTinySet(roomForImproovement).getClass().getName());
+    assertEquals(1,
+        DiagnosisKeyBuilder.collectionToTinySet(roomForImproovement).size());
   }
 }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/domain/DiagnosisKeyTest.java
@@ -1,11 +1,12 @@
-
-
 package app.coronawarn.server.common.persistence.domain;
 
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import app.coronawarn.server.common.protocols.external.exposurenotification.ReportType;
 import app.coronawarn.server.common.protocols.internal.SubmissionPayload.SubmissionType;
@@ -72,7 +73,7 @@ class DiagnosisKeyTest {
   }
 
   @DisplayName("Test retention threshold accepts positive value")
-  @ValueSource(ints = {0, 1, Integer.MAX_VALUE})
+  @ValueSource(ints = { 0, 1, Integer.MAX_VALUE })
   @ParameterizedTest
   void testRetentionThresholdAcceptsPositiveValue(int daysToRetain) {
     assertThatCode(() -> diagnosisKey.isYoungerThanRetentionThreshold(daysToRetain))
@@ -80,10 +81,43 @@ class DiagnosisKeyTest {
   }
 
   @DisplayName("Test retention threshold rejects negative value")
-  @ValueSource(ints = {Integer.MIN_VALUE, -1})
+  @ValueSource(ints = { Integer.MIN_VALUE, -1 })
   @ParameterizedTest
   void testRetentionThresholdRejectsNegativeValue(int daysToRetain) {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> diagnosisKey.isYoungerThanRetentionThreshold(daysToRetain));
+  }
+
+  @Test
+  void testSetTransmissionRiskLevel() {
+    diagnosisKey.setTransmissionRiskLevel(0);
+  }
+
+  @Test
+  void testSetReportType() {
+    diagnosisKey.setReportType(null);
+  }
+
+  @Test
+  void testSetDaysSinceOnsetOfSymptoms() {
+    diagnosisKey.setDaysSinceOnsetOfSymptoms(0);
+  }
+
+  @Test
+  void testGetVisitedCountries() {
+    assertEquals("DE", diagnosisKey.getVisitedCountries().iterator().next());
+  }
+
+  @Test
+  void testEquals() {
+    DiagnosisKey other = new DiagnosisKey("testKey222222222".getBytes(StandardCharsets.US_ASCII), expSubmissionType,
+        expRollingStartIntervalNumber, expRollingPeriod, expTransmissionRiskLevel, expSubmissionTimestamp, false,
+        originCountry, visitedCountries, reportType, daysSinceOnsetOfSymptoms);
+    assertFalse(diagnosisKey.equals(other));
+  }
+
+  @Test
+  void testHashCode() {
+    assertTrue(0 != diagnosisKey.hashCode());
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/transformation/EnfParameterAdapter.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/transformation/EnfParameterAdapter.java
@@ -3,8 +3,6 @@ package app.coronawarn.server.services.distribution.assembly.transformation;
 import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
 import app.coronawarn.server.services.distribution.config.TransmissionRiskLevelEncoding;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 /**
@@ -33,22 +31,12 @@ public class EnfParameterAdapter {
    * @return updated collection of DiagnosisKey
    */
   public Collection<DiagnosisKey> adaptKeys(Collection<DiagnosisKey> diagnosisKeys) {
-    return diagnosisKeys.stream().map(this::adapt).collect(Collectors.toList());
-  }
+    diagnosisKeys.forEach(k -> {
+      k.setReportType(trlEncoding.getReportTypeForTransmissionRiskLevel(k.getTransmissionRiskLevel()));
+      k.setDaysSinceOnsetOfSymptoms(
+          trlEncoding.getDaysSinceSymptomsForTransmissionRiskLevel(k.getTransmissionRiskLevel()));
+    });
 
-  private DiagnosisKey adapt(DiagnosisKey diagnosisKey) {
-    return DiagnosisKey.builder()
-        .withKeyDataAndSubmissionType(diagnosisKey.getKeyData(), diagnosisKey.getSubmissionType())
-        .withRollingStartIntervalNumber(diagnosisKey.getRollingStartIntervalNumber())
-        .withTransmissionRiskLevel(diagnosisKey.getTransmissionRiskLevel())
-        .withRollingPeriod(diagnosisKey.getRollingPeriod())
-        .withCountryCode(diagnosisKey.getOriginCountry())
-        .withReportType(trlEncoding
-            .getReportTypeForTransmissionRiskLevel(diagnosisKey.getTransmissionRiskLevel()))
-        .withVisitedCountries(new HashSet<>(diagnosisKey.getVisitedCountries()))
-        .withConsentToFederation(diagnosisKey.isConsentToFederation())
-        .withDaysSinceOnsetOfSymptoms(trlEncoding
-            .getDaysSinceSymptomsForTransmissionRiskLevel(diagnosisKey.getTransmissionRiskLevel()))
-        .withSubmissionTimestamp(diagnosisKey.getSubmissionTimestamp()).build();
+    return diagnosisKeys;
   }
 }


### PR DESCRIPTION
* use `Collection` wherever possible instead of `List`
* create `HashSet` only if it's really necessary, keep `null` if possible or use Set.of() for 1 and 2 element sets
* when creating `HashSet` use smallest possible solution instead of using the defaults 16/0.75f
* during the ENF parameter adaptation, don't re-create new objects (DiagnosisKey + Builder), but instead manipulate the existing ones