### PR TITLE
chore: allow rc suffix in CCL Version attribute

### DIFF
--- a/common/shared/src/test/resources/dgc/ccl-configuration.json
+++ b/common/shared/src/test/resources/dgc/ccl-configuration.json
@@ -36,7 +36,7 @@
     "Version": {
       "type": "string",
       "description": "Version of the rule (Semver)",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-rc\\.\\d+)?$"
     },
     "SchemaVersion": {
       "type": "string",


### PR DESCRIPTION
relates to https://github.com/corona-warn-app/cwa-app-ccl/commit/4d850cc6a8a1c7e78609ff787b5597f8e9f211cd
relates to https://github.com/corona-warn-app/cwa-server/pull/1719