### PR TITLE
let's give it a try with: cimg/openjdk:11.0 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,14 @@
 version: 2.1
 jobs:
   build:
-    working_directory: ~/cwa-server
-    machine:
-      image: ubuntu-2004:202101-01
-      docker_layer_caching: true
+    docker:
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - run:
-          name: Update to OpenJDK 11
+          name: Check OpenJDK Version
           command: |
-            sudo apt-get install openjdk-11-jre
-            sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
-            java -version
+             java -version
       - run:
           name: Generate cumulative pom.xml checksum
           command: |
@@ -21,16 +17,17 @@ jobs:
           when: always
       - restore_cache:
           key: cwa-server-{{ checksum "~/pom-checksum" }}
-      - run: ./mvnw --batch-mode dependency:go-offline
+      - run: 
+          name: Fetch dependencies
+          command: |
+            ./mvnw --batch-mode dependency:go-offline
       - run:
           name: JUnit Tests, Integration Tests
           command: |
-            export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
             ./mvnw --batch-mode -P integration-test verify --fail-fast
       - run:
           name: Analyze on SonarCloud
           command: |
-            export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
             ./mvnw --batch-mode sonar:sonar --fail-never
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,14 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/base:stable-LTS
     steps:
       - checkout
       - run:
           name: Check OpenJDK Version
           command: |
-             java -version
+            sudo apt-get install openjdk-11-jre
+            java -version
       - run:
           name: Generate cumulative pom.xml checksum
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/base:stable-LTS
+      - image: cimg/base:stable-20.04
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       - run:
           name: Check OpenJDK Version
           command: |
+            sudo apt-get update
             sudo apt-get install openjdk-11-jre
             java -version
       - run:


### PR DESCRIPTION
circle ci provides now other images for building: https://hub.docker.com/r/cimg/openjdk