### PR TITLE
Yaml - replace variables from enviroment

### DIFF
--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/ApplicationConfigurationV2PublicationConfig.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/ApplicationConfigurationV2PublicationConfig.java
@@ -73,15 +73,15 @@ public class ApplicationConfigurationV2PublicationConfig {
   /**
    * The location of the exposure configuration source files for Android and Ios.
    */
-  private static final String V1_RISK_PARAMETERS_FILE = "main-config/v2/risk-calculation-parameters.yaml";
-  private static final String V2_RISK_PARAMETERS_FILE = "main-config/v2/risk-calculation-parameters-1.15.yaml";
-  private static final String PRESENCE_TRACING_PARAMETERS_FILE = "main-config/v2/presence-tracing-parameters.yaml";
-  private static final String CORONA_TEST_PARAMETERS_FILE = "main-config/v2/corona-test-parameters.yaml";
-  private static final String PLAUSIBLE_DENIABILITY_PARAMETERS = "main-config/v2/plausible-deniability-parameters.yaml";
-  private static final String REVOKED_TRACE_LOCATION = "main-config/v2/revoked-trace-location-versions.yaml";
-  private static final String ANDROID_V2_DATA_MAPPING_FILE = "main-config/v2/diagnosis-keys-data-mapping.yaml";
-  private static final String ANDROID_V2_DAILY_SUMMARIES_FILE = "main-config/v2/daily-summaries-config.yaml";
-  private static final String IOS_V2_EXPOSURE_CONFIGURATION_FILE = "main-config/v2/exposure-configuration.yaml";
+  public static final String V1_RISK_PARAMETERS_FILE = "main-config/v2/risk-calculation-parameters.yaml";
+  public static final String V2_RISK_PARAMETERS_FILE = "main-config/v2/risk-calculation-parameters-1.15.yaml";
+  public static final String PRESENCE_TRACING_PARAMETERS_FILE = "main-config/v2/presence-tracing-parameters.yaml";
+  public static final String CORONA_TEST_PARAMETERS_FILE = "main-config/v2/corona-test-parameters.yaml";
+  public static final String PLAUSIBLE_DENIABILITY_PARAMETERS = "main-config/v2/plausible-deniability-parameters.yaml";
+  public static final String REVOKED_TRACE_LOCATION = "main-config/v2/revoked-trace-location-versions.yaml";
+  public static final String ANDROID_V2_DATA_MAPPING_FILE = "main-config/v2/diagnosis-keys-data-mapping.yaml";
+  public static final String ANDROID_V2_DAILY_SUMMARIES_FILE = "main-config/v2/daily-summaries-config.yaml";
+  public static final String IOS_V2_EXPOSURE_CONFIGURATION_FILE = "main-config/v2/exposure-configuration.yaml";
 
   /**
    * Fetches the source configuration as a ApplicationConfigurationAndroid instance.

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/parsing/YamlConstructorForProtoBuf.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/parsing/YamlConstructorForProtoBuf.java
@@ -1,12 +1,13 @@
-
-
 package app.coronawarn.server.services.distribution.assembly.appconfig.parsing;
 
 import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.introspector.BeanAccess;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
+import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
 /**
@@ -17,9 +18,42 @@ import org.yaml.snakeyaml.nodes.Tag;
  */
 public class YamlConstructorForProtoBuf extends Constructor {
 
+  private static final Logger logger = LoggerFactory.getLogger(YamlConstructorForProtoBuf.class);
+
   public YamlConstructorForProtoBuf(String path) {
     setPropertyUtils(new ProtoBufPropertyUtils());
     this.yamlConstructors.put(new Tag("!include"), new IncludeConstruct(path));
+  }
+
+  /**
+   * If a scalar contains a variable like <code>${...}</code> it will be replaced by the setting of the environment
+   * variable, in case it exists. You can also provide defaults like this:<br/><code>foo: ${BAR:42}</code>.
+   */
+  @Override
+  protected String constructScalar(final ScalarNode node) {
+    String scalar = super.constructScalar(node);
+    if (scalar.startsWith("${") && '}' == scalar.charAt(scalar.length() - 1)) {
+      logger.debug("environment variable substitution: {}", scalar);
+      String env = scalar.substring(2, scalar.length() - 2);
+      final int index = env.indexOf(':');
+      String defaultValue = "";
+      if (index > -1) {
+        env = env.substring(0, index);
+        defaultValue = scalar.substring(scalar.indexOf(':') + 1, scalar.length() - 1).trim();
+      }
+      scalar = System.getenv(env);
+      if (scalar == null) {
+        logger.debug("enviroment {} not set, using default '{}'", env, defaultValue);
+        if (defaultValue.isEmpty()) {
+          logger.error(
+              "{} is undefined and no default is set! Please check your yaml-files and your environment settings.",
+              env);
+        }
+        return defaultValue;
+      }
+      logger.debug("using system setting: '{}' for {}", scalar, env);
+    }
+    return scalar;
   }
 
   private static class ProtoBufPropertyUtils extends PropertyUtils {

--- a/services/distribution/src/main/resources/main-config/v2/corona-test-parameters.yaml
+++ b/services/distribution/src/main/resources/main-config/v2/corona-test-parameters.yaml
@@ -4,8 +4,8 @@ coronaRapidAntigenTestParameters:
   hoursToDeemTestOutdated: 48
   # validation rule for hoursSinceSampleCollectionToEncourageRemoval:
   #   * > 0
-  hoursSinceSampleCollectionToShowRiskCard: 168 # 7 days x 24 hours
+  hoursSinceSampleCollectionToShowRiskCard: ${HOURSSINCESAMPLECOLLECTIONTOSHOWRISKCARD:168} # 7 days x 24 hours
 coronaPCRTestParameters:
   # validation rule for hoursSinceTestRegistrationToEncourageRemoval:
   #   * > 0
-  hoursSinceTestRegistrationToShowRiskCard: 168 # 7 days x 24 hours
+  hoursSinceTestRegistrationToShowRiskCard: ${HOURSSINCETESTREGISTRATIONTOSHOWRISKCARD:168} # 7 days x 24 hours

--- a/services/distribution/src/main/resources/main-config/v2/risk-calculation-parameters-1.15.yaml
+++ b/services/distribution/src/main/resources/main-config/v2/risk-calculation-parameters-1.15.yaml
@@ -62,7 +62,7 @@ transmission-risk-level-multiplier: 0 # deprecated
 # configuration shared by multiple services
 # transmission-risk-value-mapping:
 
-max-encounter-age-in-days: 10
+max-encounter-age-in-days: ${MAX-ENCOUNTER-AGE-IN-DAYS:10}
 
 trlEncoding:
   infectiousnessOffsetStandard: 1

--- a/services/distribution/src/main/resources/main-config/v2/risk-calculation-parameters.yaml
+++ b/services/distribution/src/main/resources/main-config/v2/risk-calculation-parameters.yaml
@@ -72,7 +72,7 @@ normalized-time-per-day-to-risk-level-mapping:
 
 transmission-risk-level-multiplier: 0.2
 
-max-encounter-age-in-days: 10
+max-encounter-age-in-days: ${MAX-ENCOUNTER-AGE-IN-DAYS:10}
 
 trlEncoding:
   infectiousnessOffsetStandard: 1

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/YamlLoaderTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/YamlLoaderTest.java
@@ -1,20 +1,22 @@
-
-
 package app.coronawarn.server.services.distribution.assembly.appconfig;
 
 import static app.coronawarn.server.services.distribution.common.Helpers.loadApplicationConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import java.util.stream.Stream;
+import static org.junit.Assert.assertEquals;
+
+import app.coronawarn.server.common.protocols.internal.v2.CoronaTestParameters;
+import app.coronawarn.server.common.protocols.internal.v2.RiskCalculationParameters;
 import app.coronawarn.server.common.shared.exception.UnableToLoadFileException;
+import app.coronawarn.server.services.distribution.assembly.appconfig.parsing.v2.DeserializedDailySummariesConfig;
+import app.coronawarn.server.services.distribution.assembly.appconfig.parsing.v2.DeserializedDiagnosisKeysDataMapping;
+import app.coronawarn.server.services.distribution.assembly.appconfig.parsing.v2.DeserializedExposureConfiguration;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import app.coronawarn.server.services.distribution.assembly.appconfig.parsing.v2.DeserializedDailySummariesConfig;
-import app.coronawarn.server.services.distribution.assembly.appconfig.parsing.v2.DeserializedDiagnosisKeysDataMapping;
-import app.coronawarn.server.services.distribution.assembly.appconfig.parsing.v2.DeserializedExposureConfiguration;
 
 class YamlLoaderTest {
 
@@ -59,5 +61,21 @@ class YamlLoaderTest {
         Arguments.of("configtests/exposure-configuration-v2-ok.yaml", DeserializedExposureConfiguration.class),
         Arguments.of("configtests/diagnosis-keys-data-mapping-ok.yaml", DeserializedDiagnosisKeysDataMapping.class)
     );
+  }
+
+  @Test
+  void testDefaultYamlValues42() throws Exception {
+    RiskCalculationParameters.Builder riskCalculationParameterBuilder = YamlLoader.loadYamlIntoProtobufBuilder(
+        ApplicationConfigurationV2PublicationConfig.V1_RISK_PARAMETERS_FILE,
+        RiskCalculationParameters.Builder.class);
+    assertEquals(42, riskCalculationParameterBuilder.getMaxEncounterAgeInDays());
+
+    CoronaTestParameters.Builder coronaTestParameters = YamlLoader.loadYamlIntoProtobufBuilder(
+        ApplicationConfigurationV2PublicationConfig.CORONA_TEST_PARAMETERS_FILE,
+        CoronaTestParameters.Builder.class);
+    assertEquals(42,
+        coronaTestParameters.getCoronaPCRTestParametersBuilder().getHoursSinceTestRegistrationToShowRiskCard());
+    assertEquals(42, coronaTestParameters.getCoronaRapidAntigenTestParametersBuilder()
+        .getHoursSinceSampleCollectionToShowRiskCard());
   }
 }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/YamlLoaderTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/YamlLoaderTest.java
@@ -68,6 +68,7 @@ class YamlLoaderTest {
     RiskCalculationParameters.Builder riskCalculationParameterBuilder = YamlLoader.loadYamlIntoProtobufBuilder(
         ApplicationConfigurationV2PublicationConfig.V1_RISK_PARAMETERS_FILE,
         RiskCalculationParameters.Builder.class);
+    
     assertEquals(42, riskCalculationParameterBuilder.getMaxEncounterAgeInDays());
 
     CoronaTestParameters.Builder coronaTestParameters = YamlLoader.loadYamlIntoProtobufBuilder(

--- a/services/distribution/src/test/resources/main-config/v2/corona-test-parameters.yaml
+++ b/services/distribution/src/test/resources/main-config/v2/corona-test-parameters.yaml
@@ -1,0 +1,7 @@
+# YamlLoaderTest
+
+coronaRapidAntigenTestParameters:
+  hoursToDeemTestOutdated: 48
+  hoursSinceSampleCollectionToShowRiskCard: ${HOURSSINCESAMPLECOLLECTIONTOSHOWRISKCARD:42} # 7 days x 24 hours
+coronaPCRTestParameters:
+  hoursSinceTestRegistrationToShowRiskCard: ${HOURSSINCETESTREGISTRATIONTOSHOWRISKCARD:42} # 7 days x 24 hours

--- a/services/distribution/src/test/resources/main-config/v2/risk-calculation-parameters.yaml
+++ b/services/distribution/src/test/resources/main-config/v2/risk-calculation-parameters.yaml
@@ -1,4 +1,4 @@
-# YamlLoaderTest
+  # YamlLoaderTest
 
 minutes-at-attenuation-filters:
   -
@@ -68,7 +68,7 @@ transmission-risk-level-multiplier: 0.2
 max-encounter-age-in-days: ${MAX-ENCOUNTER-AGE-IN-DAYS:42}
 
 trlEncoding:
-  infectiousnessOffsetStandard: 1
+  infectiousnessOffsetStandard: ${:1}
   infectiousnessOffsetHigh: 2
   reportTypeOffsetRecursive: 0
   reportTypeOffsetSelfReport: 2

--- a/services/distribution/src/test/resources/main-config/v2/risk-calculation-parameters.yaml
+++ b/services/distribution/src/test/resources/main-config/v2/risk-calculation-parameters.yaml
@@ -1,4 +1,4 @@
-  # YamlLoaderTest
+# YamlLoaderTest
 
 minutes-at-attenuation-filters:
   -

--- a/services/distribution/src/test/resources/main-config/v2/risk-calculation-parameters.yaml
+++ b/services/distribution/src/test/resources/main-config/v2/risk-calculation-parameters.yaml
@@ -1,0 +1,76 @@
+# YamlLoaderTest
+
+minutes-at-attenuation-filters:
+  -
+    attenuation-range:
+      min: 0
+      max: 79
+      max-exclusive: true
+    drop-if-minutes-in-range:
+      min: 0
+      max: 5
+      max-exclusive: true
+
+trl-filters:
+  -
+    drop-if-trl-in-range:
+      min: 1
+      max: 2
+
+minutes-at-attenuation-weights:
+  -
+    attenuation-range:
+      min: 0
+      max: 63
+      max-exclusive: true
+    weight: 0.8
+  -
+    attenuation-range:
+      min: 63
+      max: 73
+      max-exclusive: true
+    weight: 1.0
+  -
+    attenuation-range:
+      min: 73
+      max: 79
+      max-exclusive: true
+    weight: 0.1
+
+normalized-time-per-e-w-to-risk-level-mapping:
+  -
+    normalized-time-range:
+      min: 0
+      max: 13
+      max-exclusive: true
+    risk-level: 1
+  -
+    normalized-time-range:
+      min: 13
+      max: 9999
+    risk-level: 2
+
+normalized-time-per-day-to-risk-level-mapping:
+  -
+    normalized-time-range:
+      min: 0
+      max: 13
+      max-exclusive: true
+    risk-level: 1
+  -
+    normalized-time-range:
+      min: 13
+      max: 99999
+    risk-level: 2
+
+transmission-risk-level-multiplier: 0.2
+
+max-encounter-age-in-days: ${MAX-ENCOUNTER-AGE-IN-DAYS:42}
+
+trlEncoding:
+  infectiousnessOffsetStandard: 1
+  infectiousnessOffsetHigh: 2
+  reportTypeOffsetRecursive: 0
+  reportTypeOffsetSelfReport: 2
+  reportTypeOffsetConfirmedClinicalDiagnosis: 4
+  reportTypeOffsetConfirmedTest: 6


### PR DESCRIPTION
`yaml` files within `main-config` are manual loaded and aren't process through the regular spring-config mechanism

but some values should be different for the test environments, so that's why we're introducing here the option to replace some values with environment settings coming from the helm-charts/values