### PR TITLE
switch from s3 ListObjectsV2 to ListObjects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <feign.version>11.8</feign.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <bouncycastle.version>1.70</bouncycastle.version>
-    <awssdk-s3.version>2.17.103</awssdk-s3.version>
+    <awssdk-s3.version>2.17.182</awssdk-s3.version>
     <io-netty.version>4.1.76.Final</io-netty.version>
     <guava.version>31.1-jre</guava.version>
     <jackson.version>2.13.2</jackson.version>

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.distribution.objectstore;
 
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
@@ -7,6 +5,7 @@ import app.coronawarn.server.services.distribution.objectstore.client.ObjectStor
 import app.coronawarn.server.services.distribution.objectstore.client.ObjectStoreClient.HeaderKey;
 import app.coronawarn.server.services.distribution.objectstore.client.S3Object;
 import app.coronawarn.server.services.distribution.objectstore.publish.LocalFile;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -104,6 +103,11 @@ public class ObjectStoreAccess {
     this.client.removeObjects(bucket, toDelete);
   }
 
+  public void deleteObject(S3Object toDelete) {
+    logger.info("Deleting {}", toDelete);
+    this.client.removeObjects(bucket, Collections.singletonList(toDelete.getObjectName()));
+  }
+
   /**
    * Fetches the list of objects in the store with the given prefix.
    *
@@ -112,6 +116,10 @@ public class ObjectStoreAccess {
    */
   public List<S3Object> getObjectsWithPrefix(String prefix) {
     return client.getObjects(bucket, prefix);
+  }
+
+  public List<S3Object> getAllObjectsWithPrefix(String prefix) {
+    return client.getObjects(bucket, prefix, null);
   }
 
   private Map<HeaderKey, String> createHeaders(int maxAge, LocalFile file) {

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/ObjectStoreAccess.java
@@ -92,6 +92,8 @@ public class ObjectStoreAccess {
    * Deletes objects in the object store, based on the given prefix (folder structure).
    *
    * @param prefix the prefix, e.g. my/folder/
+   * 
+   * @see #getAllObjectsWithPrefix(String)
    */
   public void deleteObjectsWithPrefix(String prefix) {
     List<String> toDelete = getObjectsWithPrefix(prefix)

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/S3RetentionPolicy.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/S3RetentionPolicy.java
@@ -139,6 +139,14 @@ public class S3RetentionPolicy {
     }
   }
 
+  public void deleteSingleS3Object(S3Object s3Object) {
+    try {
+      objectStoreAccess.deleteObject(s3Object);
+    } catch (ObjectStoreOperationFailedException e) {
+      failedObjectStoreOperationsCounter.incrementAndCheckThreshold(e);
+    }
+  }
+
   private boolean isDiagnosisKeyFilePathOnHourFolder(S3Object s3Object) {
     Matcher matcher = hourPathPattern.matcher(s3Object.getObjectName());
     return matcher.matches();
@@ -178,8 +186,8 @@ public class S3RetentionPolicy {
    * Delete the whole folder {@link #dccRevocationDirectory}.
    */
   public void deleteDccRevocationDir() {
-    final Collection<S3Object> s3Objects = objectStoreAccess.getObjectsWithPrefix(dccRevocationDirectory);
+    final Collection<S3Object> s3Objects = objectStoreAccess.getAllObjectsWithPrefix(dccRevocationDirectory);
     logger.info("Deleting {} dccRevocationDirectory files", s3Objects.size());
-    s3Objects.forEach(this::deleteS3Object);
+    s3Objects.forEach(this::deleteSingleS3Object);
   }
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/S3RetentionPolicy.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/S3RetentionPolicy.java
@@ -127,9 +127,12 @@ public class S3RetentionPolicy {
 
   /**
    * Java stream do not support checked exceptions within streams. This helper method rethrows them as unchecked
-   * expressions, so they can be passed up to the Retention Policy.
+   * expressions, so they can be passed up to the Retention Policy.<br />
+   * <strong>Attention:</strong> this first queries all the objects from S3 with the same prefix!
    *
    * @param s3Object the S3 object, that should be deleted.
+   * 
+   * @see ObjectStoreAccess#deleteObjectsWithPrefix(String)
    */
   public void deleteS3Object(S3Object s3Object) {
     try {
@@ -139,6 +142,12 @@ public class S3RetentionPolicy {
     }
   }
 
+  /**
+   * Java stream do not support checked exceptions within streams. This helper method rethrows them as unchecked
+   * expressions, so they can be passed up to the Retention Policy.
+   *
+   * @param s3Object the S3 object, that should be deleted.
+   */
   public void deleteSingleS3Object(S3Object s3Object) {
     try {
       objectStoreAccess.deleteObject(s3Object);

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClient.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreClient.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.distribution.objectstore.client;
 
 import app.coronawarn.server.services.distribution.statistics.exceptions.NotModifiedException;
@@ -22,6 +20,8 @@ public interface ObjectStoreClient {
    * @throws ObjectStoreOperationFailedException if the operation could not be performed.
    */
   List<S3Object> getObjects(String bucket, String prefix);
+
+  List<S3Object> getObjects(final String bucket, final String prefix, final String delimiter);
 
   JsonFile getSingleObjectContent(String bucket, String key);
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStorePublishingConfig.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStorePublishingConfig.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.distribution.objectstore.client;
 
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
@@ -26,10 +24,11 @@ public class ObjectStorePublishingConfig {
 
   @Bean(name = "publish-s3")
   public ObjectStoreClient createObjectStoreClient(DistributionServiceConfig distributionServiceConfig) {
-    return createClient(distributionServiceConfig.getObjectStore());
+    return createClient(distributionServiceConfig.getObjectStore(),
+        distributionServiceConfig.getDccRevocation().getDccListPath());
   }
 
-  private ObjectStoreClient createClient(ObjectStore objectStore) {
+  private ObjectStoreClient createClient(final ObjectStore objectStore, final String dccListPath) {
     AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(
         AwsBasicCredentials.create(objectStore.getAccessKey(), objectStore.getSecretKey()));
     String endpoint = removeTrailingSlash(objectStore.getEndpoint()) + ":" + objectStore.getPort();
@@ -38,7 +37,7 @@ public class ObjectStorePublishingConfig {
         .region(DEFAULT_REGION)
         .endpointOverride(URI.create(endpoint))
         .credentialsProvider(credentialsProvider)
-        .build());
+        .build(), dccListPath);
   }
 
   private String removeTrailingSlash(String string) {

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapper.java
@@ -167,7 +167,7 @@ public class S3ClientWrapper implements ObjectStoreClient {
           .build();
       final ListObjectsResponse response = s3Client.listObjects(request);
       marker = TRUE.equals(response.isTruncated()) ? response.nextMarker() : null;
-      if (response.isTruncated() && marker == null) {
+      if (TRUE.equals(response.isTruncated()) && marker == null) {
         // the zenko/cloudserver during the tests doesn't support the old API as it's the case for OBS at TSI
         return tryWithV2(bucket, prefix, delimiter);
       }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3Object.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/S3Object.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.distribution.objectstore.client;
 
 import java.util.Objects;
@@ -30,7 +28,7 @@ public class S3Object {
    * Constructs a new S3Object for the given object name.
    *
    * @param objectName the target object name
-   * @param cwaHash the checksum for that file
+   * @param cwaHash    the checksum for that file
    */
   public S3Object(String objectName, String cwaHash) {
     this(objectName);
@@ -71,5 +69,10 @@ public class S3Object {
   @Override
   public int hashCode() {
     return Objects.hash(objectName, cwaHash);
+  }
+
+  @Override
+  public String toString() {
+    return getObjectName();
   }
 }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
@@ -58,8 +58,6 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -107,20 +105,20 @@ class S3ClientWrapperTest {
 
   @Test
   void testBucketExistsIfBucketExists() {
-    when(s3Client.listObjectsV2((any(ListObjectsV2Request.class)))).thenReturn(ListObjectsV2Response.builder().build());
+    when(s3Client.listObjects((any(ListObjectsRequest.class)))).thenReturn(ListObjectsResponse.builder().build());
     assertThat(s3ClientWrapper.bucketExists(VALID_BUCKET_NAME)).isTrue();
   }
 
   @Test
   void testBucketExistsIfBucketDoesNotExist() {
-    when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenThrow(NoSuchBucketException.class);
+    when(s3Client.listObjects(any(ListObjectsRequest.class))).thenThrow(NoSuchBucketException.class);
     assertThat(s3ClientWrapper.bucketExists(VALID_BUCKET_NAME)).isFalse();
   }
 
   @ParameterizedTest
   @ValueSource(classes = {S3Exception.class, SdkClientException.class, SdkException.class})
   void bucketExistsThrowsObjectStoreOperationFailedExceptionIfClientThrows(Class<Exception> cause) {
-    when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenThrow(cause);
+    when(s3Client.listObjects(any(ListObjectsRequest.class))).thenThrow(cause);
     assertThatExceptionOfType(ObjectStoreOperationFailedException.class)
         .isThrownBy(() -> s3ClientWrapper.bucketExists(VALID_BUCKET_NAME));
   }
@@ -186,7 +184,7 @@ class S3ClientWrapperTest {
   @ParameterizedTest
   @ValueSource(classes = {NoSuchBucketException.class, S3Exception.class, SdkClientException.class, SdkException.class})
   void getObjectsThrowsObjectStoreOperationFailedExceptionIfClientThrows(Class<Exception> cause) {
-    when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenThrow(cause);
+    when(s3Client.listObjects(any(ListObjectsRequest.class))).thenThrow(cause);
     assertThatExceptionOfType(ObjectStoreOperationFailedException.class)
         .isThrownBy(() -> s3ClientWrapper.getObjects(VALID_BUCKET_NAME, VALID_PREFIX));
   }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
@@ -125,7 +125,7 @@ class S3ClientWrapperTest {
 
   @Test
   void testGetObjectsSendsCorrectRequest() {
-    when(s3Client.listObjects(any(ListObjectsRequest.class))).thenReturn(ListObjectsResponse.builder().build());
+    when(s3Client.listObjects(any(ListObjectsRequest.class))).thenReturn(ListObjectsResponse.builder().isTruncated(false).build());
 
     s3ClientWrapper.getObjects(VALID_BUCKET_NAME, VALID_PREFIX);
 
@@ -178,7 +178,7 @@ class S3ClientWrapperTest {
             s3Object -> software.amazon.awssdk.services.s3.model.S3Object.builder()
                 .key(s3Object.getObjectName()))
         .map(SdkBuilder::build).collect(Collectors.toList());
-    return ListObjectsResponse.builder().contents(responseObjects).build();
+    return ListObjectsResponse.builder().contents(responseObjects).isTruncated(false).build();
   }
 
   @ParameterizedTest

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/integration/ObjectStoreAccessIT.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/integration/ObjectStoreAccessIT.java
@@ -107,6 +107,7 @@ class ObjectStoreAccessIT extends BaseS3IntegrationTest {
     try {
       return resourceLoader.getResource(textFile).getFile().toPath();
     } catch (IOException e) {
+      e.printStackTrace();
       throw new RuntimeException(e);
     }
   }
@@ -115,6 +116,7 @@ class ObjectStoreAccessIT extends BaseS3IntegrationTest {
     try {
       return resourceLoader.getResource(rootTestFolder).getFile().toPath();
     } catch (IOException e) {
+      e.printStackTrace();
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
Object Store doesn't support V2 API with token... :-(

When DCC Revocation is running, we need to query ALL objects from OBS buckets and delete the same, incase the ETag did change and we need to republish everything.

But in case of regular 'distribution' run, we should ignore all S3 objects with the delimiter `/dcc-rl/`, to speed up things.