### PR TITLE
Suppress/warnings

### DIFF
--- a/common/federation/src/main/java/app/coronawarn/server/common/federation/client/CloudFeignHttpClientProviderException.java
+++ b/common/federation/src/main/java/app/coronawarn/server/common/federation/client/CloudFeignHttpClientProviderException.java
@@ -1,6 +1,7 @@
 package app.coronawarn.server.common.federation.client;
 
 public class CloudFeignHttpClientProviderException extends RuntimeException {
+  private static final long serialVersionUID = 8199713110526635715L;
 
   public CloudFeignHttpClientProviderException(final Throwable cause) {
     super(cause);

--- a/common/federation/src/test/java/app/coronawarn/server/common/federation/client/upload/BatchUploadResponseTest.java
+++ b/common/federation/src/test/java/app/coronawarn/server/common/federation/client/upload/BatchUploadResponseTest.java
@@ -1,10 +1,6 @@
-
 package app.coronawarn.server.common.federation.client.upload;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-
 import org.junit.jupiter.api.Test;
 
 class BatchUploadResponseTest {

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/FederationBatchInfo.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/domain/FederationBatchInfo.java
@@ -1,11 +1,9 @@
-
-
 package app.coronawarn.server.common.persistence.domain;
 
 import java.time.LocalDate;
 import java.util.Objects;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.annotation.PersistenceCreator;
 
 /**
  * Information about federation batches with their status.
@@ -36,7 +34,7 @@ public class FederationBatchInfo {
    * @param date     date the batch was created
    * @param status   status stored as {@link FederationBatchStatus}
    */
-  @PersistenceConstructor
+  @PersistenceCreator
   public FederationBatchInfo(String batchTag, LocalDate date, FederationBatchStatus status,
       FederationBatchSourceSystem sourceSystem) {
     this.batchTag = batchTag;

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/exception/InvalidDiagnosisKeyException.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/exception/InvalidDiagnosisKeyException.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.common.persistence.exception;
 
 /**
@@ -10,6 +8,7 @@ package app.coronawarn.server.common.persistence.exception;
  * is semantically erroneous.
  */
 public class InvalidDiagnosisKeyException extends RuntimeException {
+  private static final long serialVersionUID = -6124348897420468935L;
 
   public InvalidDiagnosisKeyException(String message) {
     super(message);

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/TraceTimeIntervalWarningRepository.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/repository/TraceTimeIntervalWarningRepository.java
@@ -1,6 +1,5 @@
 package app.coronawarn.server.common.persistence.repository;
 
-
 import app.coronawarn.server.common.persistence.domain.TraceTimeIntervalWarning;
 import org.springframework.data.jdbc.repository.query.Modifying;
 import org.springframework.data.jdbc.repository.query.Query;
@@ -12,7 +11,7 @@ import org.springframework.stereotype.Repository;
  * Event check-in repository.
  * @deprecated in favor of encrypted check-ins.
  */
-@Deprecated(since = "2.8", forRemoval = true)
+@Deprecated(since = "2.8", forRemoval = false)
 @Repository
 public interface TraceTimeIntervalWarningRepository
     extends PagingAndSortingRepository<TraceTimeIntervalWarning, Long> {

--- a/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/TraceTimeIntervalWarningService.java
+++ b/common/persistence/src/main/java/app/coronawarn/server/common/persistence/service/TraceTimeIntervalWarningService.java
@@ -28,16 +28,17 @@ import org.springframework.data.util.StreamUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+@SuppressWarnings("deprecation")
 @Component
 public class TraceTimeIntervalWarningService {
 
   private static final Logger logger =
       LoggerFactory.getLogger(TraceTimeIntervalWarningService.class);
 
-  @Deprecated(since = "2.8", forRemoval = true)
+  @Deprecated(since = "2.8", forRemoval = false)
   private final TraceTimeIntervalWarningRepository traceTimeIntervalWarningRepo;
   private final CheckInProtectedReportsRepository checkInProtectedReportsRepository;
-  @Deprecated(since = "2.8", forRemoval = true)
+  @Deprecated(since = "2.8", forRemoval = false)
   private final MessageDigest hashAlgorithm;
 
   /**
@@ -61,13 +62,13 @@ public class TraceTimeIntervalWarningService {
    *
    * @deprecated in favor of encrypted checkins.
    */
-  @Deprecated(since = "2.8", forRemoval = true)
+  @Deprecated(since = "2.8", forRemoval = false)
   @Transactional
   public int saveCheckins(List<CheckIn> checkins, int submissionTimestamp, SubmissionType submissionType) {
     return saveCheckins(checkins, this::hashLocationId, submissionTimestamp, submissionType);
   }
 
-  @Deprecated(since = "2.8", forRemoval = true)
+  @Deprecated(since = "2.8", forRemoval = false)
   private int saveCheckins(List<CheckIn> checkins, Function<ByteString, byte[]> idHashGenerator,
       int submissionTimestamp, SubmissionType submissionType) {
     int numberOfInsertedTraceWarnings = 0;
@@ -129,7 +130,7 @@ public class TraceTimeIntervalWarningService {
    *
    * @deprecated because trace time warnings are not longer supported and replaced by encrypted checkins.
    */
-  @Deprecated(since = "2.8", forRemoval = true)
+  @Deprecated(since = "2.8", forRemoval = false)
   public Collection<TraceTimeIntervalWarning> getTraceTimeIntervalWarnings() {
     return StreamUtils
         .createStreamFromIterator(traceTimeIntervalWarningRepo
@@ -147,7 +148,7 @@ public class TraceTimeIntervalWarningService {
         .collect(Collectors.toList());
   }
 
-  @Deprecated(since = "2.8", forRemoval = true)
+  @Deprecated(since = "2.8", forRemoval = false)
   private byte[] hashLocationId(ByteString locationId) {
     return hashAlgorithm.digest(locationId.toByteArray());
   }

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/TestApplication.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/TestApplication.java
@@ -25,7 +25,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@SuppressWarnings("removal")
+@SuppressWarnings("deprecation")
 @SpringBootApplication
 @Configuration
 public class TestApplication {

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/repository/TraceTimeIntervalWarningRepositoryTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/repository/TraceTimeIntervalWarningRepositoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 @DataJdbcTest
 class TraceTimeIntervalWarningRepositoryTest {
 
+  @SuppressWarnings("deprecation")
   @Autowired
   private TraceTimeIntervalWarningRepository underTest;
 

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/FederationBatchInfoServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/FederationBatchInfoServiceTest.java
@@ -1,15 +1,12 @@
-
-
 package app.coronawarn.server.common.persistence.service;
 
-import static app.coronawarn.server.common.persistence.domain.FederationBatchSourceSystem.*;
+import static app.coronawarn.server.common.persistence.domain.FederationBatchSourceSystem.EFGS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import app.coronawarn.server.common.persistence.domain.FederationBatchInfo;
 import app.coronawarn.server.common.persistence.domain.FederationBatchStatus;
-import app.coronawarn.server.common.persistence.domain.FederationBatchSourceSystem;
 import app.coronawarn.server.common.persistence.repository.FederationBatchInfoRepository;
 import java.time.LocalDate;
 import java.time.Period;
@@ -21,7 +18,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
-import org.springframework.test.context.ActiveProfiles;
 
 @DataJdbcTest
 class FederationBatchInfoServiceTest {

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/FederationUploadKeyServiceTest.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.common.persistence.service;
 
 import static app.coronawarn.server.common.persistence.service.DiagnosisKeyServiceTestHelper.assertDiagnosisKeysEqual;
@@ -22,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/TraceTimeIntervalWarningServiceTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/service/TraceTimeIntervalWarningServiceTest.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.testcontainers.shaded.org.bouncycastle.util.encoders.Hex;
 
+@SuppressWarnings("deprecation")
 @DataJdbcTest
 class TraceTimeIntervalWarningServiceTest {
 

--- a/common/persistence/src/test/java/app/coronawarn/server/common/persistence/utils/YamlPropertySourceFactoryTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/server/common/persistence/utils/YamlPropertySourceFactoryTest.java
@@ -19,7 +19,6 @@ import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.EncodedResource;
 import app.coronawarn.server.common.persistence.domain.config.TekFieldDerivations;
-import app.coronawarn.server.common.persistence.utils.YamlPropertySourceFactory;
 
 @DataJdbcTest
 @ExtendWith(MockitoExtension.class)

--- a/common/shared/src/main/java/app/coronawarn/server/common/shared/exception/UnableToLoadFileException.java
+++ b/common/shared/src/main/java/app/coronawarn/server/common/shared/exception/UnableToLoadFileException.java
@@ -1,11 +1,10 @@
-
-
 package app.coronawarn.server.common.shared.exception;
 
 /**
  * The file could not be loaded/parsed correctly.
  */
 public class UnableToLoadFileException extends Exception {
+  private static final long serialVersionUID = 5554527058338857525L;
 
   public UnableToLoadFileException(String path) {
     super("Unable to load file from path " + path);

--- a/common/shared/src/main/java/app/coronawarn/server/common/shared/functional/CheckedFunctionAndConsumerException.java
+++ b/common/shared/src/main/java/app/coronawarn/server/common/shared/functional/CheckedFunctionAndConsumerException.java
@@ -1,6 +1,7 @@
 package app.coronawarn.server.common.shared.functional;
 
 public class CheckedFunctionAndConsumerException extends RuntimeException {
+  private static final long serialVersionUID = -7637713928805965646L;
 
   public CheckedFunctionAndConsumerException(final Throwable cause) {
     super(cause);

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <guava.version>31.1-jre</guava.version>
     <jackson.version>2.13.3</jackson.version>
     <test-containers.version>1.17.3</test-containers.version>
-    <postgresql.version>42.4.1</postgresql.version>
+    <postgresql.version>42.4.2</postgresql.version>
     <wiremock.version>2.33.2</wiremock.version>
     <httpclient.version>4.5.13</httpclient.version>
     <junit.version>4.13.2</junit.version>

--- a/services/callback/src/main/java/app/coronawarn/server/services/callback/CertificateCnMismatchException.java
+++ b/services/callback/src/main/java/app/coronawarn/server/services/callback/CertificateCnMismatchException.java
@@ -3,6 +3,7 @@ package app.coronawarn.server.services.callback;
 import org.springframework.security.core.AuthenticationException;
 
 public class CertificateCnMismatchException extends AuthenticationException {
+  private static final long serialVersionUID = 5480042926779226129L;
 
   public CertificateCnMismatchException(String msg) {
     super(msg);

--- a/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackControllerTest.java
+++ b/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/CallbackControllerTest.java
@@ -21,7 +21,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, //
     classes = {ServerApplication.class, ClientCertificateTestConfig.class})

--- a/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/ChgsCallbackControllerTest.java
+++ b/services/callback/src/test/java/app/coronawarn/server/services/callback/controller/ChgsCallbackControllerTest.java
@@ -1,7 +1,6 @@
 package app.coronawarn.server.services.callback.controller;
 
 import static app.coronawarn.server.common.persistence.domain.FederationBatchSourceSystem.CHGS;
-import static app.coronawarn.server.common.persistence.domain.FederationBatchSourceSystem.EFGS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.OK;

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/parsing/IncludeResolveFailedException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/parsing/IncludeResolveFailedException.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.distribution.assembly.appconfig.parsing;
 
 import app.coronawarn.server.common.shared.exception.UnableToLoadFileException;
@@ -9,6 +7,7 @@ import org.yaml.snakeyaml.nodes.ScalarNode;
  * This exception is raised in case SnakeYaml was not able to map the content of the include to the target data type.
  */
 public class IncludeResolveFailedException extends RuntimeException {
+  private static final long serialVersionUID = -6510293265253711125L;
 
   /**
    * Creates a new Include Resolve Failed Exception.

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/parsing/NoMessageBuilderOnClassException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/parsing/NoMessageBuilderOnClassException.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.distribution.assembly.appconfig.parsing;
 
 import org.yaml.snakeyaml.nodes.Node;
@@ -9,6 +7,7 @@ import org.yaml.snakeyaml.nodes.Node;
  * should contain a Message Builder. This Message.Builder is required for the processing.
  */
 public class NoMessageBuilderOnClassException extends RuntimeException {
+  private static final long serialVersionUID = 4867340635126780197L;
 
   /**
    * Creates a new exception instance based on the given {@link Node}.

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ValidationExecutionException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ValidationExecutionException.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.distribution.assembly.appconfig.validation;
 
 /**
@@ -7,6 +5,7 @@ package app.coronawarn.server.services.distribution.assembly.appconfig.validatio
  * message property.
  */
 public class ValidationExecutionException extends RuntimeException {
+  private static final long serialVersionUID = -3970814945560559417L;
 
   public ValidationExecutionException(String message, Throwable cause) {
     super(message, cause);

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/CwaApiStructureProvider.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/component/CwaApiStructureProvider.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.distribution.assembly.component;
 
 import app.coronawarn.server.services.distribution.assembly.structure.WritableOnDisk;
@@ -62,6 +60,7 @@ public class CwaApiStructureProvider {
    *
    * @return new instance of IndexingDecoratorOnDisk base directory
    */
+  @SuppressWarnings("deprecation")
   public Directory<WritableOnDisk> getDirectory() {
     IndexDirectoryOnDisk<String> versionDirectory = new IndexDirectoryOnDisk<>(
         distributionServiceConfig.getApi().getVersionPath(),

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/TraceTimeIntervalWarningsPackageBundler.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/TraceTimeIntervalWarningsPackageBundler.java
@@ -46,7 +46,7 @@ public abstract class TraceTimeIntervalWarningsPackageBundler {
    * @see CheckinsDateSpecification#HOUR_SINCE_EPOCH_DERIVATION
    * @deprecated in favor of {@link #distributableCheckInProtectedReports}.
    */
-  @Deprecated(since = "2.8", forRemoval = true)
+  @Deprecated(since = "2.8", forRemoval = false)
   protected final Map<Integer, List<TraceTimeIntervalWarning>> distributableTraceTimeIntervalWarnings =
       new HashMap<>();
 

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/TraceTimeIntervalWarningsCountryDirectory.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/TraceTimeIntervalWarningsCountryDirectory.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("deprecation")
 public class TraceTimeIntervalWarningsCountryDirectory extends IndexDirectoryOnDisk<String> {
 
   private static final String VERSION_V2 = "v2";

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dcc/FetchDccListException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dcc/FetchDccListException.java
@@ -1,6 +1,7 @@
 package app.coronawarn.server.services.distribution.dcc;
 
 public class FetchDccListException extends Exception {
+  private static final long serialVersionUID = -6658461155713651342L;
 
   public FetchDccListException(String message, Throwable cause) {
     super(message, cause);

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dcc/decode/DccRevocationListDecodeException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dcc/decode/DccRevocationListDecodeException.java
@@ -1,6 +1,8 @@
 package app.coronawarn.server.services.distribution.dcc.decode;
 
 public class DccRevocationListDecodeException extends Exception {
+  private static final long serialVersionUID = 773876244555365963L;
+
   public DccRevocationListDecodeException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/DigitalGreenCertificateToProtobufMapping.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/DigitalGreenCertificateToProtobufMapping.java
@@ -9,12 +9,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
-
 
 @Component
 public class DigitalGreenCertificateToProtobufMapping {

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/dsc/errors/InvalidContentResponseException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/dsc/errors/InvalidContentResponseException.java
@@ -1,6 +1,7 @@
 package app.coronawarn.server.services.distribution.dgc.dsc.errors;
 
 public class InvalidContentResponseException extends Exception {
+  private static final long serialVersionUID = -4419103572626924400L;
   private static final String ERROR = "Obtaining providers from content response failed";
 
   public InvalidContentResponseException() {

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/dsc/errors/InvalidFingerprintException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/dsc/errors/InvalidFingerprintException.java
@@ -1,6 +1,7 @@
 package app.coronawarn.server.services.distribution.dgc.dsc.errors;
 
 public class InvalidFingerprintException extends Exception {
+  private static final long serialVersionUID = 5715798235468337392L;
   private static final String ERROR = "Obtaining service provider allow list failed";
 
   public InvalidFingerprintException() {

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/exception/DigitalCovidCertificateSignatureException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/exception/DigitalCovidCertificateSignatureException.java
@@ -1,9 +1,9 @@
 package app.coronawarn.server.services.distribution.dgc.exception;
 
 public class DigitalCovidCertificateSignatureException extends RuntimeException {
+  private static final long serialVersionUID = -8753378064860398366L;
 
   public DigitalCovidCertificateSignatureException(String message, Throwable cause) {
     super(message, cause);
   }
-
 }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/exception/DscListDecodeException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/exception/DscListDecodeException.java
@@ -1,6 +1,7 @@
 package app.coronawarn.server.services.distribution.dgc.exception;
 
 public class DscListDecodeException extends Exception {
+  private static final long serialVersionUID = 3606460668598764440L;
 
   public DscListDecodeException(String message, Throwable cause) {
     super(message, cause);

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/exception/FetchDscTrustListException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/dgc/exception/FetchDscTrustListException.java
@@ -1,6 +1,7 @@
 package app.coronawarn.server.services.distribution.dgc.exception;
 
 public class FetchDscTrustListException extends Exception {
+  private static final long serialVersionUID = 4730807672445241054L;
 
   public FetchDscTrustListException(String message) {
     super(message);

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreOperationFailedException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStoreOperationFailedException.java
@@ -1,11 +1,10 @@
-
-
 package app.coronawarn.server.services.distribution.objectstore.client;
 
 /**
  * {@link ObjectStoreOperationFailedException} indicates that a object store operation could not be performed.
  */
 public class ObjectStoreOperationFailedException extends RuntimeException {
+  private static final long serialVersionUID = -7588036602833284123L;
 
   /**
    * Constructs a new {@link ObjectStoreOperationFailedException} with the specified message.

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/directory/LocalStatisticsDirectory.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/directory/LocalStatisticsDirectory.java
@@ -1,7 +1,6 @@
 package app.coronawarn.server.services.distribution.statistics.directory;
 
 import app.coronawarn.server.common.protocols.internal.stats.LocalStatistics;
-import app.coronawarn.server.common.protocols.internal.stats.Statistics;
 import app.coronawarn.server.services.distribution.assembly.component.CryptoProvider;
 import app.coronawarn.server.services.distribution.assembly.structure.Writable;
 import app.coronawarn.server.services.distribution.assembly.structure.WritableOnDisk;

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/exceptions/NotModifiedException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/exceptions/NotModifiedException.java
@@ -1,6 +1,8 @@
 package app.coronawarn.server.services.distribution.statistics.exceptions;
 
 public class NotModifiedException extends Exception {
+  private static final long serialVersionUID = 2387737811630513750L;
+
   public NotModifiedException(String path, String etag) {
     super(String.format("File %s not modified since last checked. ETag: %s", path, etag));
   }

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/JsonFileLoaderException.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/statistics/file/JsonFileLoaderException.java
@@ -1,6 +1,7 @@
 package app.coronawarn.server.services.distribution.statistics.file;
 
 public class JsonFileLoaderException extends RuntimeException {
+  private static final long serialVersionUID = 481244982371451315L;
 
   public JsonFileLoaderException(String path, final Throwable cause) {
     super(String.format("Failed to load Local JSON from path %s", path), cause);

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ApplicationConfigurationValidatorTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/appconfig/validation/ApplicationConfigurationValidatorTest.java
@@ -8,7 +8,6 @@ import static app.coronawarn.server.services.distribution.common.Helpers.loadApp
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import app.coronawarn.server.common.protocols.internal.ApplicationConfiguration;
 import app.coronawarn.server.common.shared.exception.UnableToLoadFileException;
 import app.coronawarn.server.services.distribution.assembly.appconfig.ApplicationConfigurationPublicationConfig;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
@@ -80,16 +79,6 @@ class ApplicationConfigurationValidatorTest {
   private static TestWithExpectedResult minRiskThresholdOutOfBoundsPositive() {
     return TEST_BUILDER.build("app-config_mrs_oob.yaml")
         .with(buildError("min-risk-score", RISK_SCORE_MAX + 1, VALUE_OUT_OF_BOUNDS));
-  }
-
-  private ConfigurationValidator buildApplicationConfigurationValidator(
-      DistributionServiceConfig distributionServiceConfig)
-      throws UnableToLoadFileException {
-    ApplicationConfigurationPublicationConfig applicationConfigurationPublicationConfig = new ApplicationConfigurationPublicationConfig();
-    ApplicationConfiguration appConfig = applicationConfigurationPublicationConfig
-        .createMainConfiguration(distributionServiceConfig);
-
-    return new ApplicationConfigurationValidator(appConfig);
   }
 
   public static ValidationResult buildExpectedResult(ValidationError... errors) {

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/component/DiagnosisKeysStructureProviderTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/component/DiagnosisKeysStructureProviderTest.java
@@ -1,14 +1,10 @@
 package app.coronawarn.server.services.distribution.assembly.component;
 
 import static app.coronawarn.server.services.distribution.common.Helpers.buildDiagnosisKeys;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
 import app.coronawarn.server.common.persistence.service.DiagnosisKeyService;
 import app.coronawarn.server.common.persistence.service.common.KeySharingPoliciesChecker;
-import app.coronawarn.server.common.protocols.external.exposurenotification.ReportType;
 import app.coronawarn.server.services.distribution.assembly.diagnosiskeys.DiagnosisKeyBundler;
 import app.coronawarn.server.services.distribution.assembly.diagnosiskeys.ProdDiagnosisKeyBundler;
 import app.coronawarn.server.services.distribution.assembly.structure.WritableOnDisk;
@@ -17,9 +13,7 @@ import app.coronawarn.server.services.distribution.assembly.transformation.EnfPa
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.config.TransmissionRiskLevelEncoding;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Assertions;

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/component/TraceTimeIntervalWarningsStructureProviderTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/component/TraceTimeIntervalWarningsStructureProviderTest.java
@@ -92,6 +92,7 @@ class TraceTimeIntervalWarningsStructureProviderTest {
     when(outputDirectoryProvider.getDirectory()).thenReturn(testDirectory);
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   void should_create_correct_top_parent_folder_for_warnings_file_structure() {
     when(traceTimeWarningService.getTraceTimeIntervalWarnings()).thenReturn(Collections.emptyList());
@@ -333,6 +334,7 @@ class TraceTimeIntervalWarningsStructureProviderTest {
     return !it.endsWith(DS_STORE);
   }
 
+  @SuppressWarnings("deprecation")
   private void writeDirectories(List<TraceTimeIntervalWarning> traceWarnings) throws IOException {
     when(traceTimeWarningService.getTraceTimeIntervalWarnings()).thenReturn(traceWarnings);
     Directory<WritableOnDisk> outputDirectory = this.outputDirectoryProvider.getDirectory();

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/component/ValueSetsNotFetchedStructureProviderTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/component/ValueSetsNotFetchedStructureProviderTest.java
@@ -1,6 +1,5 @@
 package app.coronawarn.server.services.distribution.assembly.component;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
@@ -27,7 +26,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/structure/directory/DirectoryTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/structure/directory/DirectoryTest.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.distribution.assembly.structure.directory;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,6 +65,7 @@ class DirectoryTest {
   @Test
   void checkWriteWritesOwnDirectory() {
     class MockFile extends java.io.File {
+      private static final long serialVersionUID = 2416208157399566292L;
 
       public MockFile() {
         super(outputDir.getPath());

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/DemoTraceTimeIntervalWarningsPackageBundlerTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/DemoTraceTimeIntervalWarningsPackageBundlerTest.java
@@ -45,6 +45,7 @@ class DemoTraceTimeIntervalWarningsPackageBundlerTest {
     bundler = new DemoTraceTimeIntervalWarningsPackageBundler(distributionServiceConfig);
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   void testGetsTraceLocationWarningsForHour() {
     List<TraceTimeIntervalWarning> warnings = Stream
@@ -69,6 +70,7 @@ class DemoTraceTimeIntervalWarningsPackageBundlerTest {
     assertThat(bundler.getCheckInProtectedReportsForHour(5)).hasSize(15);
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   void testGetHoursTraceLocationWarningsForCountry() {
     List<TraceTimeIntervalWarning> warnings = Stream
@@ -81,6 +83,7 @@ class DemoTraceTimeIntervalWarningsPackageBundlerTest {
     assertThat(bundler.getHoursForDistributableWarnings("DE")).hasSize(3);
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   void testGetHoursTraceLocationWarningsForUnknownCountryReturnsEmptySet() {
     List<TraceTimeIntervalWarning> warnings = Stream
@@ -117,6 +120,7 @@ class DemoTraceTimeIntervalWarningsPackageBundlerTest {
     assertThat(bundler.getHoursForDistributableCheckInProtectedReports("UNKNOWN")).isEmpty();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   void should_include_current_hour() throws IOException {
     LocalDateTime utcHour = TimeUtils.getCurrentUtcHour();

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/decorator/HourIntervalIndexingDecoratorTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/decorator/HourIntervalIndexingDecoratorTest.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.distribution.assembly.tracewarnings.structure.directory.decorator;
 
 import static org.mockito.ArgumentMatchers.anyString;
@@ -28,7 +26,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-
+@SuppressWarnings("deprecation")
 @ExtendWith(SpringExtension.class)
 class HourIntervalIndexingDecoratorTest {
 
@@ -54,7 +52,6 @@ class HourIntervalIndexingDecoratorTest {
 
     underTest = makeDecoratedHourDirectory();
   }
-
 
   @AfterEach
   void tearDown() {
@@ -88,6 +85,7 @@ class HourIntervalIndexingDecoratorTest {
     );
   }
 
+  @Deprecated
   private AbstractHourIntervalIndexingDecorator makeDecoratedHourDirectory() {
     return new HourIntervalIndexingV1Decorator(
         new TraceTimeIntervalWarningsHourV1Directory(traceTimeIntervalWarningsPackageBundler, cryptoProvider,

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/file/TraceTimeIntervalWarningExportFileTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/directory/file/TraceTimeIntervalWarningExportFileTest.java
@@ -24,6 +24,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+@SuppressWarnings("deprecation")
 @ExtendWith(MockitoExtension.class)
 class TraceTimeIntervalWarningExportFileTest {
 

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/integration/TraceTimeIntervalWarningsDistributionIT.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/assembly/tracewarnings/structure/integration/TraceTimeIntervalWarningsDistributionIT.java
@@ -76,6 +76,7 @@ class TraceTimeIntervalWarningsDistributionIT {
     when(outputDirectoryProvider.getDirectory()).thenReturn(testDirectory);
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   void testIndicesAreOldestAndLatestForMultipleSubmissions() throws Exception {
     // given

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/config/DistributionServiceConfigTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/config/DistributionServiceConfigTest.java
@@ -228,7 +228,6 @@ class DistributionServiceConfigTest {
 
   @Nested
   class CclAllowListTest {
-
     @Test
     void failsOnInvalidSupportedCountries() {
       String[] cclAllowList = distributionServiceConfig.getDigitalGreenCertificate().getCclAllowList();
@@ -236,35 +235,50 @@ class DistributionServiceConfigTest {
     }
   }
 
-  private static Stream<Arguments> iosDetectionParametersMaxExposureDetectionsPerIntervalArguments() {
+  /**
+   * @MethodSource
+   */
+  static Stream<Arguments> iosDetectionParametersMaxExposureDetectionsPerIntervalArguments() {
     return Stream.of(
         Arguments.of(-1, IosExposureDetectionParameters.MIN_VALUE_ERROR_MESSAGE_MAX_EXPOSURE_DETECTIONS),
         Arguments.of(7, IosExposureDetectionParameters.MAX_VALUE_ERROR_MESSAGE_MAX_EXPOSURE_DETECTIONS)
     );
   }
 
-  private static Stream<Arguments> androidKeyDownloadParametersDownloadTimeoutArguments() {
+  /**
+   * @MethodSource
+   */
+  static Stream<Arguments> androidKeyDownloadParametersDownloadTimeoutArguments() {
     return Stream.of(
         Arguments.of(-1, AndroidKeyDownloadParameters.MIN_VALUE_ERROR_MESSAGE_DOWNLOAD_TIMEOUT),
         Arguments.of(1801, AndroidKeyDownloadParameters.MAX_VALUE_ERROR_MESSAGE_DOWNLOAD_TIMEOUT)
     );
   }
 
-  private static Stream<Arguments> androidKeyDownloadParametersOverallTimeoutArguments() {
+  /**
+   * @MethodSource
+   */
+  static Stream<Arguments> androidKeyDownloadParametersOverallTimeoutArguments() {
     return Stream.of(
         Arguments.of(-1, AndroidKeyDownloadParameters.MIN_VALUE_ERROR_MESSAGE_OVERALL_TIMEOUT),
         Arguments.of(1801, AndroidKeyDownloadParameters.MAX_VALUE_ERROR_MESSAGE_OVERALL_TIMEOUT)
     );
   }
 
-  private static Stream<Arguments> androidDetectionParametersMaxExposureDetectionsPerIntervalArguments() {
+  /**
+   * @MethodSource
+   */
+  static Stream<Arguments> androidDetectionParametersMaxExposureDetectionsPerIntervalArguments() {
     return Stream.of(
         Arguments.of(-1, AndroidExposureDetectionParameters.MIN_VALUE_ERROR_MESSAGE_MAX_EXPOSURE_DETECTIONS),
         Arguments.of(7, AndroidExposureDetectionParameters.MAX_VALUE_ERROR_MESSAGE_MAX_EXPOSURE_DETECTIONS)
     );
   }
 
-  private static Stream<Arguments> androidDetectionParametersOverAllTimeoutBoundariesArguments() {
+  /**
+   * @MethodSource
+   */
+  static Stream<Arguments> androidDetectionParametersOverAllTimeoutBoundariesArguments() {
     return Stream.of(
         Arguments.of(-1, AndroidExposureDetectionParameters.MIN_VALUE_ERROR_MESSAGE_OVERALL_TIMEOUT),
         Arguments.of(3601, AndroidExposureDetectionParameters.MAX_VALUE_ERROR_MESSAGE_OVERALL_TIMEOUT)

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/DccValidationAllowListInvalidSignatureIntegrationTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/DccValidationAllowListInvalidSignatureIntegrationTest.java
@@ -1,12 +1,11 @@
 package app.coronawarn.server.services.distribution.dgc;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import app.coronawarn.server.common.protocols.internal.dgc.ValidationServiceAllowlist;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
 import app.coronawarn.server.services.distribution.dgc.dsc.DigitalCovidValidationCertificateToProtobufMapping;
-import app.coronawarn.server.services.distribution.dgc.dsc.errors.InvalidFingerprintException;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +14,6 @@ import org.springframework.boot.test.context.ConfigDataApplicationContextInitial
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import java.util.Optional;
 
 @EnableConfigurationProperties(value = DistributionServiceConfig.class)
 @ExtendWith(SpringExtension.class)
@@ -33,6 +31,5 @@ class DccValidationAllowListInvalidSignatureIntegrationTest {
       Optional<ValidationServiceAllowlist> underTest =
           digitalCovidValidationCertificateToProtobufMapping.constructProtobufMapping();
       assertThat(underTest.get().getServiceProvidersList()).isEmpty();
-
   }
 }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/DccValidationAllowListSignatureTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/DccValidationAllowListSignatureTest.java
@@ -98,7 +98,6 @@ class DccValidationAllowListSignatureTest {
     assertThat(optionalProtobuf.get().getServiceProvidersList()).isEmpty();
   }
 
-  @SuppressWarnings("CatchMayIgnoreException")
   @Test
   void testValidateSchemaInexistent() {
     try {
@@ -150,7 +149,6 @@ class DccValidationAllowListSignatureTest {
   @Mock
   private CloseableHttpClient httpClient;
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   void testWithMockedHttpClientReturningNull() throws IOException {
     try (MockedStatic<HttpClients> httpClientsMockedStatic = Mockito.mockStatic(HttpClients.class)) {
@@ -162,7 +160,6 @@ class DccValidationAllowListSignatureTest {
     }
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   void testWithMockedHttpClientReturningResponse() throws IOException {
     try (MockedStatic<HttpClients> httpClientsMockedStatic = Mockito.mockStatic(HttpClients.class)) {

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/integration/DigitalCovidCertificateInvalidTruststoreTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/integration/DigitalCovidCertificateInvalidTruststoreTest.java
@@ -13,7 +13,6 @@ import app.coronawarn.server.services.distribution.dgc.exception.FetchBusinessRu
 import feign.RetryableException;
 import javax.net.ssl.SSLHandshakeException;
 import org.junit.Assert;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,9 +36,6 @@ class DigitalCovidCertificateInvalidTruststoreTest {
   @Autowired
   private DigitalCovidCertificateClient digitalCovidCertificateClient;
 
-  @Autowired
-  private DistributionServiceConfig distributionServiceConfig;
-
   @Test
   void shouldNotEstablishSslConnection() {
     Exception exception = Assert.assertThrows(FetchBusinessRulesException.class,
@@ -47,5 +43,4 @@ class DigitalCovidCertificateInvalidTruststoreTest {
     assertThat(exception.getCause()).isInstanceOf(RetryableException.class);
     assertThat(exception.getCause().getCause()).isInstanceOf(SSLHandshakeException.class);
   }
-
 }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/integration/DigitalCovidCertificateSignatureTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/dgc/integration/DigitalCovidCertificateSignatureTest.java
@@ -10,7 +10,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 
 import app.coronawarn.server.common.shared.util.SecurityUtils;
@@ -43,9 +42,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/client/S3ClientWrapperTest.java
@@ -84,7 +84,7 @@ class S3ClientWrapperTest {
   @Autowired
   private ObjectStoreClient s3ClientWrapper;
 
-  final Map emptyMap = Collections.emptyMap();
+  final Map<HeaderKey, String> emptyMap = Collections.emptyMap();
 
   @Configuration
   @EnableRetry

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/integration/ObjectStoreFilePreservationIT.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/objectstore/integration/ObjectStoreFilePreservationIT.java
@@ -140,8 +140,9 @@ class ObjectStoreFilePreservationIT extends BaseS3IntegrationTest {
 
           if (filesAreDifferent(previouslyPublished, secondVersion)) {
             throw new AssertionError("Files have been changed on object store "
-                + "due to retention policy. Before: " + previouslyPublished.getObjectName()
-                + "-" + previouslyPublished.getCwaHash()
+                + "due to retention policy. Before: " + (previouslyPublished != null
+                    ? previouslyPublished.getObjectName() + "-" + previouslyPublished.getCwaHash()
+                    : null)
                 + "| After:" + secondVersion.getObjectName()
                 + "-" + secondVersion.getCwaHash());
           }

--- a/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/KeyFigureCardFactoryTest.java
+++ b/services/distribution/src/test/java/app/coronawarn/server/services/distribution/statistics/KeyFigureCardFactoryTest.java
@@ -18,7 +18,6 @@ import app.coronawarn.server.common.protocols.internal.stats.KeyFigure.Rank;
 import app.coronawarn.server.common.protocols.internal.stats.KeyFigure.Trend;
 import app.coronawarn.server.common.protocols.internal.stats.KeyFigure.TrendSemantic;
 import app.coronawarn.server.services.distribution.config.DistributionServiceConfig;
-import app.coronawarn.server.services.distribution.statistics.keyfigurecard.Cards;
 import app.coronawarn.server.services.distribution.statistics.keyfigurecard.KeyFigureCardFactory;
 import app.coronawarn.server.services.distribution.statistics.keyfigurecard.factory.MissingPropertyException;
 import org.junit.jupiter.api.BeforeEach;

--- a/services/download/src/main/java/app/coronawarn/server/services/download/BatchAuditException.java
+++ b/services/download/src/main/java/app/coronawarn/server/services/download/BatchAuditException.java
@@ -1,7 +1,6 @@
 package app.coronawarn.server.services.download;
 
 public class BatchAuditException extends RuntimeException {
-
   private static final long serialVersionUID = 421314018302400787L;
 
   public BatchAuditException(String msg, Throwable cause) {

--- a/services/download/src/main/java/app/coronawarn/server/services/download/BatchAuditException.java
+++ b/services/download/src/main/java/app/coronawarn/server/services/download/BatchAuditException.java
@@ -2,6 +2,8 @@ package app.coronawarn.server.services.download;
 
 public class BatchAuditException extends RuntimeException {
 
+  private static final long serialVersionUID = 421314018302400787L;
+
   public BatchAuditException(String msg, Throwable cause) {
     super(msg, cause);
   }

--- a/services/download/src/main/java/app/coronawarn/server/services/download/FatalFederationGatewayException.java
+++ b/services/download/src/main/java/app/coronawarn/server/services/download/FatalFederationGatewayException.java
@@ -1,7 +1,8 @@
 package app.coronawarn.server.services.download;
 
 public class FatalFederationGatewayException extends Exception {
-  
+  private static final long serialVersionUID = -7256623337128544306L;
+
   public FatalFederationGatewayException(String message) {
     super(message);
   }

--- a/services/download/src/test/java/app/coronawarn/server/services/download/DownloadDateBaseSwitchToCallbackIT.java
+++ b/services/download/src/test/java/app/coronawarn/server/services/download/DownloadDateBaseSwitchToCallbackIT.java
@@ -54,7 +54,6 @@ class DownloadDateBaseSwitchToCallbackIT {
   private static final String ERROR_BATCH_TAG = "error_batch";
   private static final String SWITCH_DAY_UNPROCESSED_BATCH_TAG = "switch_day_unprocessed_batch";
   private static final String SWITCH_DAY_NEW_UNPROCESSED_BATCH_TAG = "switch_day_new_unprocessed_batch";
-  private static final String SWITCH_DAY_NEW_UNPROCESSED_1_BATCH_TAG = "switch_day_new_unprocessed_batch_1";
 
   private static final String SWITCH_DAY_ERROR_BATCH_TAG = "switch_day_error";
 

--- a/services/download/src/test/java/app/coronawarn/server/services/download/runner/RetentionPolicyTest.java
+++ b/services/download/src/test/java/app/coronawarn/server/services/download/runner/RetentionPolicyTest.java
@@ -4,7 +4,6 @@ import static app.coronawarn.server.common.persistence.domain.FederationBatchSou
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import app.coronawarn.server.common.persistence.domain.FederationBatchSourceSystem;
 import app.coronawarn.server.common.persistence.domain.config.TekFieldDerivations;
 import app.coronawarn.server.common.persistence.service.FederationBatchInfoService;
 import app.coronawarn.server.services.download.config.DownloadServiceConfig;

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/checkins/EventCheckinFacade.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/checkins/EventCheckinFacade.java
@@ -114,7 +114,7 @@ public class EventCheckinFacade {
    * @param submissionPayload the payload where to extract the checkins from.
    * @return an instance of {@link CheckinsStorageResult} that represents how many check ins were saved and filtered.
    */
-  @SuppressWarnings("removal")
+  @SuppressWarnings("deprecation")
   public CheckinsStorageResult extractAndStoreCheckins(SubmissionPayload submissionPayload) {
     CheckinsStorageResult checkinsStorageResult = new CheckinsStorageResult(0, 0);
 

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/checkins/EventCheckinFacade.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/checkins/EventCheckinFacade.java
@@ -114,6 +114,7 @@ public class EventCheckinFacade {
    * @param submissionPayload the payload where to extract the checkins from.
    * @return an instance of {@link CheckinsStorageResult} that represents how many check ins were saved and filtered.
    */
+  @SuppressWarnings("removal")
   public CheckinsStorageResult extractAndStoreCheckins(SubmissionPayload submissionPayload) {
     CheckinsStorageResult checkinsStorageResult = new CheckinsStorageResult(0, 0);
 

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/config/SubmissionServiceConfig.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/config/SubmissionServiceConfig.java
@@ -66,7 +66,7 @@ public class SubmissionServiceConfig {
    *
    * @deprecated should be removed when false
    */
-  @Deprecated(since = "2.8", forRemoval = true)
+  @Deprecated(since = "2.8", forRemoval = false)
   private Boolean unencryptedCheckinsEnabled;
 
   @Autowired
@@ -217,7 +217,7 @@ public class SubmissionServiceConfig {
    *
    * @deprecated should be removed when false
    */
-  @Deprecated(since = "2.8", forRemoval = true)
+  @Deprecated(since = "2.8", forRemoval = false)
   public Boolean isUnencryptedCheckinsEnabled() {
     return unencryptedCheckinsEnabled == null ? false : unencryptedCheckinsEnabled;
   }

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/FakeRequestController.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/controller/FakeRequestController.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.submission.controller;
 
 import static app.coronawarn.server.services.submission.controller.SubmissionController.CWA_FILTERED_CHECKINS_HEADER;
@@ -42,7 +40,6 @@ public class FakeRequestController {
    */
   @PostMapping(value = SUBMISSION_ROUTE, headers = {"cwa-fake!=0"})
   @Timed(description = "Time spent handling fake submission.")
-  @SuppressWarnings("unchecked")
   public DeferredResult<ResponseEntity<Void>> fakeRequest(@RequestHeader("cwa-fake") Integer fake) {
     submissionMonitor.incrementRequestCounter();
     submissionMonitor.incrementFakeRequestCounter();

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/validation/ValidSubmissionOnBehalfPayload.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/validation/ValidSubmissionOnBehalfPayload.java
@@ -55,13 +55,11 @@ public @interface ValidSubmissionOnBehalfPayload {
      *
      * @deprecated in favor of {@link #eventCheckInProtectedReportsValidator}.
      */
-    @Deprecated(since = "2.8", forRemoval = true)
     private final EventCheckinDataValidator eventCheckInValidator;
     private final EventCheckInProtectedReportsValidator eventCheckInProtectedReportsValidator;
     private static final Logger logger = LoggerFactory.getLogger(ValidSubmissionOnBehalfPayload.class);
     private static final Marker SECURITY = MarkerFactory.getMarker("SECURITY");
 
-    @SuppressWarnings("deprecation")
     public ValidSubmissionOnBehalfPayloadValidator(EventCheckinDataValidator eventCheckinValidator,
         EventCheckInProtectedReportsValidator eventCheckInProtectedReportsValidator) {
       this.eventCheckInValidator = eventCheckinValidator;
@@ -83,7 +81,6 @@ public @interface ValidSubmissionOnBehalfPayload {
      * @param context           constraint validator context for enabling violation messages.
      * @return whether the payload is valid or not.
      */
-    @SuppressWarnings("deprecation")
     @Override
     public boolean isValid(SubmissionPayload submissionPayload, ConstraintValidatorContext context) {
       return Stream.of(diagnosisKeysAreEmpty(submissionPayload, context),

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/validation/ValidSubmissionOnBehalfPayload.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/validation/ValidSubmissionOnBehalfPayload.java
@@ -8,7 +8,6 @@ import app.coronawarn.server.common.protocols.internal.SubmissionPayload.Submiss
 import app.coronawarn.server.services.submission.checkins.EventCheckInProtectedReportsValidator;
 import app.coronawarn.server.services.submission.checkins.EventCheckinDataValidator;
 import app.coronawarn.server.services.submission.validation.ValidSubmissionOnBehalfPayload.ValidSubmissionOnBehalfPayloadValidator;
-import app.coronawarn.server.services.submission.validation.ValidSubmissionPayload.SubmissionPayloadValidator;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.util.stream.Stream;
@@ -21,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
+@SuppressWarnings("deprecation")
 @Target(PARAMETER)
 @Retention(RUNTIME)
 @Constraint(validatedBy = ValidSubmissionOnBehalfPayloadValidator.class)
@@ -61,6 +61,7 @@ public @interface ValidSubmissionOnBehalfPayload {
     private static final Logger logger = LoggerFactory.getLogger(ValidSubmissionOnBehalfPayload.class);
     private static final Marker SECURITY = MarkerFactory.getMarker("SECURITY");
 
+    @SuppressWarnings("deprecation")
     public ValidSubmissionOnBehalfPayloadValidator(EventCheckinDataValidator eventCheckinValidator,
         EventCheckInProtectedReportsValidator eventCheckInProtectedReportsValidator) {
       this.eventCheckInValidator = eventCheckinValidator;
@@ -82,6 +83,7 @@ public @interface ValidSubmissionOnBehalfPayload {
      * @param context           constraint validator context for enabling violation messages.
      * @return whether the payload is valid or not.
      */
+    @SuppressWarnings("deprecation")
     @Override
     public boolean isValid(SubmissionPayload submissionPayload, ConstraintValidatorContext context) {
       return Stream.of(diagnosisKeysAreEmpty(submissionPayload, context),

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/validation/ValidSubmissionPayload.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/validation/ValidSubmissionPayload.java
@@ -70,7 +70,7 @@ public @interface ValidSubmissionPayload {
      *
      * @deprecated in favor of {@link #eventCheckInProtectedReportsValidator}. 
      */
-    @Deprecated(since = "2.8", forRemoval = true)
+    @Deprecated(since = "2.8", forRemoval = false)
     private final EventCheckinDataValidator eventCheckinValidator;
     private final EventCheckInProtectedReportsValidator eventCheckInProtectedReportsValidator;
     private static final Logger logger = LoggerFactory.getLogger(SubmissionPayloadValidator.class);

--- a/services/submission/src/main/java/app/coronawarn/server/services/submission/verification/CloudFeignClientProvider.java
+++ b/services/submission/src/main/java/app/coronawarn/server/services/submission/verification/CloudFeignClientProvider.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.submission.verification;
 
 import app.coronawarn.server.common.federation.client.hostname.HostnameVerifierProvider;
@@ -11,7 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import javax.net.ssl.SSLContext;
-import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.springframework.cloud.commons.httpclient.ApacheHttpClientConnectionManagerFactory;

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/assertions/SubmissionAssertions.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/assertions/SubmissionAssertions.java
@@ -1,20 +1,16 @@
-
-
 package app.coronawarn.server.services.submission.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
 import app.coronawarn.server.common.protocols.external.exposurenotification.TemporaryExposureKey;
 import app.coronawarn.server.common.protocols.internal.SubmissionPayload;
 import app.coronawarn.server.services.submission.config.SubmissionServiceConfig;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public final class SubmissionAssertions {
 

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/checkins/EventCheckinDataValidatorTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/checkins/EventCheckinDataValidatorTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("deprecation")
 public class EventCheckinDataValidatorTest {
 
   private static final int CORRECT_TRL = 1;

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/checkins/EventCheckinsFacadeIT.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/checkins/EventCheckinsFacadeIT.java
@@ -25,6 +25,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
+@SuppressWarnings("deprecation")
 @SpringBootTest
 @DirtiesContext
 @ActiveProfiles("integration-test")

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/SubmissionControllerTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/SubmissionControllerTest.java
@@ -83,7 +83,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
 @TestInstance(Lifecycle.PER_CLASS)
-@SuppressWarnings("unchecked")
+@SuppressWarnings({ "unchecked", "deprecation" })
 class SubmissionControllerTest {
 
   @MockBean

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/SubmissionPayloadMockData.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/SubmissionPayloadMockData.java
@@ -167,6 +167,7 @@ public final class SubmissionPayloadMockData {
         .build();
   }
 
+  @Deprecated
   public static SubmissionPayload buildPayloadWithCheckinData(List<CheckIn> checkinData) {
     TemporaryExposureKey key =
         buildTemporaryExposureKey(VALID_KEY_DATA_1, createRollingStartIntervalNumber(2), 3,

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/TEKDatasetGeneration.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/controller/TEKDatasetGeneration.java
@@ -1,5 +1,3 @@
-
-
 package app.coronawarn.server.services.submission.controller;
 
 import app.coronawarn.server.common.persistence.domain.DiagnosisKey;
@@ -7,13 +5,18 @@ import app.coronawarn.server.common.protocols.external.exposurenotification.Repo
 import app.coronawarn.server.common.protocols.external.exposurenotification.TemporaryExposureKey;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import java.util.List;
 import java.util.stream.Stream;
 import static app.coronawarn.server.services.submission.controller.SubmissionPayloadMockData.*;
 
 public class TEKDatasetGeneration {
 
-  private static Stream<Arguments> getOverlappingTestDatasets() {
+  /**
+   * Used in {@link PayloadValidationTest} as {@link MethodSource}
+   * @return
+   */
+  static Stream<Arguments> getOverlappingTestDatasets() {
     return Stream.of(
         getOverlappingDatasetWithFixedPeriods(),
         getOverlappingDatasetWithFlexiblePeriods(),
@@ -27,7 +30,6 @@ public class TEKDatasetGeneration {
     return Lists.list(
         buildTemporaryExposureKey(VALID_KEY_DATA_1, rollingStartIntervalNumber1, 1, ReportType.CONFIRMED_TEST,1),
         buildTemporaryExposureKey(VALID_KEY_DATA_2, rollingStartIntervalNumber2, 3, ReportType.CONFIRMED_TEST,1));
-
   }
 
   private static List<TemporaryExposureKey> getOverlappingDatasetWithFlexiblePeriods(){
@@ -37,7 +39,6 @@ public class TEKDatasetGeneration {
         buildTemporaryExposureKeyWithFlexibleRollingPeriod(VALID_KEY_DATA_1, rollingStartIntervalNumber1, 1, 54),
         buildTemporaryExposureKeyWithFlexibleRollingPeriod(VALID_KEY_DATA_1, rollingStartIntervalNumber1, 1, 90),
         buildTemporaryExposureKeyWithFlexibleRollingPeriod(VALID_KEY_DATA_2, rollingStartIntervalNumber2, 3, 133));
-
   }
 
   private static List<TemporaryExposureKey> getMixedOverlappingDataset(){
@@ -47,10 +48,13 @@ public class TEKDatasetGeneration {
         buildTemporaryExposureKeyWithFlexibleRollingPeriod(VALID_KEY_DATA_1, rollingStartIntervalNumber1, 1, 54),
         buildTemporaryExposureKeyWithFlexibleRollingPeriod(VALID_KEY_DATA_1, rollingStartIntervalNumber1, 1, 90),
         buildTemporaryExposureKey(VALID_KEY_DATA_2, rollingStartIntervalNumber2, 2, ReportType.CONFIRMED_TEST,1));
-
   }
 
-  private static Stream<Arguments> getRollingPeriodDatasets() {
+  /**
+   * Used in {@link PayloadValidationTest} as {@link MethodSource}
+   * @return
+   */
+  static Stream<Arguments> getRollingPeriodDatasets() {
     return Stream.of(
         getFixedRollingPeriodDataset(),
         getFlexibleRollingPeriodDataset(),
@@ -90,5 +94,4 @@ public class TEKDatasetGeneration {
         buildTemporaryExposureKey(VALID_KEY_DATA_3, rollingStartIntervalNumber3, 3, ReportType.CONFIRMED_TEST,1),
         buildTemporaryExposureKey(VALID_KEY_DATA_2, rollingStartIntervalNumber2, 3, ReportType.CONFIRMED_TEST,1));
   }
-
 }

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/integration/DataHelpers.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/integration/DataHelpers.java
@@ -98,7 +98,7 @@ public class DataHelpers {
         ByteString.copyFrom(locationId));
   }
 
-
+  @Deprecated
   public static SubmissionPayload buildSubmissionPayloadWithCheckins(List<String> visitedCountries,
       String originCountry,
       Boolean consentToFederation, List<TemporaryExposureKey> temporaryExposureKeys,

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/integration/SubmissionDisabledUnencryptedCheckInsIT.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/integration/SubmissionDisabledUnencryptedCheckInsIT.java
@@ -13,7 +13,6 @@ import app.coronawarn.server.common.protocols.internal.SubmissionPayload;
 import app.coronawarn.server.common.protocols.internal.SubmissionPayload.SubmissionType;
 import app.coronawarn.server.common.protocols.internal.pt.CheckIn;
 import app.coronawarn.server.common.protocols.internal.pt.CheckInProtectedReport;
-import app.coronawarn.server.services.submission.config.SubmissionServiceConfig;
 import app.coronawarn.server.services.submission.controller.FakeDelayManager;
 import app.coronawarn.server.services.submission.controller.RequestExecutor;
 import app.coronawarn.server.services.submission.verification.TanVerifier;
@@ -24,9 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -38,16 +35,6 @@ class SubmissionDisabledUnencryptedCheckInsIT {
 
   @Autowired
   private RequestExecutor executor;
-
-  @Autowired
-  private SubmissionServiceConfig config;
-
-  @Autowired
-  private JdbcTemplate jdbcTemplate;
-
-  @Autowired
-  private TestRestTemplate testRestTemplate;
-
 
   @MockBean
   private TanVerifier tanVerifier;
@@ -61,7 +48,7 @@ class SubmissionDisabledUnencryptedCheckInsIT {
     when(fakeDelayManager.getJitteredFakeDelay()).thenReturn(1000L);
   }
 
-
+  @Deprecated
   @Test
   void unencryptedCheckInsDisabledShouldResultInSavingLessNumberOfCheckIns() {
     // GIVEN:

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/integration/SubmissionOnBehalfIT.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/integration/SubmissionOnBehalfIT.java
@@ -58,6 +58,7 @@ public class SubmissionOnBehalfIT {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
+  @Deprecated
   @Test
   @DisplayName("Should return 200 OK if payload is valid but contains empty checkins and tan verification is successful and response header == EVENT")
   public void shouldReturn200WhenEvenWhenCheckInsAreEmpty() {
@@ -126,6 +127,7 @@ public class SubmissionOnBehalfIT {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
   }
 
+  @Deprecated
   static Stream<Arguments> generateInvalidPayloads() {
     return Stream.of(
         Arguments.of(validSubmissionBuilder().addAllKeys(createValidTemporaryExposureKeys()).build()),
@@ -194,7 +196,7 @@ public class SubmissionOnBehalfIT {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
   }
 
-
+  @Deprecated
   private static SubmissionPayload.Builder validSubmissionBuilder() {
     byte[] locationIdHash = new byte[32];
     new Random().nextBytes(locationIdHash);

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/integration/SubmissionPersistenceIT.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/integration/SubmissionPersistenceIT.java
@@ -366,6 +366,7 @@ class SubmissionPersistenceIT {
     );
   }
 
+  @Deprecated
   @Test
   void unencryptedCheckInsEnabledShouldResultInSavingCorrectNumberOfCheckIns() {
     // GIVEN:

--- a/services/submission/src/test/java/app/coronawarn/server/services/submission/validation/ValidSubmissionOnBehalfTest.java
+++ b/services/submission/src/test/java/app/coronawarn/server/services/submission/validation/ValidSubmissionOnBehalfTest.java
@@ -1,6 +1,5 @@
 package app.coronawarn.server.services.submission.validation;
 
-
 import static app.coronawarn.server.services.submission.validation.ValidSubmissionOnBehalfPayload.ValidSubmissionOnBehalfPayloadValidator;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -27,6 +26,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+@SuppressWarnings("deprecation")
 @ExtendWith(MockitoExtension.class)
 public class ValidSubmissionOnBehalfTest {
 
@@ -45,7 +45,6 @@ public class ValidSubmissionOnBehalfTest {
 
   @Mock
   ConstraintValidatorContext constraintValidatorContext;
-
 
   @Test
   void shouldReturnTrueIfSubmissionOnBehalfPayloadIsValid() {


### PR DESCRIPTION
we've marked some classes to be deprecated, now there are a lot of compiler warnings... let's ignore at least the ones, that we introduced ourselves

some highlighted commits:
* https://github.com/corona-warn-app/cwa-server/pull/1885/commits/fe1c2180565080cf8650015b23221845e7e0e389 - springframework PersistenceConstructor is deprecated, we'll use PersistenceCreator instead
* https://github.com/corona-warn-app/cwa-server/pull/1885/commits/9e02c2d5fd4600b012d58ebd860c62abc1752d7c - when the assertion is thrown it could lead to a NullPointerException :-(