### PR TITLE
HF/2.27.1

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,4 +1,4 @@
--Drevision=2.27.0
+-Drevision=2.27.1
 -Dlicense.projectName=Corona-Warn-App
 -Dlicense.inceptionYear=2020
 -Dlicense.licenseName=apache_v2

--- a/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStorePublishingConfig.java
+++ b/services/distribution/src/main/java/app/coronawarn/server/services/distribution/objectstore/client/ObjectStorePublishingConfig.java
@@ -25,7 +25,7 @@ public class ObjectStorePublishingConfig {
   @Bean(name = "publish-s3")
   public ObjectStoreClient createObjectStoreClient(DistributionServiceConfig distributionServiceConfig) {
     return createClient(distributionServiceConfig.getObjectStore(),
-        distributionServiceConfig.getDccRevocation().getDccListPath());
+        distributionServiceConfig.getDccRevocation().getDccRevocationDirectory());
   }
 
   private ObjectStoreClient createClient(final ObjectStore objectStore, final String dccListPath) {


### PR DESCRIPTION
when accessing the OBS bucket and we're requesting objects, we use the wrong value `/chunk.lst` as delimiter :-(

but we need to use: `dcc-rl` instead