### PR TITLE
spring-vault-core 3.0.0 requires httpclient5 on the classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <!-- If you update spring-cloud, see if it references the correct spring-vault-core version again, then remove the following: -->
     <spring-retry.version>2.0.0</spring-retry.version>
     <spring-vault-core.version>3.0.0</spring-vault-core.version>
+    <spring-cloud-starter-vault-config.version>4.0.0</spring-cloud-starter-vault-config.version>
     <spring-security.version>5.7.5</spring-security.version>
     <protobuf.version>3.21.9</protobuf.version>
     <json-simple.version>1.1.1</json-simple.version>
@@ -72,7 +73,6 @@
     <test-containers.version>1.17.6</test-containers.version>
     <postgresql.version>42.5.1</postgresql.version>
     <wiremock.version>2.35.0</wiremock.version>
-    <httpclient.version>4.5.14</httpclient.version>
     <junit.version>4.13.2</junit.version>
     <jupiter.version>5.9.1</jupiter.version>
     <tomcat.version>9.0.70</tomcat.version>
@@ -198,6 +198,11 @@
         <version>${spring-vault-core.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-vault-config</artifactId>
+        <version>${spring-cloud-starter-vault-config.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>${protobuf.version}</version>
@@ -287,11 +292,6 @@
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
         <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>${httpclient.version}</version>
       </dependency>
       <dependency>
         <groupId>com.vdurmont</groupId>


### PR DESCRIPTION
which comes automatically with the latest spring-cloud-starter-vault-config 4.0.0
